### PR TITLE
fix(images): switch from agent-init+agent-tasks to unified bones CLI

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -16,21 +16,26 @@ REGISTRY         ?= local
 TAG              ?= latest
 AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra
 
-# prebuild-bones: cross-compile agent-infra binaries on the host for linux/arm64.
+# prebuild-bones: cross-compile the unified bones CLI for linux/arm64.
 # Required before running `make claude` because agent-infra and its dependency
 # EdgeSync/leaf are private repos (no credentials in Docker build context).
+#
+# bones is the unified CLI (replaces the old agent-init + agent-tasks
+# binaries). Subcommands:
+#   bones init                 — create workspace (was: agent-init)
+#   bones tasks <subcmd>       — task management (was: agent-tasks)
+#   bones repo <subcmd>        — fossil-style repo ops (new)
 .PHONY: prebuild-bones
 prebuild-bones:
+	# Clean bin/ first so stale binaries (e.g. the prior agent-init +
+	# agent-tasks pair) don't get COPY'd into the Docker image.
+	rm -rf claude/bin codex/bin pi/bin gemini/bin
 	mkdir -p claude/bin codex/bin pi/bin gemini/bin
 	cd $(AGENT_INFRA_PATH) && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/agent-tasks ./cmd/agent-tasks
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/bones ./cmd/bones
 
 .PHONY: claude
 claude:

--- a/images/README.md
+++ b/images/README.md
@@ -11,7 +11,7 @@ Every `darkish-*` image carries the same baseline regardless of backend:
 | Layer | Contents | Notes |
 |---|---|---|
 | apt utilities | `jq`, `ripgrep`, `fzf`, `less`, `gh`, `ca-certificates`, `curl`, `git` | Standard tools every harness uses |
-| bones binaries | `agent-init`, `agent-tasks` | Pre-compiled on the host (`make prebuild-bones`) and copied from `<backend>/bin/`. agent-infra is currently private; in-Docker `git clone` blocked until it goes public. The other 12 bones names from the spec (assert, autoclaim, chat, etc.) are not yet in the upstream agent-infra repo. |
+| bones unified CLI | `bones` (subcommands: `init`, `tasks`, `repo`, ...) | Pre-compiled on the host from `~/projects/agent-infra/cmd/bones` (`make prebuild-bones`) and copied from `<backend>/bin/`. agent-infra is currently private; in-Docker `git clone` blocked until it goes public. Replaces the prior `agent-init` + `agent-tasks` binaries — both are now subcommands. |
 | Universal skill | `caveman` (cloned from `juliusbrussee/caveman`) | Communication-tier discipline; mounted at `/home/scion/skills/caveman/` |
 | Universal MCP | `context-mode` (npm `@mksglu/context-mode` with git-clone fallback to `mksglu/context-mode`) | Sandboxed raw-output handling; every harness faces context-window pressure |
 | Trust prelude | per-backend (validated for claude + codex; placeholders for pi + gemini) | Suppresses first-encounter trust dialogs |
@@ -22,7 +22,7 @@ it is a paid product. Code search is handled by `context-mode` instead.
 ### Refresh procedure
 
 ```bash
-make -C images prebuild-bones    # rebuild bones binaries from ~/projects/agent-infra
+make -C images prebuild-bones    # rebuild the bones CLI from ~/projects/agent-infra
 make -C images all               # rebuild all four darkish-* images
 ```
 
