### PR TITLE
Phase 4: README install/quickstart + go-install version introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,57 @@ By Daniel Mestas
 
 Run multiple Claude Code instances in parallel, building at least 4x the work at the same time, bother the operator half as much, with deterministic guarantees, observability, and evolution over time. The human stays in the loop only for taste, architecture, ethics, and reversibility. For work with machine-checkable correctness — formal specs, reference binaries, tunable objectives — the same architecture runs fully dark. See §11.
 
+## Install
+
+```bash
+# Recommended (Homebrew):
+brew install danmestas/tap/darken
+
+# Alternative (Go modules):
+go install github.com/danmestas/darken/cmd/darken@latest
+
+# Direct download:
+# https://github.com/danmestas/darken/releases/latest
+```
+
+The `darken` binary is self-contained — templates, scripts, Dockerfiles, and the host-mode skills are embedded. Workers spawn as containerized subharnesses (claude / codex / pi / gemini); see §5 for the roster. You'll need Docker, [scion](https://github.com/ptone/scion), and credentials for whichever backends you use (`darken creds` populates them from your local Keychain / `~/.codex/auth.json` / env vars).
+
+## Quick start — orchestrator mode in a fresh repo
+
+```bash
+# In any repo you want to drive with the §7 pipeline:
+cd ~/projects/some-other-repo
+
+# One-time setup
+darken init                                       # scaffolds CLAUDE.md
+darken creds                                      # push hub secrets
+darken bootstrap                                  # stage skills, ensure images
+
+# Open Claude Code; CLAUDE.md auto-loads orchestrator-mode skill
+claude code
+
+# In the session, give it a task:
+# > "Audit the auth flow for compliance gaps"
+# Orchestrator routes (light/heavy), dispatches subharnesses,
+# echoes decisions, pauses only when the escalation classifier fires.
+```
+
+`darken doctor` runs preflight + per-harness checks. `darken doctor <role>` shows which substrate layer (override / project / embedded) served that role's manifest.
+
+### Customizing the substrate
+
+The embedded substrate is the always-present fallback. Override per-machine in `~/.config/darken/overrides/`, per-project in `<repo>/.scion/templates/<role>/`, or per-invocation via `darken --substrate-overrides <path>`. Run `darken create-harness <name> --backend codex --model gpt-5.5 ...` to scaffold a new role into your overrides.
+
+### Updating
+
+```bash
+brew upgrade darken
+# or:
+go install github.com/danmestas/darken/cmd/darken@latest
+```
+
+`darken version` reports the binary version + a 12-char prefix of the embedded substrate hash. Operators on the same release tag should see the same substrate hash; divergence indicates a local build.
+
 ## 1. Problem
 
 In spec-kit-style sessions, the AI surfaces multiple decisions per feature and the operator ratifies most without changing the recommendation. The AI isn't asking because it needs a human; it's asking because the harness was configured to ask.

--- a/cmd/darken/version.go
+++ b/cmd/darken/version.go
@@ -3,12 +3,16 @@ package main
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/danmestas/darken/internal/substrate"
 )
 
-// version is overridden at build time via -ldflags="-X main.version=v0.1.0".
-// Defaults to "dev" for source-tree builds.
+// version is overridden at build time via -ldflags="-X main.version=v0.1.0"
+// when goreleaser produces release archives + the homebrew formula. For
+// `go install` paths, version stays "dev" because the ldflag isn't applied —
+// resolvedVersion() falls through to runtime/debug.ReadBuildInfo() and
+// reports the module version that go modules resolved.
 var version = "dev"
 
 func runVersion(args []string) error {
@@ -19,6 +23,23 @@ func runVersion(args []string) error {
 	if len(hash) > 12 {
 		hash = hash[:12]
 	}
-	fmt.Printf("darken %s (substrate sha256:%s)\n", version, hash)
+	fmt.Printf("darken %s (substrate sha256:%s)\n", resolvedVersion(), hash)
 	return nil
+}
+
+// resolvedVersion returns the build-time-injected version when present;
+// otherwise falls back to the module version recorded by `go install`
+// (debug.ReadBuildInfo). Returns "dev" only for source-tree builds where
+// neither path produces a real version.
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		v := info.Main.Version
+		if v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
 }


### PR DESCRIPTION
## Summary

Two small Phase 4 polishes that close the loop on \`v0.1.0\` shipping last hour.

## What lands

**README**

- New \`## Install\` section at the top with three install paths (brew, go install, direct download)
- New \`## Quick start\` section showing the new-repo workflow: \`darken init\` → \`darken creds\` → \`darken bootstrap\` → \`claude code\`
- Substrate customization note (overrides at user / project / flag scope)
- Update instructions (\`brew upgrade darken\`)

**\`cmd/darken/version.go\`**

\`go install\` previously reported \`dev\` because it doesn't get the \`-X main.version=...\` ldflag that goreleaser injects. New \`resolvedVersion()\` falls through to \`runtime/debug.ReadBuildInfo()\` when \`version == \"dev\"\`, picking up the module version that go modules resolved.

Result:

| Build path | Before | After |
|---|---|---|
| brew install (goreleaser) | \`v0.1.0\` ✓ | \`v0.1.0\` ✓ (unchanged) |
| \`go install ...@v0.1.0\` | \`dev\` ✗ | \`v0.1.0\` ✓ |
| Source tree (\`make darken\`) | \`dev\` | \`v0.1.0+dirty\` (Go vcs stamp) |

The source-tree case improves too — instead of bare \`dev\`, you get e.g. \`v0.1.0+dirty\` showing which release tag you're working off + whether the working tree is clean.

## Test plan

- [x] \`go test ./... -count=1\` — all 3 packages green
- [x] \`go vet ./...\`, \`gofmt -l cmd/ internal/\` — clean
- [x] \`make darken && bin/darken version\` → \`darken v0.1.0+dirty (substrate sha256:5faefecdf8a3)\`
- [x] \`go build -o /tmp/test ./cmd/darken && /tmp/test version\` → same (simulates go-install path; release tag picked up via debug.ReadBuildInfo)
- [ ] **Operator validation post-merge**: \`go install github.com/danmestas/darken/cmd/darken@v0.1.0\` should now report \`darken v0.1.0\` (no \`+dirty\`, no \`dev\`)

## Backward-compat caveats

None. Pure additive: README adds sections (no removed content); version.go's helper is a fallback path that only fires when the ldflag isn't set.

## Phases done

After this merges, the four-phase installable-substrate work is complete:

- ✅ Phase 1 — substrate resolver + rename darkish→darken
- ✅ Phase 2 — embed substrate + \`darken init\` + \`darken version\`
- ✅ Phase 3 — release pipeline (goreleaser + GH Actions + tap) — \`v0.1.0\` shipped
- ✅ Phase 4 — README install/quickstart + go-install version introspection

The repo rename PR (#8) and the create-harness fix (#5) were unscheduled but landed in the same arc.