### PR TITLE
fix(release): publish formula to Formula/ subdir (matches bones convention)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,11 @@ release:
 
 brews:
   - name: darken
+    # Modern Homebrew convention: formulae live in Formula/<name>.rb.
+    # Mixing root-level + Formula/ formulae in the same tap (we share
+    # danmestas/homebrew-tap with bones) confuses brew's name resolution
+    # and breaks `brew upgrade`.
+    directory: Formula
     repository:
       owner: danmestas
       name: homebrew-tap


### PR DESCRIPTION
## Summary

You share `danmestas/homebrew-tap` with the `bones` project, which publishes to `Formula/bones.rb` (modern convention). Our `.goreleaser.yaml` was publishing to root-level `darken.rb` (older convention). Mixed conventions in the same tap broke `brew upgrade darken` end-to-end — brew couldn't reliably resolve the formula by name.

The fix is one line: add `directory: Formula` to the brews block. Snapshot-verified: formula now writes to `dist/homebrew/Formula/darken.rb`.

## What lands

- `.goreleaser.yaml`: `directory: Formula` under the `brews` entry + comment explaining why.

## Operator action items (post-merge)

1. **Tag v0.1.2**:

   ```bash
   git checkout main && git pull
   git tag -a v0.1.2 -m "darken v0.1.2 — formula moves to Formula/ subdir"
   git push origin v0.1.2
   gh run watch
   ```

2. **Delete the stale root-level `darken.rb` from the tap** (one-time cleanup):

   ```bash
   tmp=$(mktemp -d)
   gh repo clone danmestas/homebrew-tap "$tmp"
   cd "$tmp"
   git rm darken.rb  # the root-level one; Formula/darken.rb stays
   git commit -m "chore: remove stale root-level darken.rb (now at Formula/darken.rb)"
   git push origin main
   cd - && rm -rf "$tmp"
   ```

3. **Test brew upgrade end-to-end**:

   ```bash
   brew update
   brew upgrade darken  # should now find Formula/darken.rb cleanly
   darken version       # darken 0.1.2 (substrate sha256:...)
   ```

## Test plan

- [x] `goreleaser release --snapshot --clean` writes to `dist/homebrew/Formula/darken.rb`
- [x] Existing tap path resolution: bones is at `Formula/bones.rb`; darken will join it at `Formula/darken.rb` (no name collision)
- [ ] **Operator validation**: tag v0.1.2, watch workflow succeed, observe `Formula/darken.rb` appears in tap, run `brew upgrade darken` to v0.1.2

## Cross-reference

This closes the brew-side polish from PR #9's Phase 4 work. The `go install` path was unaffected — version-introspection still reports v0.1.1 / v0.1.2 correctly through `runtime/debug.ReadBuildInfo`.