@@ -126,8 +126,8 @@ First-time setup needs:
    make -C images prebuild-bones
    ```
 
-   This cross-compiles `agent-init` and `agent-tasks` for `linux/arm64`
-   from `~/projects/agent-infra` into all four `images/<backend>/bin/`
+   This cross-compiles the unified `bones` CLI for `linux/arm64` from
+   `~/projects/agent-infra/cmd/bones` into all four `images/<backend>/bin/`
    directories. Re-run after `agent-infra` updates.
 
 Then:

--- a/images/claude/Dockerfile
+++ b/images/claude/Dockerfile
@@ -1,19 +1,20 @@
 # darkish-claude — universal baseline + claude backend.
 # Layers ordered heaviest-at-bottom for cache efficiency.
 #
-# NOTE (A-01 blockers resolved):
-#   - agent-infra and its dependency EdgeSync/leaf are private repos.
-#     Binaries are pre-compiled on the host (CGO_ENABLED=0 GOOS=linux) and
-#     copied from ./bin/ into the image. The bones-builder stage is omitted
-#     until SSH/netrc credentials can be mounted at build time.
-#     Restore the multi-stage build once the repos are public or CI has creds.
-#   - mgrep-code-search is also private; omitted until accessible.
-#   - Only 4 cmds exist in the current agent-infra (agent-init, agent-tasks,
-#     orchestrator-validate-plan, space-invaders-orchestrate); the 12 remaining
-#     binaries from the spec do not yet exist. Only agent-init and agent-tasks
-#     are included as they are the core operational primitives.
-#   - agent-infra requires go 1.26; pre-built on go 1.26.2 darwin/arm64 for
-#     linux/arm64 target.
+# NOTE: agent-infra and its dependency EdgeSync/leaf are private repos.
+# The unified bones CLI is pre-compiled on the host (CGO_ENABLED=0 GOOS=linux
+# GOARCH=arm64) and copied from ./bin/ into the image. Restore the multi-
+# stage build once the repos are public or CI has credentials.
+#
+# bones replaces the prior agent-init + agent-tasks binaries with a single
+# CLI that exposes them as subcommands:
+#   bones init                — create a workspace (was: agent-init)
+#   bones tasks <subcmd>      — task management   (was: agent-tasks)
+#   bones repo <subcmd>       — fossil-style repo ops (new)
+#
+# agent-infra requires go 1.26; pre-built on go 1.26.2 darwin/arm64 for
+# linux/arm64 target. mgrep-code-search is intentionally omitted in favor
+# of context-mode (private + paid).
 
 ARG BASE_IMAGE=local/scion-claude:latest
 
@@ -26,11 +27,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries (agent-init, agent-tasks).
+# 2. Pre-built bones unified CLI.
 #    Compiled on host: CGO_ENABLED=0 GOOS=linux GOARCH=arm64
 #    Refresh with: make -C images prebuild-bones
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/images/claude/test-bones.sh
+++ b/images/claude/test-bones.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 # Smoke-test that the universal baseline is present in darkish-claude.
 #
-# NOTE (A-01): The original spec listed 14 agent-infra binaries plus mgrep.
-# The current agent-infra repo only ships agent-init and agent-tasks;
-# the remaining 12 cmds (assert, autoclaim, chat, compactanthropic, dispatch,
-# fossil, holds, jskv, presence, tasks, testutil, workspace) are not yet
-# present upstream. mgrep-code-search is a private repo; both are omitted
-# from REQUIRED_BIN until they land. Update this list when the cmds exist.
+# bones is the unified CLI from agent-infra (replaces the prior
+# agent-init + agent-tasks binaries with subcommands). The smoke test
+# confirms `bones` is on PATH and `bones --help` runs cleanly inside
+# the image.
 set -euo pipefail
 
 IMG="${1:-local/darkish-claude:latest}"
 
 REQUIRED_BIN=(
-  agent-init agent-tasks
+  bones
   jq rg fzf gh
 )
 
@@ -22,5 +20,11 @@ for b in "${REQUIRED_BIN[@]}"; do
     exit 1
   fi
 done
+
+# bones --help must run cleanly (catches truncated/corrupted binary).
+if ! docker run --rm --entrypoint /bin/sh "${IMG}" -c "bones --help >/dev/null 2>&1"; then
+  echo "FAIL: bones --help failed in ${IMG}" >&2
+  exit 1
+fi
 
 echo "PASS: all baseline binaries present in ${IMG}"

--- a/images/codex/Dockerfile
+++ b/images/codex/Dockerfile
@@ -1,15 +1,12 @@
 # darkish-codex — universal baseline + codex backend.
 # Mirrors darkish-claude's pattern.
 #
-# NOTE (A-02 mirrors A-01 blockers):
-#   - agent-infra is private; binaries are pre-compiled on the host
-#     (CGO_ENABLED=0 GOOS=linux GOARCH=arm64) and copied from ./bin/.
-#     Restore in-Docker bones-builder once agent-infra goes public.
-#   - mgrep is intentionally omitted (paid product; operator uses
-#     context-mode for search instead).
-#   - Only agent-init and agent-tasks ship today; the other 12 named
-#     bones cmds are not yet present in agent-infra upstream.
-#   - Refresh binaries with: make -C images prebuild-bones
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (CGO_ENABLED=0 GOOS=linux GOARCH=arm64) and copied from ./bin/.
+# bones exposes init/tasks/repo as subcommands. Refresh with:
+#   make -C images prebuild-bones
+#
+# mgrep is intentionally omitted in favor of context-mode (paid + private).
 
 ARG BASE_IMAGE=local/scion-codex:latest
 
@@ -22,9 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries (agent-init, agent-tasks).
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/images/codex/test-bones.sh
+++ b/images/codex/test-bones.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Smoke-test that the universal baseline is present in darkish-codex.
+# Smoke-test that the universal baseline is present in darkish-claude.
 #
-# NOTE (A-02 mirrors A-01): bones is currently 2 binaries (agent-init,
-# agent-tasks) pre-built on the host. mgrep is intentionally omitted
-# (paid product; operator uses context-mode for search). Update list
-# when more agent-infra cmds land or paid tools are added.
+# bones is the unified CLI from agent-infra (replaces the prior
+# agent-init + agent-tasks binaries with subcommands). The smoke test
+# confirms `bones` is on PATH and `bones --help` runs cleanly inside
+# the image.
 set -euo pipefail
 
 IMG="${1:-local/darkish-codex:latest}"
 
 REQUIRED_BIN=(
-  agent-init agent-tasks
+  bones
   jq rg fzf gh
 )
 
@@ -20,5 +20,11 @@ for b in "${REQUIRED_BIN[@]}"; do
     exit 1
   fi
 done
+
+# bones --help must run cleanly (catches truncated/corrupted binary).
+if ! docker run --rm --entrypoint /bin/sh "${IMG}" -c "bones --help >/dev/null 2>&1"; then
+  echo "FAIL: bones --help failed in ${IMG}" >&2
+  exit 1
+fi
 
 echo "PASS: all baseline binaries present in ${IMG}"

--- a/images/gemini/Dockerfile
+++ b/images/gemini/Dockerfile
@@ -1,11 +1,11 @@
 # darkish-gemini — universal baseline + gemini backend.
 # Mirrors A-01's pattern.
 #
-# NOTE (A-04 mirrors A-01 / A-02 / A-03 blockers):
-#   - agent-infra is private; binaries pre-compiled on the host (linux/arm64)
-#     and copied from ./bin/. Refresh: make -C images prebuild-bones.
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (linux/arm64) and copied from ./bin/. Refresh:
+#   make -C images prebuild-bones
+# bones exposes init/tasks/repo as subcommands.
 #   - mgrep omitted (paid; context-mode replaces).
-#   - Only agent-init + agent-tasks ship today; other bones cmds pending.
 #   - Gemini auth (3 options):
 #       * GEMINI_API_KEY env var (free tier on AI Studio)
 #       * ~/.gemini/oauth_creds.json (gemini-cli OAuth; scion auto-detects)
@@ -24,9 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries.
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/images/gemini/test-bones.sh
+++ b/images/gemini/test-bones.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Smoke-test that the universal baseline is present in darkish-gemini.
+# Smoke-test that the universal baseline is present in darkish-claude.
 #
-# NOTE (A-04 mirrors A-01..A-03): bones is currently 2 binaries
-# (agent-init, agent-tasks) pre-built on the host. mgrep omitted
-# (paid; context-mode replaces). Gemini auth: GEMINI_API_KEY env var,
-# OAuth file (~/.gemini/oauth_creds.json), or Vertex ADC.
+# bones is the unified CLI from agent-infra (replaces the prior
+# agent-init + agent-tasks binaries with subcommands). The smoke test
+# confirms `bones` is on PATH and `bones --help` runs cleanly inside
+# the image.
 set -euo pipefail
 
 IMG="${1:-local/darkish-gemini:latest}"
 
 REQUIRED_BIN=(
-  agent-init agent-tasks
+  bones
   jq rg fzf gh
 )
 
@@ -20,5 +20,11 @@ for b in "${REQUIRED_BIN[@]}"; do
     exit 1
   fi
 done
+
+# bones --help must run cleanly (catches truncated/corrupted binary).
+if ! docker run --rm --entrypoint /bin/sh "${IMG}" -c "bones --help >/dev/null 2>&1"; then
+  echo "FAIL: bones --help failed in ${IMG}" >&2
+  exit 1
+fi
 
 echo "PASS: all baseline binaries present in ${IMG}"

--- a/images/pi/Dockerfile
+++ b/images/pi/Dockerfile
@@ -1,11 +1,11 @@
 # darkish-pi — universal baseline + pi backend (OpenRouter-routed).
 # Mirrors A-01's pattern.
 #
-# NOTE (A-03 mirrors A-01 / A-02 blockers):
-#   - agent-infra is private; binaries pre-compiled on the host (linux/arm64)
-#     and copied from ./bin/. Refresh: make -C images prebuild-bones.
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (linux/arm64) and copied from ./bin/. Refresh:
+#   make -C images prebuild-bones
+# bones exposes init/tasks/repo as subcommands.
 #   - mgrep omitted (paid; context-mode replaces).
-#   - Only agent-init + agent-tasks ship today; other bones cmds pending.
 #   - Pi auth: OPENROUTER_API_KEY env var (no OAuth file mount).
 #   - Pi uses pi-coding-agent CLI; --non-interactive flag bypasses any
 #     first-run trust dialog observed in existing pi-templates.
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries.
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/images/pi/test-bones.sh
+++ b/images/pi/test-bones.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# Smoke-test that the universal baseline is present in darkish-pi.
+# Smoke-test that the universal baseline is present in darkish-claude.
 #
-# NOTE (A-03 mirrors A-01 / A-02): bones is currently 2 binaries
-# (agent-init, agent-tasks) pre-built on the host. mgrep omitted
-# (paid; context-mode replaces). Pi auth is OPENROUTER_API_KEY env var.
+# bones is the unified CLI from agent-infra (replaces the prior
+# agent-init + agent-tasks binaries with subcommands). The smoke test
+# confirms `bones` is on PATH and `bones --help` runs cleanly inside
+# the image.
 set -euo pipefail
 
 IMG="${1:-local/darkish-pi:latest}"
 
 REQUIRED_BIN=(
-  agent-init agent-tasks
+  bones
   jq rg fzf gh
 )
 
@@ -19,5 +20,11 @@ for b in "${REQUIRED_BIN[@]}"; do
     exit 1
   fi
 done
+
+# bones --help must run cleanly (catches truncated/corrupted binary).
+if ! docker run --rm --entrypoint /bin/sh "${IMG}" -c "bones --help >/dev/null 2>&1"; then
+  echo "FAIL: bones --help failed in ${IMG}" >&2
+  exit 1
+fi
 
 echo "PASS: all baseline binaries present in ${IMG}"

--- a/internal/substrate/data/images/Makefile
+++ b/internal/substrate/data/images/Makefile
@@ -16,21 +16,26 @@ REGISTRY         ?= local
 TAG              ?= latest
 AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra
 
-# prebuild-bones: cross-compile agent-infra binaries on the host for linux/arm64.
+# prebuild-bones: cross-compile the unified bones CLI for linux/arm64.
 # Required before running `make claude` because agent-infra and its dependency
 # EdgeSync/leaf are private repos (no credentials in Docker build context).
+#
+# bones is the unified CLI (replaces the old agent-init + agent-tasks
+# binaries). Subcommands:
+#   bones init                 — create workspace (was: agent-init)
+#   bones tasks <subcmd>       — task management (was: agent-tasks)
+#   bones repo <subcmd>        — fossil-style repo ops (new)
 .PHONY: prebuild-bones
 prebuild-bones:
+	# Clean bin/ first so stale binaries (e.g. the prior agent-init +
+	# agent-tasks pair) don't get COPY'd into the Docker image.
+	rm -rf claude/bin codex/bin pi/bin gemini/bin
 	mkdir -p claude/bin codex/bin pi/bin gemini/bin
 	cd $(AGENT_INFRA_PATH) && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/agent-tasks ./cmd/agent-tasks && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/agent-init ./cmd/agent-init && \
-	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/agent-tasks ./cmd/agent-tasks
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/bones ./cmd/bones && \
+	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/gemini/bin/bones ./cmd/bones
 
 .PHONY: claude
 claude:

--- a/internal/substrate/data/images/README.md
+++ b/internal/substrate/data/images/README.md
@@ -11,7 +11,7 @@ Every `darkish-*` image carries the same baseline regardless of backend:
 | Layer | Contents | Notes |
 |---|---|---|
 | apt utilities | `jq`, `ripgrep`, `fzf`, `less`, `gh`, `ca-certificates`, `curl`, `git` | Standard tools every harness uses |
-| bones binaries | `agent-init`, `agent-tasks` | Pre-compiled on the host (`make prebuild-bones`) and copied from `<backend>/bin/`. agent-infra is currently private; in-Docker `git clone` blocked until it goes public. The other 12 bones names from the spec (assert, autoclaim, chat, etc.) are not yet in the upstream agent-infra repo. |
+| bones unified CLI | `bones` (subcommands: `init`, `tasks`, `repo`, ...) | Pre-compiled on the host from `~/projects/agent-infra/cmd/bones` (`make prebuild-bones`) and copied from `<backend>/bin/`. agent-infra is currently private; in-Docker `git clone` blocked until it goes public. Replaces the prior `agent-init` + `agent-tasks` binaries — both are now subcommands. |
 | Universal skill | `caveman` (cloned from `juliusbrussee/caveman`) | Communication-tier discipline; mounted at `/home/scion/skills/caveman/` |
 | Universal MCP | `context-mode` (npm `@mksglu/context-mode` with git-clone fallback to `mksglu/context-mode`) | Sandboxed raw-output handling; every harness faces context-window pressure |
 | Trust prelude | per-backend (validated for claude + codex; placeholders for pi + gemini) | Suppresses first-encounter trust dialogs |
@@ -22,7 +22,7 @@ it is a paid product. Code search is handled by `context-mode` instead.
 ### Refresh procedure
 
 ```bash
