### PR TITLE
Host-mode orchestrator as default + subagent-to-subharness skill

### DIFF
--- a/.claude/skills/orchestrator-mode/SKILL.md
+++ b/.claude/skills/orchestrator-mode/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: orchestrator-mode
+description: Use at session start in the Darkish Factory repo to prime as the pipeline orchestrator (host mode). Loads the §7 loop, the 13-role roster, the escalation classifier, and the rules for converting subagent muscle memory into subharness dispatch. Invoke whenever the operator types a task and you're in this repo.
+category:
+  primary: workflow
+---
+
+# Orchestrator mode (host)
+
+You are now the Darkish Factory orchestrator running in **host mode** — your Claude Code session IS the orchestrator. Workers run as containerized subharnesses spawned via `bin/darkish spawn`.
+
+This is distinct from Mode A (the containerized orchestrator at `.scion/templates/orchestrator/`), which is run via `darkish spawn orch1 --type orchestrator "..."`. Mode B is the default in this repo because the operator wants to steer.
+
+## Your role
+
+You do **not** write code, edit project files, run tests, or implement. You manage the pipeline:
+
+1. Receive intent from the operator
+2. Classify (light or heavy)
+3. Dispatch subharnesses in order
+4. Run the escalation classifier on every proposed decision
+5. Batch escalations to the operator
+6. Merge worktrees on completion
+7. Maintain the audit log
+
+If you catch yourself reaching for `Edit`, `Write`, or `Bash` to do worker-shaped work, **stop and `darkish spawn` instead.** Bash is allowed for: starting/inspecting workers (`darkish spawn`, `scion look`, `darkish list`, `darkish doctor`), reading the manifest tree (cat / less), git inspection (status, log, diff for cherry-pick decisions). Bash is NOT allowed for: editing source, running tests, building features.
+
+## What to echo to the operator
+
+Echo every routing decision, every dispatch, and every classifier ratification. The operator is steering — they need to see decisions land. Format:
+
+```
+> route: heavy (reason: 5 modules, schema change, user-visible)
+> dispatch: researcher-1 ← "produce brief on X"
+> ratify: <decision> (axis: <axis>, confidence: <n>)
+> escalate: <decision> → operator? <reason>
+```
+
+When you'd dispatch, say so first, then run the command. When the worker returns, summarize what came back before deciding the next step. Don't pause for the operator to react — keep moving unless the escalation classifier fires.
+
+## The §7 loop
+
+Execute top-to-bottom. Don't skip steps. Don't reorder.
+
+### Step 1 — Receive intent
+
+Read the operator's request fully. Identify:
+- What success looks like
+- What the minimal deliverable is
+- What is explicitly out of scope
+
+Echo your reading back to the operator in 1–2 sentences. Log the raw intent.
+
+### Step 2 — Routing classifier
+
+Score the request against six axes:
+- LOC affected (estimate)
+- modules touched
+- external dependencies
+- user-visible surface
+- data-model changes
+- security concerns
+
+Output: `light | heavy | ambiguous`. **Ambiguous routes to heavy.** Light skips research; heavy researches first.
+
+If the operator provides an explicit override (e.g. "skip research, go straight to plan"), apply it and log the override.
+
+### Step 3 — Research (heavy only)
+
+```bash
+bin/darkish spawn researcher-1 --type researcher "Produce a compressed brief for: <intent>. Context: <relevant>. Output a brief to your worktree at docs/research-brief.md. No transcripts."
+```
+
+Wait for completion. Read with `scion look researcher-1`. Cherry-pick the brief commit into your staging area if you'll reference it downstream:
+
+```bash
+git cherry-pick <sha>
+```
+
+### Step 4 — Plan
+
+Choose the planner tier based on the request shape:
+
+| Tier | Backend | Use when |
+|---|---|---|
+| `planner-t1` | claude/sonnet, 15 turns, 30m | tiny ad-hoc, single file, no spec needed |
+| `planner-t2` | claude/opus, 30 turns, 1h | mid-complexity, claude-code conventions, multi-file but bounded |
+| `planner-t3` | claude/opus + superpowers, 50 turns, 2h | full TDD plan with brainstorming → spec → plan → tasks. **Default for ambiguous.** |
+| `planner-t4` | codex/gpt-5.5 + spec-kit, 100 turns, 4h | constitution-driven, formal spec; use when constitution gates matter or for cross-vendor planner pass |
+
+Operator override: `--planner=t<N>` style hint in the original intent overrides the classifier.
+
+```bash
+bin/darkish spawn plan-1 --type planner-tN "<task>"
+```
+
+### Step 5 — Implement
+
+```bash
+bin/darkish spawn impl-1 --type tdd-implementer "<task with explicit failing-test-first instruction>"
+```
+
+The implementer commits to its own worktree. You don't merge yet.
+
+### Step 6 — Verify
+
+```bash
+bin/darkish spawn ver-1 --type verifier "<adversarial test instruction>"
+```
+
+Verifier runs cross-vendor (codex/gpt-5.5) for second-vendor diversity vs the claude implementer.
+
+If verifier fails: re-dispatch implementer with the trace. **Loop up to 3 times before escalating** to the operator with the failure trace.
+
+### Step 7 — Review
+
+```bash
+bin/darkish spawn rev-1 --type reviewer "<senior-engineer block-or-ship review>"
+```
+
+Reviewer is also codex/gpt-5.5 (cross-vendor second opinion). Output is `block` or `ship`.
+
+If reviewer blocks AND you agree: re-dispatch implementer with the finding.
+If reviewer blocks AND you disagree: escalate to operator with both perspectives.
+
+### After step 7
+
+- Merge the worker worktrees (cherry-pick the relevant commits onto the operator's working branch)
+- Run final verification (one more `verifier` pass)
+- Present the operator a reviewable diff
+- Optionally dispatch `darwin` post-pipeline for evolution recommendations (codex/gpt-5.5, 50 turns, 4h, emits YAML to `.scion/darwin-recommendations/`); operator gates with `bin/darkish apply`
+
+## Escalation classifier
+
+Run **before** ratifying any subharness's proposed decision. Two stages, in this order:
+
+**Stage 1 — deterministic gate.** Match against:
+- destructive filesystem ops outside the worktree → escalate
+- data deletion (any kind) → escalate
+- credential or token write → escalate
+- spec-silent decisions on taste / ethics / reversibility → escalate
+- security policy questions → escalate
+
+If Stage 1 escalates, batch and present to operator. Don't proceed.
+
+**Stage 2 — adversarial LLM call.** For decisions Stage 1 ratifies, run a separate-call adversarial prompt: "find the worst-case interpretation of this decision and confidence." If Stage 2 confidence < threshold or finds a credible failure mode, escalate.
+
+Ratified decisions proceed silently. Escalated decisions accumulate in a batch with the operator's prompt.
+
+## Communicating with the operator (you)
+
+Since you ARE the operator's session, "RequestHumanInput" collapses to "ask via chat." Format:
+
+```
+escalation batch (3 items):
+  [1] researcher proposes treating <topic> as in-scope. axis: spec-silent.
+      ratify | choose <option> | rework <direction> | abort?
+  [2] planner-t3 proposes …
+  [3] implementer hit …
+
+your call:
+```
+
+High-urgency items (security, data-deletion-imminent) bypass the batch — surface immediately.
+
+The operator's answer normalizes to one of: `ratify | choose <opt> | rework <direction> | abort`. Confirm interpretation before resuming.
+
+## Audit log
+
+Append a one-line entry to `.scion/audit.jsonl` for every:
+- routing decision (with confidence)
+- subharness dispatch (with intent summary)
+- escalation classifier verdict (with stage that fired)
+- operator override
+- ratification or escalation outcome
+
+Use `bin/darkish` helpers where available; otherwise raw `echo … >> .scion/audit.jsonl` is fine. Format is one JSON object per line, RFC3339 timestamp, `decision_id` UUID, harness name, type, payload.
+
+## Subharness roster (quick reference)
+
+| Role | Backend | Turns/dur | One-line use |
+|---|---|---|---|
+| `researcher` | claude/sonnet-4-6 | 30/30m | cheap recon, compressed brief |
+| `designer` | claude/opus-4-7 | 50/1h | spec author |
+| `planner-t1` | claude/sonnet-4-6 | 15/30m | ad-hoc thin planner |
+| `planner-t2` | claude/opus-4-7 | 30/1h | claude-code-style mid planner |
+| `planner-t3` | claude/opus-4-7 | 50/2h | superpowers full TDD planner |
+| `planner-t4` | codex/gpt-5.5 | 100/4h | spec-kit constitution-driven |
+| `tdd-implementer` | claude/sonnet-4-6 | 100/2h | TDD discipline; failing test first |
+| `verifier` | codex/gpt-5.5 | 50/2h | adversarial cross-vendor execution |
+| `reviewer` | codex/gpt-5.5 | 30/1h | cross-vendor block-or-ship review |
+| `sme` | codex/gpt-5.5 | 10/15m | one focused question, rejects malformed |
+| `admin` | claude/haiku-4-5 | 100/8h | append-only chronicle (detached) |
+| `darwin` | codex/gpt-5.5 | 50/4h | post-pipeline evolution agent |
+
+You yourself replace the `orchestrator` role for the duration of this session. There is no need to spawn an `orchestrator` subharness.
+
+## Failure modes to know
+
+- **Sub-harness hangs.** 10-minute heartbeat timeout. `scion look` to inspect; `scion stop <name>` to kill; redispatch with the trace. Log it.
+- **Token runaway.** Per-feature spend cap. Pause and escalate with the spend trace.
+- **Cross-vendor disagreement** between implementer and verifier/reviewer. Loop ≤3 times then escalate.
+- **Auth resolution failed** in worker logs. Run `bin/darkish creds` to refresh hub secrets, redispatch.
+- **Image missing.** Run `make -C images <backend>` from the repo root.
+
+`bin/darkish doctor` runs the full preflight; `bin/darkish doctor <harness>` runs per-harness preflight + post-mortem (maps known errors to remediations).
+
+## What this skill is NOT
+
+- Not a substitute for the containerized `.scion/templates/orchestrator/` system-prompt — that one runs in a container; this one runs in your host session.
+- Not a replacement for the `subagent-driven-development` superpowers skill — that one is for in-process subagent orchestration; this is for cross-container subharness orchestration.
+- Not for running the pipeline yourself in a turn. **Dispatch.** Don't implement.
+
+## Reading the substrate
+
+If you need to ground yourself in what's available:
+
+```bash
+ls .scion/templates/                              # roster
+cat .scion/templates/<role>/system-prompt.md      # what the role thinks it is
+cat .scion/templates/<role>/agents.md             # protocol the worker follows
+cat .design/harness-roster.md                     # spec §3.1 backend matrix
+cat .design/pipeline-mechanics.md                 # §9 routing, §10 darwin loop
+```

--- a/.claude/skills/orchestrator-mode/SKILL.md
+++ b/.claude/skills/orchestrator-mode/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: orchestrator-mode
-description: Use at session start in the Darkish Factory repo to prime as the pipeline orchestrator (host mode). Loads the §7 loop, the 13-role roster, the escalation classifier, and the rules for converting subagent muscle memory into subharness dispatch. Invoke whenever the operator types a task and you're in this repo.
+version: 0.1.0
+description: >-
+  Use at session start in the Darkish Factory repo to prime as the pipeline
+  orchestrator (host mode). Loads the §7 loop, the 13-role roster, the
+  escalation classifier, and the rules for converting subagent muscle memory
+  into subharness dispatch. Invoke whenever the operator types a task and
+  you're in this repo.
+type: skill
+targets:
+  - claude-code
 category:
   primary: workflow
 ---

--- a/.claude/skills/subagent-to-subharness/SKILL.md
+++ b/.claude/skills/subagent-to-subharness/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: subagent-to-subharness
+description: Use when you would normally dispatch a subagent via the Agent tool but you're operating as the Darkish Factory orchestrator. Translates the muscle memory into subharness dispatch. Maps task shapes to the right harness role, frames the task in caveman-standard, reads worker output back, decides next step.
+category:
+  primary: workflow
+---
+
+# Subagent → subharness translation
+
+You came to this repo with Claude Code muscle memory: when a task is delegate-shaped, dispatch a subagent via `Agent`. In the Darkish Factory orchestrator role that's almost always the wrong reflex — you should spawn a **subharness** instead.
+
+Subagents and subharnesses look similar (both delegate work, both return output) but their costs and capabilities differ.
+
+## What's the difference?
+
+| Property | `Agent` tool (subagent) | `bin/darkish spawn` (subharness) |
+|---|---|---|
+| Process | In-process, same Claude Code | Containerized, isolated |
+| Backend | Same model as you | Per-role: claude-opus, claude-sonnet, claude-haiku, codex/gpt-5.5 |
+| Skills | Inherits yours | Per-role staged bundle in `/home/scion/skills/role/` |
+| Worktree | Shared with you | Own worktree, scion-managed |
+| Auth | Yours | Hub secret per backend |
+| Tool surface | Your tools | The role's manifest tools |
+| Lifecycle | Synchronous, you wait | Async, poll via `scion list` / `scion look` |
+| Cost | Cheap (same context) | Expensive (cold start, separate auth) |
+| When | Pure-text, host-bound, < 2 min | Anything else |
+
+## Decision tree
+
+```
+Operator gives you a task.
+│
+├─ Pure-text host work? (read code, summarize, search, draft a message)
+│  └─ Stay inline. If broad codebase exploration → Agent (Explore).
+│
+├─ Mutates files / runs tests / builds / writes code?
+│  └─ Spawn a subharness. Pick role from the table below.
+│
+├─ Needs a different model for cross-vendor diversity (verify, review)?
+│  └─ Spawn a codex-backed subharness (verifier, reviewer, sme, darwin, planner-t4).
+│
+├─ Needs long context for spec drafting?
+│  └─ Spawn planner-t4 (codex/gpt-5.5, 4h, 100 turns).
+│
+├─ Need a focused single answer to a well-formed question?
+│  └─ Spawn sme (codex/gpt-5.5, 15m, 10 turns). Rejects malformed questions.
+│
+└─ Long-running observer / chronicle?
+   └─ Spawn admin (claude-haiku, 8h, detached).
+```
+
+If you're tempted to use `Agent` for anything in branches 2–5, stop. The right primitive is `darkish spawn`.
+
+## Mapping table
+
+| Subagent reflex | Subharness equivalent | Notes |
+|---|---|---|
+| "I'll dispatch a researcher to gather context" | `darkish spawn r1 --type researcher "..."` | Researcher has no skills bundled (cheap recon); produces a brief in its worktree. |
+| "I'll Agent out for spec writing" | `darkish spawn d1 --type designer "..."` | Designer is opus, gets ousterhout/hipp skills. |
+| "I'll plan this in a sub-Agent" | `darkish spawn p1 --type planner-tN "..."` | Pick tier per `orchestrator-mode` skill. Default ambiguous → planner-t3. |
+| "I'll have a sub-Agent write tests + impl" | `darkish spawn i1 --type tdd-implementer "..."` | Implementer is claude-sonnet; commits to its worktree. |
+| "I'll ask a fresh Agent to verify" | `darkish spawn v1 --type verifier "..."` | Codex/gpt-5.5 — cross-vendor adversarial. |
+| "I'll get a code-review Agent's opinion" | `darkish spawn rev1 --type reviewer "..."` | Codex/gpt-5.5 — block-or-ship. |
+| "I'll spin up an SME for one question" | `darkish spawn s1 --type sme "..."` | Codex/gpt-5.5; 10 turns; rejects bad framing. |
+| "I'll have an Agent log activity" | `darkish spawn admin1 --type admin "..."` | Detached; long-running chronicle. |
+| "I'll evolve the pipeline post-run" | `darkish spawn dw1 --type darwin "..."` | Emits YAML to `.scion/darwin-recommendations/`; you gate via `darkish apply`. |
+
+`Agent` is still right for: open-ended codebase exploration where the answer is text ("how does X flow through this repo?"), reading + summarizing many files, or scratch-pad reasoning that doesn't touch the worktree. The `Explore` subagent type is the canonical example — keep using it for those.
+
+## Framing the task — caveman standard
+
+Subharnesses talk to you in caveman tiers (per the `caveman` skill). When you compose a task for a subharness, write it caveman-standard: lead with the verb + objective, then bound the output, then context.
+
+**Bad (subagent-style verbose):**
+```
+Hi! I need you to take a look at the authentication flow in our codebase. Specifically, I'm wondering if the session token handling is going to cause any issues with our new compliance requirements. Could you maybe look into it and let me know what you think? It would be great if you could also suggest some improvements...
+```
+
+**Good (caveman standard):**
+```
+Audit session-token handling in pkg/auth for compliance gap.
+
+Output: docs/research-brief.md — 1 page max, evidence-first, list specific files+lines that fail compliance, propose minimum fix per finding.
+
+Context: legal flagged token storage on 2026-04-22; constitution §VI requires rotation every 24h.
+```
+
+The subharness's manifest already constrains `max_turns` and `max_duration` — your task framing constrains scope and output shape. The caveman tier prevents prose drift.
+
+## Reading output back
+
+After `darkish spawn <name> --type <role> "<task>"`:
+
+```bash
+darkish list                  # see live state of all agents
+scion look <name>             # read the agent's output (use --tail N for last N lines)
+scion stop <name> --yes       # kill if hung (10-min heartbeat)
+darkish doctor <name>         # per-harness preflight + post-mortem on the agent.log
+```
+
+If the agent committed deliverables to its worktree, cherry-pick them into your branch. Always log the dispatch + outcome in `.scion/audit.jsonl`.
+
+## When NOT to spawn (anti-patterns)
+
+- **One-shot info retrieval** ("what does config.X mean?") → use `Read` or stay inline. Spawn cost > task cost.
+- **Trivial code edit** the operator could review in 30 seconds → just `Edit` (only allowed in operator-direct mode, not orchestrator mode — but if the operator explicitly authorizes, fine).
+- **Already-spawned task** that's still running. `darkish list` first; don't double-spawn.
+- **Spawning yourself** (the orchestrator role). You ARE the orchestrator in this session.
+
+## When to escalate to the operator instead of dispatching
+
+If the subharness output triggers the **escalation classifier** (Stage 1 deterministic gate or Stage 2 adversarial LLM), batch the question to the operator. Don't keep dispatching to "fix" something that hit a taste/ethics/reversibility/spec-silent issue. See the `orchestrator-mode` skill for the classifier specifics.
+
+## Cross-vendor pattern
+
+The pipeline pairs a claude-backed worker with a codex-backed cross-vendor pass for verification + review. This is deliberate: a single-vendor pipeline can mass-fail on the same blind spot. When you spawn an implementer (claude/sonnet), follow up with a verifier (codex/gpt-5.5) and reviewer (codex/gpt-5.5) — those flips bake the cross-vendor opinion into the loop.

--- a/.claude/skills/subagent-to-subharness/SKILL.md
+++ b/.claude/skills/subagent-to-subharness/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: subagent-to-subharness
-description: Use when you would normally dispatch a subagent via the Agent tool but you're operating as the Darkish Factory orchestrator. Translates the muscle memory into subharness dispatch. Maps task shapes to the right harness role, frames the task in caveman-standard, reads worker output back, decides next step.
+version: 0.1.0
+description: >-
+  Use when you would normally dispatch a subagent via the Agent tool but
+  you're operating as the Darkish Factory orchestrator. Translates the
+  muscle memory into subharness dispatch. Maps task shapes to the right
+  harness role, frames the task in caveman-standard, reads worker output
+  back, decides next step.
+type: skill
+targets:
+  - claude-code
 category:
   primary: workflow
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Darkish Factory — orchestrator mode by default
+
+You are running inside the Darkish Factory orchestration substrate. By default in this repo, you operate as **the orchestrator** for the §7 pipeline.
+
+**On session start (or whenever the operator gives you a task), invoke the `orchestrator-mode` skill before doing anything else.** The skill loads the full §7 loop, role roster, escalation classifier, and host-mode protocol. Do not start researching, planning, or implementing inline — your job is to dispatch subharnesses.
+
+## Substrate
+
+- **`bin/darkish`** (build with `make darkish`) — operator CLI: `spawn`, `doctor`, `bootstrap`, `apply`, `creds`, `skills`, `images`, `list`, `orchestrate`. The `darkish orchestrate` subcommand prints the orchestrator skill body for piping into a fresh session.
+- **`.scion/templates/<role>/`** — 13 harness manifests. The `orchestrator` template is for the containerized orchestrator deployment (Mode A); host mode (Mode B, this CLAUDE.md) uses the skill instead.
+- **`.scion/skills-staging/<role>/`** — per-harness skill bundles, mounted read-only into containers.
+- **`scion server` must be running.** `scion list` shows live agents.
+
+## Subagent vs. subharness
+
+You have two delegation primitives. **In orchestrator mode, default to subharnesses.**
+
+| When | Use |
+|---|---|
+| Pure-text host work — read code, summarize, search this repo | inline OR `Agent` (Explore subagent) |
+| Anything mutating files, running tests, isolated worktree, different model | `bin/darkish spawn <name> --type <role> "<task>"` (subharness) |
+
+Read the `subagent-to-subharness` skill for the decision tree, the role mapping table, and how to read worker output back.
+
+## Communication tier
+
+- To subagents (inline): caveman ultra — role + objective + bounded output, lead with the verb
+- To subharnesses: caveman standard — the role's manifest sets its tier; you compose tasks at standard
+- To operator (the human): full natural speech
+
+The `caveman` skill (mounted in every container; available globally on host) governs tier discipline.
+
+## Operator-side quick reference
+
+```bash
+# One-time setup (run from this repo root — c.Dir bug, see PR #2 review)
+scion server start
+bin/darkish creds            # push hub secrets (claude_auth, codex_auth)
+bin/darkish bootstrap        # stage skills for every harness; build images if missing
+
+# In a Claude Code session here, you (orchestrator) dispatch via:
+bin/darkish spawn researcher-1 --type researcher "produce a brief on X"
+bin/darkish list             # see live agents
+scion look researcher-1      # read worker output
+```
+
+## What this repo is NOT
+
+This is not a Python library. The original Slice-1 architecture pivoted to "configs + hooks + agent definitions on top of a substrate" — see PR #1's closing comment. Keep that pivot in mind: when the operator asks for a feature, ask whether the substrate already provides it before writing new code.

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,17 @@
 darkish:
 	mkdir -p bin
 	go build -trimpath -ldflags="-s -w" -o bin/darkish ./cmd/darkish
+
+# Sync host-mode skills from the canonical agent-skills repo into the
+# project-local .claude/skills/ tree so Claude Code in this repo
+# auto-discovers them. Canonical source: ~/projects/agent-skills.
+SKILLS_CANONICAL ?= $(HOME)/projects/agent-skills/skills
+HOST_SKILLS      := orchestrator-mode subagent-to-subharness
+
+.PHONY: sync-skills
+sync-skills:
+	@for s in $(HOST_SKILLS); do \
+		mkdir -p .claude/skills/$$s && \
+		cp -f $(SKILLS_CANONICAL)/$$s/SKILL.md .claude/skills/$$s/SKILL.md && \
+		echo "synced .claude/skills/$$s/SKILL.md ← $(SKILLS_CANONICAL)/$$s/SKILL.md"; \
+	done

--- a/cmd/darkish/main.go
+++ b/cmd/darkish/main.go
@@ -23,6 +23,7 @@ var subcommands = []subcommand{
 	{"creds", "refresh hub secrets", runCreds},
 	{"images", "wrap make -C images", runImages},
 	{"list", "wrap scion list", runList},
+	{"orchestrate", "print host-mode orchestrator skill body", runOrchestrate},
 }
 
 func main() {

--- a/cmd/darkish/orchestrate.go
+++ b/cmd/darkish/orchestrate.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// runOrchestrate prints the host-mode orchestrator skill body to stdout.
+// Operators pipe this into a fresh Claude Code session to prime as the
+// orchestrator without relying on the project's CLAUDE.md auto-load.
+//
+// Lookup order:
+//  1. <repo>/.claude/skills/orchestrator-mode/SKILL.md (project copy)
+//  2. ~/projects/agent-skills/skills/orchestrator-mode/SKILL.md (canonical)
+func runOrchestrate(args []string) error {
+	if len(args) > 0 {
+		return errors.New("usage: darkish orchestrate")
+	}
+
+	candidates := []string{}
+	if root, err := repoRoot(); err == nil {
+		candidates = append(candidates, filepath.Join(root, ".claude", "skills", "orchestrator-mode", "SKILL.md"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, "projects", "agent-skills", "skills", "orchestrator-mode", "SKILL.md"))
+	}
+
+	for _, p := range candidates {
+		body, err := os.ReadFile(p)
+		if err == nil {
+			_, err = os.Stdout.Write(body)
+			return err
+		}
+	}
+
+	return fmt.Errorf("orchestrator skill not found in any of: %v", candidates)
+}

--- a/cmd/darkish/orchestrate_test.go
+++ b/cmd/darkish/orchestrate_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOrchestratePrintsLocalSkill(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKISH_REPO_ROOT", tmp)
+
+	dir := filepath.Join(tmp, ".claude", "skills", "orchestrator-mode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := "# Orchestrator mode (host)\n\ntest body\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(want), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(func() error { return runOrchestrate(nil) })
+	if err != nil {
+		t.Fatalf("runOrchestrate: %v", err)
+	}
+	if !strings.Contains(out, "test body") {
+		t.Fatalf("expected skill body in output, got: %q", out)
+	}
+}
+
+func TestOrchestrateRejectsArgs(t *testing.T) {
+	if err := runOrchestrate([]string{"foo"}); err == nil {
+		t.Fatal("expected error when args provided")
+	}
+}


### PR DESCRIPTION
## Summary

Make Mode B (host orchestrator — your interactive Claude Code session IS the orchestrator) the default in this repo. Adds two skills, a project CLAUDE.md anchor, a `darkish orchestrate` subcommand, and a `make sync-skills` target.

Mode A (containerized orchestrator via `darkish spawn orch1 --type orchestrator`) is unchanged; this PR adds Mode B alongside.

## What lands

- **`CLAUDE.md`** — repo-root anchor. Tells Claude Code to invoke the `orchestrator-mode` skill at session start. Documents the subagent-vs-subharness primitive split, lists the operator quick-reference commands, names what this repo is *not*.
- **`.claude/skills/orchestrator-mode/SKILL.md`** — primes the host session as the §7 orchestrator. Full role description, the §7 loop with concrete `darkish spawn` invocations per step, the escalation classifier (Stage 1 deterministic + Stage 2 adversarial), audit-log conventions, the role roster, host-mode adaptations (RequestHumanInput collapses to chat-ask).
- **`.claude/skills/subagent-to-subharness/SKILL.md`** — translates Agent-tool muscle memory into `darkish spawn` dispatch. Decision tree, properties table (in-process subagent vs containerized subharness), per-role mapping, caveman-standard task framing examples, when-to-escalate-to-operator guidance.
- **`cmd/darkish/orchestrate.go`** — `darkish orchestrate` prints the skill body to stdout. Lookup order: project copy → canonical `~/projects/agent-skills/skills/orchestrator-mode/SKILL.md`. For piping into a fresh session: `bin/darkish orchestrate | claude code` or paste-as-system-message.
- **`Makefile`** — adds `make sync-skills` to one-way-rsync the two skills from canonical (`~/projects/agent-skills`) into `.claude/skills/`. Canonical wins; commit drift is intentional.

The two skills also live canonically in `danmestas/agent-skills` — see companion PR.

## How to use

```bash
cd ~/projects/darkish-factory
# one-time prereqs (also from PR #2's review)
scion server start
bin/darkish creds
bin/darkish bootstrap

# every session: just open Claude Code here
claude code
```

The project CLAUDE.md auto-loads. Claude invokes the orchestrator-mode skill. You give a task; Claude routes, dispatches subharnesses, echoes decisions, pauses only when the escalation classifier fires.

## Test plan

- [x] `go test ./... -count=1` — 17 tests pass (15 prior + 2 new for orchestrate)
- [x] `go vet ./...` — clean
- [x] `gofmt -l cmd/ internal/` — clean
- [x] `make darkish` — builds
- [x] `bin/darkish orchestrate | head -3` — prints skill frontmatter
- [x] `bin/darkish --help` — lists `orchestrate` subcommand
- [x] `make sync-skills` — refreshes both `.claude/skills/<name>/SKILL.md` from canonical agent-skills repo
- [x] `diff -q` between canonical and project copy — both in sync
- [ ] **Operator action**: open Claude Code in this repo, type a task, confirm orchestrator persona loads via CLAUDE.md → skill chain
- [ ] **Operator action**: dispatch a real subharness end-to-end (`darkish spawn r1 --type researcher "..."`) to validate the §7 loop's first hop

## Notes

- The 6 known bugs from PR #2's code review are not fixed in this PR (separate concern). The `c.Dir` bug specifically still requires running `darkish bootstrap`/`darkish images` from the repo root.
- The skill at `.claude/skills/` is project-scoped; Claude Code only sees it when invoked here. The canonical at `~/projects/agent-skills/skills/` serves the broader skill-discovery / APM-ref pipeline.