### PR TITLE
Fix: create-harness roster insertion + 8-column row

### DIFF
--- a/cmd/darken/create_harness.go
+++ b/cmd/darken/create_harness.go
@@ -70,13 +70,54 @@ func runCreateHarness(args []string) error {
 	if err != nil {
 		return err
 	}
-	row := fmt.Sprintf("| `%s` | %s | %d | %s | false | %s | %s |\n",
-		role, *model, *maxTurns, "1h", *axes, *desc)
-	// The real harness-roster.md has a blank line after the heading; the
-	// anchor "## Roster\n\n" matches both fixtures and the live doc.
-	out := strings.Replace(string(body), "## Roster\n\n",
-		"## Roster\n\n"+row, 1)
+	// 8 cells matching .design/harness-roster.md header:
+	// Role | Backend | Model | Max turns | Max duration | Detached | Axes | One-line role.
+	row := fmt.Sprintf("| `%s` | %s | %s | %d | %s | false | %s | %s |\n",
+		role, *backend, *model, *maxTurns, "1h", *axes, *desc)
+	out, err := insertAfterTableSeparator(string(body), row)
+	if err != nil {
+		return fmt.Errorf("%s: %w", rosterPath, err)
+	}
 	return os.WriteFile(rosterPath, []byte(out), 0o644)
+}
+
+// insertAfterTableSeparator finds the first markdown table separator
+// line (e.g. "|---|---|---|") in body and inserts row immediately
+// after it. This places new entries inside the table body rather than
+// above its header. Returns an error if no separator is found —
+// silent fall-through would corrupt the roster.
+func insertAfterTableSeparator(body, row string) (string, error) {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if isMarkdownTableSeparator(strings.TrimSpace(line)) {
+			newRow := strings.TrimRight(row, "\n")
+			out := append([]string{}, lines[:i+1]...)
+			out = append(out, newRow)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n"), nil
+		}
+	}
+	return "", errors.New("missing markdown table separator (|---|---|...)")
+}
+
+// isMarkdownTableSeparator reports whether line is a GitHub-flavored
+// markdown table separator: pipe-delimited cells of dashes (with
+// optional alignment colons), e.g. "|---|---|---|" or "|:---|---:|".
+func isMarkdownTableSeparator(line string) bool {
+	if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") || len(line) < 5 {
+		return false
+	}
+	inner := strings.Trim(line, "|")
+	cells := strings.Split(inner, "|")
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		c = strings.TrimLeft(c, ":")
+		c = strings.TrimRight(c, ":")
+		if len(c) < 3 || strings.Trim(c, "-") != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func splitNonEmpty(s, sep string) []string {

--- a/cmd/darken/create_harness_test.go
+++ b/cmd/darken/create_harness_test.go
@@ -7,13 +7,23 @@ import (
 	"testing"
 )
 
+// rosterFixture mirrors the real .design/harness-roster.md table shape:
+// 8 columns, header + separator + at least one existing data row. New
+// rows must land *after* the separator and inside the table body.
+const rosterFixture = `# Harness Roster
+
+## Roster
+
+| Role | Backend | Model | Max turns | Max duration | Detached | Escalation-axis affinity | One-line role |
+|---|---|---|---|---|---|---|---|
+` + "| `orchestrator` | claude | claude-opus-4-7 | 200 | 4h | false | All axes | the operator's only handle |\n"
+
 func TestCreateHarnessProjectScope(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 	os.MkdirAll(filepath.Join(tmp, ".scion", "templates"), 0o755)
 	os.MkdirAll(filepath.Join(tmp, ".design"), 0o755)
-	os.WriteFile(filepath.Join(tmp, ".design", "harness-roster.md"),
-		[]byte("# Harness Roster\n\n## Roster\n\n| Role | Model |\n|---|---|\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".design", "harness-roster.md"), []byte(rosterFixture), 0o644)
 
 	err := runCreateHarness([]string{
 		"newrole",
@@ -35,10 +45,7 @@ func TestCreateHarnessProjectScope(t *testing.T) {
 			t.Fatalf("%s not created: %v", path, err)
 		}
 	}
-	roster, _ := os.ReadFile(filepath.Join(tmp, ".design", "harness-roster.md"))
-	if !strings.Contains(string(roster), "newrole") {
-		t.Fatalf("roster missing newrole entry")
-	}
+	rosterAssertRowAfterSeparator(t, filepath.Join(tmp, ".design", "harness-roster.md"), "newrole")
 }
 
 func TestCreateHarnessUserScope(t *testing.T) {
@@ -51,8 +58,7 @@ func TestCreateHarnessUserScope(t *testing.T) {
 	t.Setenv("HOME", fakeHome)
 
 	os.MkdirAll(filepath.Join(tmp, ".design"), 0o755)
-	os.WriteFile(filepath.Join(tmp, ".design", "harness-roster.md"),
-		[]byte("# Harness Roster\n\n## Roster\n\n| Role | Model |\n|---|---|\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".design", "harness-roster.md"), []byte(rosterFixture), 0o644)
 
 	err := runCreateHarness([]string{
 		"newrole",
@@ -74,10 +80,7 @@ func TestCreateHarnessUserScope(t *testing.T) {
 	}
 
 	// Roster always lives in the working repo, regardless of scope.
-	roster, _ := os.ReadFile(filepath.Join(tmp, ".design", "harness-roster.md"))
-	if !strings.Contains(string(roster), "newrole") {
-		t.Fatalf("roster missing newrole entry")
-	}
+	rosterAssertRowAfterSeparator(t, filepath.Join(tmp, ".design", "harness-roster.md"), "newrole")
 }
 
 func TestCreateHarnessRejectsBadScope(t *testing.T) {
@@ -98,5 +101,76 @@ func TestCreateHarnessRejectsBadScope(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--scope") {
 		t.Fatalf("expected error to mention --scope, got: %v", err)
+	}
+}
+
+// TestCreateHarnessRowHasEightCells regression-guards the row template
+// shape. The roster table has 8 columns; an off-by-one row template
+// generates malformed markdown that doesn't render as a table row.
+func TestCreateHarnessRowHasEightCells(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	os.MkdirAll(filepath.Join(tmp, ".scion", "templates"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".design"), 0o755)
+	os.WriteFile(filepath.Join(tmp, ".design", "harness-roster.md"), []byte(rosterFixture), 0o644)
+
+	err := runCreateHarness([]string{
+		"newrole",
+		"--scope", "project",
+		"--backend", "codex",
+		"--model", "gpt-5.5",
+		"--description", "Test role",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := os.ReadFile(filepath.Join(tmp, ".design", "harness-roster.md"))
+	for _, line := range strings.Split(string(body), "\n") {
+		if !strings.Contains(line, "newrole") {
+			continue
+		}
+		// 8 columns => 9 pipe characters (leading + trailing + 7 between cells).
+		if got := strings.Count(line, "|"); got != 9 {
+			t.Fatalf("expected 9 pipe chars (8 cells), got %d in line: %q", got, line)
+		}
+		// Confirm the backend cell is present.
+		if !strings.Contains(line, "| codex |") {
+			t.Fatalf("expected backend cell '| codex |' in row, got: %q", line)
+		}
+		return
+	}
+	t.Fatal("newrole row not found in roster")
+}
+
+// rosterAssertRowAfterSeparator confirms the line containing roleName
+// appears strictly after the markdown table separator (|---|...|).
+// A row inserted *above* the header would be a regression.
+func rosterAssertRowAfterSeparator(t *testing.T, path, roleName string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(body), "\n")
+	sepIdx := -1
+	roleIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isMarkdownTableSeparator(trimmed) && sepIdx == -1 {
+			sepIdx = i
+		}
+		if strings.Contains(line, roleName) && roleIdx == -1 {
+			roleIdx = i
+		}
+	}
+	if sepIdx == -1 {
+		t.Fatalf("roster missing table separator")
+	}
+	if roleIdx == -1 {
+		t.Fatalf("roster missing role %q", roleName)
+	}
+	if roleIdx <= sepIdx {
+		t.Fatalf("role %q at line %d landed at-or-above separator at line %d (rows must come AFTER the separator)", roleName, roleIdx+1, sepIdx+1)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 1 validation surfaced two bugs in \`darken create-harness\` (originated in PR #2; not Phase 1 regressions):

1. **Roster row landed above the table header.** Previous anchor \`## Roster\n\n\` matched the heading + blank line; rows inserted immediately after that broke the markdown table — the new row appeared *between* the heading and the column header. Live test (in this PR's commit message): the diff after a \`darken create-harness\` call showed:

\`\`\`diff
 ## Roster
 
+| ... new row ...
 | Role | Backend | Model | ...
 |---|---|---|...
\`\`\`

2. **Row template had 7 cells; the actual roster has 8.** Missing column was \`Backend\` (claude/codex/pi/gemini). Result: malformed markdown that doesn't render as a table row.

## Fix

- New helper \`insertAfterTableSeparator(body, row)\` finds the first markdown table separator (\`|---|---|...|\`) and inserts the row immediately after it. Errors if no separator is found (silent fall-through would corrupt).
- New helper \`isMarkdownTableSeparator(line)\` detects GFM-style separators with any column count + optional alignment colons.
- Row template updated to 8 cells: \`| \`<role>\` | <backend> | <model> | <maxTurns> | 1h | false | <axes> | <description> |\`.

## Why pre-existing tests didn't catch it

\`TestCreateHarnessProjectScope\` and \`TestCreateHarnessUserScope\` used \`strings.Contains(roster, "newrole")\` — confirmed the row landed *somewhere*, not *where*. Test fixture was a 2-column toy table, so the column-count mismatch never triggered visible breakage.

## Test plan

- [x] New \`TestCreateHarnessRowHasEightCells\` asserts the inserted row contains exactly 9 pipe characters (= 8 cells) and includes the backend cell
- [x] New helper \`rosterAssertRowAfterSeparator\` threaded through both scope tests; fails if the role line index ≤ separator line index
- [x] Test fixture (\`rosterFixture\` const) now mirrors the real 8-column header + separator shape
- [x] \`go test ./... -count=1\` — all 4 create-harness tests + remaining suite green
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l cmd/ internal/\` clean
- [x] **Live smoke**: \`darken create-harness smoketest --scope project ...\` against the real \`.design/harness-roster.md\` — confirmed row lands at line 11, immediately after the separator at line 10. Cleaned up after.