-make -C images prebuild-bones    # rebuild bones binaries from ~/projects/agent-infra
+make -C images prebuild-bones    # rebuild the bones CLI from ~/projects/agent-infra
 make -C images all               # rebuild all four darkish-* images
 ```
 
@@ -126,8 +126,8 @@ First-time setup needs:
    make -C images prebuild-bones
    ```
 
-   This cross-compiles `agent-init` and `agent-tasks` for `linux/arm64`
-   from `~/projects/agent-infra` into all four `images/<backend>/bin/`
+   This cross-compiles the unified `bones` CLI for `linux/arm64` from
+   `~/projects/agent-infra/cmd/bones` into all four `images/<backend>/bin/`
    directories. Re-run after `agent-infra` updates.
 
 Then:

--- a/internal/substrate/data/images/claude/Dockerfile
+++ b/internal/substrate/data/images/claude/Dockerfile
@@ -1,19 +1,20 @@
 # darkish-claude — universal baseline + claude backend.
 # Layers ordered heaviest-at-bottom for cache efficiency.
 #
-# NOTE (A-01 blockers resolved):
-#   - agent-infra and its dependency EdgeSync/leaf are private repos.
-#     Binaries are pre-compiled on the host (CGO_ENABLED=0 GOOS=linux) and
-#     copied from ./bin/ into the image. The bones-builder stage is omitted
-#     until SSH/netrc credentials can be mounted at build time.
-#     Restore the multi-stage build once the repos are public or CI has creds.
-#   - mgrep-code-search is also private; omitted until accessible.
-#   - Only 4 cmds exist in the current agent-infra (agent-init, agent-tasks,
-#     orchestrator-validate-plan, space-invaders-orchestrate); the 12 remaining
-#     binaries from the spec do not yet exist. Only agent-init and agent-tasks
-#     are included as they are the core operational primitives.
-#   - agent-infra requires go 1.26; pre-built on go 1.26.2 darwin/arm64 for
-#     linux/arm64 target.
+# NOTE: agent-infra and its dependency EdgeSync/leaf are private repos.
+# The unified bones CLI is pre-compiled on the host (CGO_ENABLED=0 GOOS=linux
+# GOARCH=arm64) and copied from ./bin/ into the image. Restore the multi-
+# stage build once the repos are public or CI has credentials.
+#
+# bones replaces the prior agent-init + agent-tasks binaries with a single
+# CLI that exposes them as subcommands:
+#   bones init                — create a workspace (was: agent-init)
+#   bones tasks <subcmd>      — task management   (was: agent-tasks)
+#   bones repo <subcmd>       — fossil-style repo ops (new)
+#
+# agent-infra requires go 1.26; pre-built on go 1.26.2 darwin/arm64 for
+# linux/arm64 target. mgrep-code-search is intentionally omitted in favor
+# of context-mode (private + paid).
 
 ARG BASE_IMAGE=local/scion-claude:latest
 
