### PR TITLE
polish: CHANGELOG + CONTRIBUTING (libfossil-level hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Apache-2.0 LICENSE.
+
+### Changed
+
+- Switch images from `agent-init` + `agent-tasks` to the unified `bones` CLI.
+
+## [0.1.2] - 2026-04-27
+
+### Fixed
+
+- GoReleaser formula subdir layout for the Homebrew tap.
+
+## [0.1.1] - 2026-04-27
+
+### Added
+
+- README and `darken --version` flag (phase 4 polish).
+
+## [0.1.0] - 2026-04-27
+
+Initial release of `darken`, a containerized orchestration harness with a
+4-axis problem model and an embedded substrate plus per-machine,
+per-project, and per-invocation override layers.
+
+### Added
+
+- `darken` CLI for creating and managing containerized harnesses.
+- Embedded substrate with override-layer system (machine / project / invocation).
+- Module renamed to `github.com/danmestas/darken`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to darken
+
+Thanks for your interest in `darken`, a containerized orchestration harness
+with a 4-axis problem model and embedded-substrate-with-overrides design.
+This document covers everything you need to get a working checkout, build the
+binary, and submit changes.
+
+## Development setup
+
+Requires Go 1.23 or newer.
+
+```
+git clone https://github.com/danmestas/darken
+cd darken
+make darken
+```
+
+`make darken` builds the `darken` CLI to `bin/darken`. The repository ships
+with embedded substrate templates that are baked into the binary at build
+time via `make sync-skills` and `make sync-embed-data`.
+
+For end-user installation (running darken, not building it), the released
+binary is distributed via a Homebrew tap — see the README for `brew install`
+instructions.
+
+## Running tests
+
+```
+go test ./...                # full suite
+go test -race ./...          # race detector
+```
+
+Tests live under `tests/` for integration coverage and alongside source
+files (`*_test.go`) for unit tests.
+
+## Embedded data
+
+If you change skills, templates, or other embedded substrate content, regenerate
+the embedded blobs:
+
+```
+make sync-skills        # refresh embedded skills
+make sync-embed-data    # refresh other embedded data
+```
+
+CI runs the same sync to guarantee the embedded content matches `templates/`
+and `skills/` in the repo.
+
+## Code layout
+
+- `cmd/` — CLI entry points (`darken`).
+- `internal/` — implementation packages, not exported.
+- `templates/` — substrate templates baked into the binary.
+- `images/` — container image definitions for the orchestrator.
+- `scripts/` — build and sync helper scripts.
+- `tests/` — integration tests.
+- `docs/` — design docs and the 4-axis problem statement.
+
+## Submitting changes
+
+1. Open a feature branch off `main`. Direct commits to `main` are not accepted.
+2. Run `go test ./...` locally before pushing.
+3. If you changed embedded content, run `make sync-skills` / `make sync-embed-data`.
+4. Open a PR; CI will re-run tests and verify the embedded content is in sync.
+
+## Reporting issues
+
+Open an issue at https://github.com/danmestas/darken/issues with reproduction
+steps, the harness backend involved (Claude Code / Codex / Gemini / Copilot),
+and the output of `darken --version`.


### PR DESCRIPTION
## Summary

Matches the `bones` polish template. Adds `CHANGELOG.md` (Keep-a-Changelog) and `CONTRIBUTING.md` (modeled on libfossil's structure).

## What's in here

- **`CHANGELOG.md`** — `[0.1.0]` initial release (`darken` CLI + embedded substrate + override layers), `[0.1.1]` README+version flag, `[0.1.2]` GoReleaser fix. `[Unreleased]` carries the in-flight unified-bones-CLI image switch.
- **`CONTRIBUTING.md`** — Dev setup (`make darken`), embedded-content regen (`make sync-skills`, `make sync-embed-data`), test commands, code layout, PR flow.

## What's NOT in here

- No README badges (deferred across the polish program).
- No CODE_OF_CONDUCT / SECURITY / issue templates.
- No README rewrite.

## Test plan

- [x] CHANGELOG validates as Keep-a-Changelog
- [x] All `make` targets in CONTRIBUTING exist in the Makefile