@@ -26,11 +27,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries (agent-init, agent-tasks).
+# 2. Pre-built bones unified CLI.
 #    Compiled on host: CGO_ENABLED=0 GOOS=linux GOARCH=arm64
 #    Refresh with: make -C images prebuild-bones
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/internal/substrate/data/images/codex/Dockerfile
+++ b/internal/substrate/data/images/codex/Dockerfile
@@ -1,15 +1,12 @@
 # darkish-codex — universal baseline + codex backend.
 # Mirrors darkish-claude's pattern.
 #
-# NOTE (A-02 mirrors A-01 blockers):
-#   - agent-infra is private; binaries are pre-compiled on the host
-#     (CGO_ENABLED=0 GOOS=linux GOARCH=arm64) and copied from ./bin/.
-#     Restore in-Docker bones-builder once agent-infra goes public.
-#   - mgrep is intentionally omitted (paid product; operator uses
-#     context-mode for search instead).
-#   - Only agent-init and agent-tasks ship today; the other 12 named
-#     bones cmds are not yet present in agent-infra upstream.
-#   - Refresh binaries with: make -C images prebuild-bones
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (CGO_ENABLED=0 GOOS=linux GOARCH=arm64) and copied from ./bin/.
+# bones exposes init/tasks/repo as subcommands. Refresh with:
+#   make -C images prebuild-bones
+#
+# mgrep is intentionally omitted in favor of context-mode (paid + private).
 
 ARG BASE_IMAGE=local/scion-codex:latest
 
@@ -22,9 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries (agent-init, agent-tasks).
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/internal/substrate/data/images/gemini/Dockerfile
+++ b/internal/substrate/data/images/gemini/Dockerfile
@@ -1,11 +1,11 @@
 # darkish-gemini — universal baseline + gemini backend.
 # Mirrors A-01's pattern.
 #
-# NOTE (A-04 mirrors A-01 / A-02 / A-03 blockers):
-#   - agent-infra is private; binaries pre-compiled on the host (linux/arm64)
-#     and copied from ./bin/. Refresh: make -C images prebuild-bones.
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (linux/arm64) and copied from ./bin/. Refresh:
+#   make -C images prebuild-bones
+# bones exposes init/tasks/repo as subcommands.
 #   - mgrep omitted (paid; context-mode replaces).
-#   - Only agent-init + agent-tasks ship today; other bones cmds pending.
 #   - Gemini auth (3 options):
 #       * GEMINI_API_KEY env var (free tier on AI Studio)
 #       * ~/.gemini/oauth_creds.json (gemini-cli OAuth; scion auto-detects)
@@ -24,9 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries.
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \

--- a/internal/substrate/data/images/pi/Dockerfile
+++ b/internal/substrate/data/images/pi/Dockerfile
@@ -1,11 +1,11 @@
 # darkish-pi — universal baseline + pi backend (OpenRouter-routed).
 # Mirrors A-01's pattern.
 #
-# NOTE (A-03 mirrors A-01 / A-02 blockers):
-#   - agent-infra is private; binaries pre-compiled on the host (linux/arm64)
-#     and copied from ./bin/. Refresh: make -C images prebuild-bones.
+# NOTE: agent-infra is private; the unified bones CLI is pre-compiled on
+# the host (linux/arm64) and copied from ./bin/. Refresh:
+#   make -C images prebuild-bones
+# bones exposes init/tasks/repo as subcommands.
 #   - mgrep omitted (paid; context-mode replaces).
-#   - Only agent-init + agent-tasks ship today; other bones cmds pending.
 #   - Pi auth: OPENROUTER_API_KEY env var (no OAuth file mount).
 #   - Pi uses pi-coding-agent CLI; --non-interactive flag bypasses any
 #     first-run trust dialog observed in existing pi-templates.
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq ripgrep fzf less gh ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Pre-built bones binaries.
+# 2. Pre-built bones unified CLI.
 COPY bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/agent-init /usr/local/bin/agent-tasks
+RUN chmod +x /usr/local/bin/bones
 
 # 3. Universal skill: caveman.
 RUN mkdir -p /home/scion/skills && \


### PR DESCRIPTION
## Summary

agent-infra collapsed its multi-binary setup into a single \`bones\` CLI. The old \`agent-init\` / \`agent-tasks\` binaries no longer exist at \`./cmd/<name>\` in the canonical repo, so \`make -C images prebuild-bones\` was building from missing paths and \`brew install bones\` was the only way to actually have it on PATH.

Now: each darkish-* image carries the unified bones binary, with all old subcommands available via \`bones init\` / \`bones tasks <...>\` / \`bones repo <...>\`.

## What changed

- \`images/Makefile\`: \`prebuild-bones\` cross-compiles \`./cmd/bones\` once per backend (4 builds, was 8). Self-cleans \`bin/\` first so stale binaries don't ship.
- \`images/{claude,codex,pi,gemini}/Dockerfile\`: COPY single \`bones\` binary, chmod it.
- \`images/{claude,codex,pi,gemini}/test-bones.sh\`: smoke-test \`bones\` is on PATH AND \`bones --help\` runs cleanly inside each image.
- \`images/README.md\`: baseline table + refresh-procedure docs updated to describe the unified CLI.
- \`internal/substrate/data/\`: regenerated via \`make sync-embed-data\`; drift guard PASS.

## Substrate hash

\`5faefecdf8a3\` → \`ee346ff63f0a\` (embedded mirror picked up the image-layer changes).

## bones subcommand mapping

| Old binary | New invocation |
|---|---|
| \`agent-init\` | \`bones init\` |
| \`agent-tasks <subcmd>\` | \`bones tasks <subcmd>\` |
| (new) | \`bones repo <subcmd>\` (fossil-style ops) |

## Closes a PR #2 review nit

The PR #2 code-review-comment reported that \`planner-t1/agents.md\` instructs the planner to "use \`bones\` if you need cross-file lookup" but only \`agent-init\` + \`agent-tasks\` were available — the reference was misleading. Now that bones is on PATH inside every darkish-* image AND supports cross-file ops via \`bones repo query\` / \`bones repo extract\` / etc., the planner-t1 reference is accurate. No change needed to that file.

## Test plan

- [x] \`make -C images prebuild-bones\` completes; produces 4 \`bin/bones\` binaries
- [x] \`make -C images all\` rebuilds all 4 darkish-* images
- [x] \`bash images/{claude,codex,pi,gemini}/test-bones.sh\` — all 4 PASS
- [x] \`bash scripts/test-embed-drift.sh\` — PASS (data/ in sync with canonical)
- [x] \`go test ./... -count=1\` — all green
- [ ] **Operator validation post-merge**: spawn a real harness and confirm \`bones init\` / \`bones repo info\` / \`bones tasks aggregate\` work from inside the container

## Notes

- Bones shipped as a separate brew tap formula too (\`Formula/bones.rb\` in danmestas/homebrew-tap), independent of this PR. Inside containers we use the cross-compiled binary; on the operator host you have brew-installed bones.
- The subcommand list in bones may evolve; future agent-infra updates can land in this repo via \`make -C images prebuild-bones && make -C images all && make sync-embed-data\` (single-step refresh).