### PR TITLE
Phase 5: init completeness + spawn resolver + statusLine + DX roadmap

### DIFF
--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -72,7 +72,10 @@ func ensureAllSkillsStaged() error {
 	}
 	dirs, err := os.ReadDir(filepath.Join(root, ".scion", "templates"))
 	if err != nil {
-		// No project-local templates is fine; embedded substrate provides them.
+		// Any ReadDir failure (missing dir, permission denied, etc.) falls
+		// through to embedded. Permission-denied is unexpected here but
+		// safe to treat as "no project templates" — the operator's binary
+		// always carries a complete embedded substrate.
 		return ensureAllSkillsStagedFromEmbedded()
 	}
 	for _, d := range dirs {
@@ -88,6 +91,12 @@ func ensureAllSkillsStaged() error {
 
 // ensureAllSkillsStagedFromEmbedded iterates the embedded .scion/templates/
 // list when the working repo has no project-local templates dir.
+//
+// Returns the fs.ReadDir error directly (vs the project-layer path
+// which swallows per-template stage-skills errors). An embedded read
+// failure indicates a corrupt binary, which is fatal and should
+// surface; per-template failures are operator-config issues that
+// shouldn't abort the whole bootstrap.
 func ensureAllSkillsStagedFromEmbedded() error {
 	entries, err := fs.ReadDir(substrate.EmbeddedFS(), "data/.scion/templates")
 	if err != nil {

--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -3,9 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/danmestas/darken/internal/substrate"
 )
 
 func runBootstrap(args []string) error {
@@ -56,11 +59,7 @@ func ensureImages() error {
 }
 
 func ensureHubSecrets() error {
-	root, err := repoRoot()
-	if err != nil {
-		return err
-	}
-	return runShell(filepath.Join(root, "scripts", "stage-creds.sh"), "all")
+	return runSubstrateScript("scripts/stage-creds.sh", []string{"all"})
 }
 
 // ensureAllSkillsStaged runs stage-skills.sh per harness directory.
@@ -73,14 +72,33 @@ func ensureAllSkillsStaged() error {
 	}
 	dirs, err := os.ReadDir(filepath.Join(root, ".scion", "templates"))
 	if err != nil {
-		return err
+		// No project-local templates is fine; embedded substrate provides them.
+		return ensureAllSkillsStagedFromEmbedded()
 	}
 	for _, d := range dirs {
 		if !d.IsDir() || d.Name() == "base" {
 			continue
 		}
-		if err := runShell(filepath.Join(root, "scripts", "stage-skills.sh"), d.Name()); err != nil {
+		if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
 			fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
+		}
+	}
+	return nil
+}
+
+// ensureAllSkillsStagedFromEmbedded iterates the embedded .scion/templates/
+// list when the working repo has no project-local templates dir.
+func ensureAllSkillsStagedFromEmbedded() error {
+	entries, err := fs.ReadDir(substrate.EmbeddedFS(), "data/.scion/templates")
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == "base" {
+			continue
+		}
+		if err := runSubstrateScript("scripts/stage-skills.sh", []string{e.Name()}); err != nil {
+			fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", e.Name(), err)
 		}
 	}
 	return nil

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -10,10 +10,16 @@ import (
 func TestBootstrapStepsAreOrdered(t *testing.T) {
 	dir := t.TempDir()
 	log := filepath.Join(dir, "log")
-	for _, b := range []string{"scion", "docker", "make", "bash"} {
+	for _, b := range []string{"scion", "docker", "make"} {
 		os.WriteFile(filepath.Join(dir, b),
 			[]byte("#!/bin/sh\necho \"$0 $@\" >> "+log+"\n"), 0o755)
 	}
+	// bash stub: log args + dump the script body. Bootstrap now extracts
+	// embedded substrate scripts to a temp file, so the file name is
+	// random — but the body's own header comment names the script
+	// (e.g. "# stage-creds.sh — ..."), which we can grep for.
+	os.WriteFile(filepath.Join(dir, "bash"),
+		[]byte("#!/bin/sh\necho \"$0 $@\" >> "+log+"\ncat \"$1\" >> "+log+"\n"), 0o755)
 	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
 	_ = runBootstrap([]string{})
 

--- a/cmd/darken/init.go
+++ b/cmd/darken/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -51,22 +52,51 @@ func runInit(args []string) error {
 
 	if exists && !*force {
 		fmt.Printf("skipped %s (already exists; use --force to overwrite)\n", claudePath)
-		return nil
+	} else {
+		body, err := renderCLAUDE(target)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
+			return err
+		}
+		fmt.Printf("wrote %s\n", claudePath)
 	}
 
-	body, err := renderCLAUDE(target)
-	if err != nil {
-		return err
+	// Scaffold skills (project-local copies of the embedded host-mode skills)
+	for _, skill := range []string{"orchestrator-mode", "subagent-to-subharness"} {
+		if err := scaffoldSkill(target, skill); err != nil {
+			fmt.Fprintf(os.Stderr, "init: skill scaffold %s failed: %v\n", skill, err)
+		} else {
+			fmt.Printf("scaffolded .claude/skills/%s/SKILL.md\n", skill)
+		}
 	}
-	if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
-		return err
+
+	// Scaffold statusLine + gitignore
+	if err := scaffoldStatusLine(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: statusLine scaffold failed: %v\n", err)
+	} else {
+		fmt.Println("scaffolded .claude/settings.local.json")
 	}
-	fmt.Printf("wrote %s\n", claudePath)
+	if err := scaffoldGitignore(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: .gitignore append failed: %v\n", err)
+	} else {
+		fmt.Println("appended darken entries to .gitignore")
+	}
+
+	// bones init (soft-fail if bones not on PATH)
+	if err := runBonesInit(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: bones init failed: %v\n", err)
+	} else if _, err := exec.LookPath("bones"); err == nil {
+		fmt.Println("ran `bones init` for workspace bootstrap")
+	}
+
 	return nil
 }
 
 // renderCLAUDE renders the embedded CLAUDE.md template with the
-// target dir's basename as RepoName.
+// target dir's basename as RepoName and the first 12 chars of the
+// embedded substrate hash as SubstrateHash12.
 func renderCLAUDE(targetDir string) (string, error) {
 	body, err := readEmbeddedTemplate("data/templates/CLAUDE.md.tmpl")
 	if err != nil {
@@ -76,8 +106,12 @@ func renderCLAUDE(targetDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data := struct{ RepoName string }{
-		RepoName: filepath.Base(targetDir),
+	data := struct {
+		RepoName        string
+		SubstrateHash12 string
+	}{
+		RepoName:        filepath.Base(targetDir),
+		SubstrateHash12: firstN(substrate.EmbeddedHash(), 12),
 	}
 	var sb strings.Builder
 	if err := tmpl.Execute(&sb, data); err != nil {
@@ -92,4 +126,102 @@ func readEmbeddedTemplate(path string) ([]byte, error) {
 		return nil, fmt.Errorf("embedded template not found: %s: %w", path, err)
 	}
 	return body, nil
+}
+
+// firstN returns the first n characters of s, or all of s if shorter.
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// scaffoldSkill copies a skill from the embedded substrate into
+// .claude/skills/<name>/SKILL.md so Claude Code's project-local skill
+// discovery picks it up.
+func scaffoldSkill(targetDir, name string) error {
+	body, err := fs.ReadFile(substrate.EmbeddedFS(), "data/skills/"+name+"/SKILL.md")
+	if err != nil {
+		return err
+	}
+	dst := filepath.Join(targetDir, ".claude", "skills", name, "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, body, 0o644)
+}
+
+// scaffoldStatusLine writes .claude/settings.local.json with a
+// statusLine.command pointing at `darken status`. If the file already
+// exists, leaves it alone (don't clobber other settings).
+func scaffoldStatusLine(targetDir string) error {
+	path := filepath.Join(targetDir, ".claude", "settings.local.json")
+	if _, err := os.Stat(path); err == nil {
+		return nil // existing settings; don't clobber
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	body := `{
+  "statusLine": {
+    "command": "darken status",
+    "type": "command"
+  }
+}
+`
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+// scaffoldGitignore appends darken-related entries to <target>/.gitignore.
+// Idempotent — only appends entries not already present.
+func scaffoldGitignore(targetDir string) error {
+	path := filepath.Join(targetDir, ".gitignore")
+	var existing []byte
+	if b, err := os.ReadFile(path); err == nil {
+		existing = b
+	}
+	entries := []string{
+		"# darken: scion runtime + per-spawn worktrees + claude-code worktrees",
+		".scion/agents/",
+		".scion/skills-staging/",
+		".scion/audit.jsonl",
+		".claude/worktrees/",
+		".claude/settings.local.json",
+		".superpowers/",
+	}
+	var add []string
+	for _, e := range entries {
+		if !strings.Contains(string(existing), e) {
+			add = append(add, e)
+		}
+	}
+	if len(add) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		f.WriteString("\n")
+	}
+	for _, e := range add {
+		f.WriteString(e + "\n")
+	}
+	return nil
+}
+
+// runBonesInit shells out to `bones init` in the target dir if bones is
+// on PATH. Soft-fail: bones being missing is not fatal — operator
+// without bones still gets a usable orchestrator session.
+func runBonesInit(targetDir string) error {
+	if _, err := exec.LookPath("bones"); err != nil {
+		return nil // soft-fail; bones not on PATH
+	}
+	c := exec.Command("bones", "init")
+	c.Dir = targetDir
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
 }

--- a/cmd/darken/init_test.go
+++ b/cmd/darken/init_test.go
@@ -82,3 +82,84 @@ func TestInitDryRun(t *testing.T) {
 		t.Fatal("--dry-run should not create files")
 	}
 }
+
+// stubBones plants a no-op bones script at the front of PATH so
+// runBonesInit finds an executable and treats it as installed but
+// the script does nothing destructive in the test's tmp dir.
+func stubBones(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	body := "#!/usr/bin/env bash\nexit 0\n"
+	path := filepath.Join(dir, "bones")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestInitScaffoldsSkills(t *testing.T) {
+	stubBones(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	for _, skill := range []string{"orchestrator-mode", "subagent-to-subharness"} {
+		path := filepath.Join(tmp, ".claude", "skills", skill, "SKILL.md")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("skill %s not scaffolded: %v", skill, err)
+		}
+	}
+}
+
+func TestInitWritesStatusLineSettings(t *testing.T) {
+	stubBones(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatalf("settings.local.json not created: %v", err)
+	}
+	if !strings.Contains(string(body), `"command": "darken status"`) {
+		t.Fatalf("settings missing statusLine.command: %s", body)
+	}
+}
+
+func TestInitAppendsGitignore(t *testing.T) {
+	stubBones(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	// Plant a pre-existing .gitignore to confirm append (not overwrite).
+	os.WriteFile(filepath.Join(tmp, ".gitignore"), []byte("# pre-existing\n*.log\n"), 0o644)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if !strings.Contains(string(body), "# pre-existing") {
+		t.Fatalf("init clobbered existing .gitignore: %s", body)
+	}
+	if !strings.Contains(string(body), ".scion/agents/") {
+		t.Fatalf("init didn't append darken entries: %s", body)
+	}
+}
+
+func TestInitSecondRunIsIdempotent(t *testing.T) {
+	stubBones(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if string(body1) != string(body2) {
+		t.Fatalf("second init mutated .gitignore (not idempotent):\nwas: %q\nnow: %q", body1, body2)
+	}
+}

--- a/cmd/darken/main.go
+++ b/cmd/darken/main.go
@@ -33,6 +33,7 @@ var subcommands = []subcommand{
 	{"orchestrate", "print host-mode orchestrator skill body", runOrchestrate},
 	{"init", "scaffold CLAUDE.md in a target dir", runInit},
 	{"version", "print binary version + embedded substrate hash", runVersion},
+	{"status", "print one-line status (statusLine-friendly)", runStatus},
 }
 
 func main() {

--- a/cmd/darken/script_runner.go
+++ b/cmd/darken/script_runner.go
@@ -6,37 +6,56 @@ import (
 	"os/exec"
 )
 
-// runSubstrateScript reads a substrate-relative script via the resolver,
-// extracts it to a temp file with exec permissions, runs it with the
-// given args, and cleans up the temp file. Stdout and stderr are
-// inherited so the user sees script progress in-place.
+// extractSubstrateScript reads a substrate-relative script via the
+// resolver and writes it to a temp file with exec permissions.
+// Returns the temp file path and a cleanup func that removes it.
+// Caller is responsible for invoking cleanup (typically via defer).
 //
 // Path is substrate-relative (e.g. "scripts/stage-creds.sh"), not an
 // OS path. The resolver layers flag → env → user → project → embedded.
-func runSubstrateScript(substratePath string, args []string) error {
+func extractSubstrateScript(substratePath string) (path string, cleanup func(), err error) {
 	body, err := substrateResolver().ReadFile(substratePath)
 	if err != nil {
-		return fmt.Errorf("substrate script %s: %w", substratePath, err)
+		return "", nil, fmt.Errorf("substrate script %s: %w", substratePath, err)
 	}
 
 	tmp, err := os.CreateTemp("", "darken-script-*.sh")
 	if err != nil {
-		return err
+		return "", nil, err
 	}
-	defer os.Remove(tmp.Name())
+	cleanup = func() { os.Remove(tmp.Name()) }
 
-	if _, err := tmp.Write(body); err != nil {
+	if _, werr := tmp.Write(body); werr != nil {
 		tmp.Close()
-		return err
+		cleanup()
+		return "", nil, werr
 	}
-	if err := tmp.Close(); err != nil {
-		return err
+	if cerr := tmp.Close(); cerr != nil {
+		cleanup()
+		return "", nil, cerr
 	}
-	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
-		return err
+	if cerr := os.Chmod(tmp.Name(), 0o755); cerr != nil {
+		cleanup()
+		return "", nil, cerr
 	}
+	return tmp.Name(), cleanup, nil
+}
 
-	c := exec.Command("bash", append([]string{tmp.Name()}, args...)...)
+// runSubstrateScript extracts a substrate-relative script and runs it
+// with the given args. Stdout and stderr are inherited so the user
+// sees script progress in-place.
+//
+// Uses the bash on PATH (not /bin/bash) so test stubs that prepend a
+// fake bash to PATH work. Future hardening to /bin/bash would require
+// updating spawn_test.go's bash stub strategy.
+func runSubstrateScript(substratePath string, args []string) error {
+	tmpPath, cleanup, err := extractSubstrateScript(substratePath)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	c := exec.Command("bash", append([]string{tmpPath}, args...)...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	return c.Run()
@@ -46,27 +65,12 @@ func runSubstrateScript(substratePath string, args []string) error {
 // combined stdout+stderr as a string. Production callers use
 // runSubstrateScript above, which inherits stdout/stderr.
 func runSubstrateScriptCaptured(substratePath string, args []string) (string, error) {
-	body, err := substrateResolver().ReadFile(substratePath)
-	if err != nil {
-		return "", fmt.Errorf("substrate script %s: %w", substratePath, err)
-	}
-
-	tmp, err := os.CreateTemp("", "darken-script-*.sh")
+	tmpPath, cleanup, err := extractSubstrateScript(substratePath)
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.Write(body); err != nil {
-		tmp.Close()
-		return "", err
-	}
-	if err := tmp.Close(); err != nil {
-		return "", err
-	}
-	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
-		return "", err
-	}
+	defer cleanup()
 
-	out, err := exec.Command("bash", append([]string{tmp.Name()}, args...)...).CombinedOutput()
+	out, err := exec.Command("bash", append([]string{tmpPath}, args...)...).CombinedOutput()
 	return string(out), err
 }

--- a/cmd/darken/script_runner.go
+++ b/cmd/darken/script_runner.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// runSubstrateScript reads a substrate-relative script via the resolver,
+// extracts it to a temp file with exec permissions, runs it with the
+// given args, and cleans up the temp file. Stdout and stderr are
+// inherited so the user sees script progress in-place.
+//
+// Path is substrate-relative (e.g. "scripts/stage-creds.sh"), not an
+// OS path. The resolver layers flag → env → user → project → embedded.
+func runSubstrateScript(substratePath string, args []string) error {
+	body, err := substrateResolver().ReadFile(substratePath)
+	if err != nil {
+		return fmt.Errorf("substrate script %s: %w", substratePath, err)
+	}
+
+	tmp, err := os.CreateTemp("", "darken-script-*.sh")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
+		return err
+	}
+
+	c := exec.Command("bash", append([]string{tmp.Name()}, args...)...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// runSubstrateScriptCaptured is the test-only variant that returns
+// combined stdout+stderr as a string. Production callers use
+// runSubstrateScript above, which inherits stdout/stderr.
+func runSubstrateScriptCaptured(substratePath string, args []string) (string, error) {
+	body, err := substrateResolver().ReadFile(substratePath)
+	if err != nil {
+		return "", fmt.Errorf("substrate script %s: %w", substratePath, err)
+	}
+
+	tmp, err := os.CreateTemp("", "darken-script-*.sh")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
+		return "", err
+	}
+
+	out, err := exec.Command("bash", append([]string{tmp.Name()}, args...)...).CombinedOutput()
+	return string(out), err
+}

--- a/cmd/darken/script_runner_test.go
+++ b/cmd/darken/script_runner_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSubstrateScript_ExtractsAndExecs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Provide an env-layer override so the resolver finds the script.
+	// (Project layer only resolves .scion/templates/* paths; env layer
+	// accepts any path, which matches how a user override directory works.)
+	overrides := filepath.Join(tmp, "overrides")
+	dir := filepath.Join(overrides, "scripts")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptBody := "#!/bin/sh\necho hello-from-stub\n"
+	scriptPath := filepath.Join(dir, "demo-script.sh")
+	if err := os.WriteFile(scriptPath, []byte(scriptBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DARKEN_SUBSTRATE_OVERRIDES", overrides)
+
+	// runSubstrateScript should find the script via the resolver, write it
+	// to a temp file with exec permissions, and run it. The body should
+	// flow back to the caller via stdout.
+	out, err := runSubstrateScriptCaptured("scripts/demo-script.sh", []string{})
+	if err != nil {
+		t.Fatalf("runSubstrateScript failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "hello-from-stub") {
+		t.Fatalf("expected stub output, got %q", out)
+	}
+}
+
+func TestRunSubstrateScript_FailsCleanly_OnMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	err := runSubstrateScript("scripts/no-such-script-anywhere.sh", []string{})
+	if err == nil {
+		t.Fatal("expected error for non-existent script")
+	}
+}

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 )
 
 func runSpawn(args []string) error {
@@ -28,16 +27,11 @@ func runSpawn(args []string) error {
 	}
 	posArgs := fs.Args()
 
-	root, err := repoRoot()
-	if err != nil {
-		return err
-	}
-
 	if !*noStage {
-		if err := runShell(filepath.Join(root, "scripts", "stage-creds.sh"), "all"); err != nil {
+		if err := runSubstrateScript("scripts/stage-creds.sh", []string{"all"}); err != nil {
 			fmt.Fprintln(os.Stderr, "spawn: stage-creds non-fatal:", err)
 		}
-		if err := runShell(filepath.Join(root, "scripts", "stage-skills.sh"), *harnessType); err != nil {
+		if err := runSubstrateScript("scripts/stage-skills.sh", []string{*harnessType}); err != nil {
 			return fmt.Errorf("stage-skills failed: %w", err)
 		}
 	}

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -53,6 +53,10 @@ func runSpawn(args []string) error {
 
 // runShell invokes a shell script via bash. Stdout/stderr are inherited
 // so the user sees script progress in-place.
+//
+// TODO: remove once all callers (bootstrap.go, creds.go, skills.go,
+// apply.go) migrate to runSubstrateScript via subsequent Phase 5
+// tasks. Spawn.go is the first migration; bootstrap.go is Task 2.
 func runShell(script string, args ...string) error {
 	c := exec.Command("bash", append([]string{script}, args...)...)
 	c.Stdout = os.Stdout

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -10,12 +10,21 @@ import (
 func TestSpawnInvokesStageThenScion(t *testing.T) {
 	dir := t.TempDir()
 	log := filepath.Join(dir, "calls.log")
-	for _, b := range []string{"scion", "bash"} {
-		stub := filepath.Join(dir, b)
-		if err := os.WriteFile(stub, []byte(
-			"#!/bin/sh\necho \"$0 $@\" >> "+log+"\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+
+	// scion stub: log invocation args (used to assert `start smoke-1`).
+	scionStub := filepath.Join(dir, "scion")
+	if err := os.WriteFile(scionStub, []byte(
+		"#!/bin/sh\necho \"$0 $@\" >> "+log+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// bash stub: log args + dump the script body. spawn now extracts
+	// embedded substrate scripts to a temp file, so the file name is
+	// random — but the body's own header comment names the script
+	// (e.g. "# stage-creds.sh — ..."), which we can grep for.
+	bashStub := filepath.Join(dir, "bash")
+	if err := os.WriteFile(bashStub, []byte(
+		"#!/bin/sh\necho \"$0 $@\" >> "+log+"\ncat \"$1\" >> "+log+"\n"), 0o755); err != nil {
+		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
 

--- a/cmd/darken/status.go
+++ b/cmd/darken/status.go
@@ -1,0 +1,23 @@
+// Package main — `darken status` produces a single-line summary suitable
+// for Claude Code's statusLine.command. Must be fast — called every
+// prompt. Avoid external commands (no scion list, no docker calls).
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/danmestas/darken/internal/substrate"
+)
+
+func runStatus(args []string) error {
+	if len(args) > 0 {
+		return errors.New("usage: darken status")
+	}
+	hash := substrate.EmbeddedHash()
+	if len(hash) > 12 {
+		hash = hash[:12]
+	}
+	fmt.Printf("[darken: orchestrator-mode | substrate %s]\n", hash)
+	return nil
+}

--- a/cmd/darken/status_test.go
+++ b/cmd/darken/status_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusOutputFormat(t *testing.T) {
+	out, err := captureStdout(func() error { return runStatus(nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Format: [darken: orchestrator-mode | substrate <12-hex>]
+	if !strings.HasPrefix(out, "[darken:") {
+		t.Fatalf("status output missing [darken: prefix: %q", out)
+	}
+	if !strings.Contains(out, "substrate ") {
+		t.Fatalf("status output missing substrate hash: %q", out)
+	}
+	if !strings.Contains(out, "orchestrator-mode") {
+		t.Fatalf("status output missing mode label: %q", out)
+	}
+}
+
+func TestStatusRejectsArgs(t *testing.T) {
+	if err := runStatus([]string{"foo"}); err == nil {
+		t.Fatal("expected error when args provided")
+	}
+}

--- a/docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md
+++ b/docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md
@@ -1,0 +1,836 @@
+# Darken Phase 5 — Init Completeness + Spawn Resolver + Operator Feedback
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `darken init <repo>` actually finish setting up a working repo for orchestrator-mode end-to-end. Today the command writes a CLAUDE.md that *references* skills the working repo doesn't have, asks `darken spawn` to run scripts the working repo doesn't carry, and gives the operator no visible signal that the session is in orchestrator mode. After Phase 5: `darken init <fresh-repo> && cd <fresh-repo> && claude code` opens a session that auto-loads the orchestrator skill, has bones workspace bootstrapped, shows a clear status line, and can `darken spawn` workers without erroring on missing files.
+
+**Architecture:** Extend the substrate resolver pattern from Phases 1+2 to script execution (`spawn.go`, `bootstrap.go`). Extend `darken init` to extract embedded skills + write a Claude Code statusLine config + run `bones init` when available + append .gitignore entries. Add a `darken status` subcommand that backs the statusLine. Fix one stale Makefile path (agent-infra → bones rename).
+
+**Tech Stack:** Go 1.23+, stdlib only. Reuses `internal/substrate.Resolver` + `embed.FS` from Phase 2. No new dependencies.
+
+---
+
+## File structure
+
+### Created
+- `cmd/darken/status.go` — `runStatus` for the statusLine command
+- `cmd/darken/status_test.go` — covers output format
+
+### Modified
+- `cmd/darken/spawn.go` — `runShell` calls swap to substrate-resolver-backed script extraction
+- `cmd/darken/bootstrap.go` — same swap for the script execution paths
+- `cmd/darken/init.go` — scaffolds skills, runs bones init, writes statusLine config, appends gitignore
+- `cmd/darken/init_test.go` — covers the new scaffolds
+- `cmd/darken/main.go` — registers `status` subcommand
+- `internal/substrate/data/templates/CLAUDE.md.tmpl` — directive language so Claude announces orchestrator mode on first response
+- `images/Makefile` — `AGENT_INFRA_PATH` default points at `$(HOME)/projects/bones`; rename references
+- `internal/substrate/data/` — regenerated via `make sync-embed-data`
+
+### NOT modified
+- The harness templates under `.scion/templates/<role>/` — Phase 5 is operator-side init/spawn polish, not a worker behavior change.
+
+---
+
+## Tasks
+
+### Task 1: Substrate-resolver-backed script execution in `spawn.go`
+
+**Why:** `runShell(filepath.Join(root, "scripts", "stage-creds.sh"), ...)` assumes the working repo carries substrate scripts. New repos don't. Extract from embedded substrate at runtime.
+
+**Files:**
+- Modify: `cmd/darken/spawn.go`
+- Create: `cmd/darken/script_runner.go` — shared helper for "extract embedded script to temp, exec, clean up"
+- Create: `cmd/darken/script_runner_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/darken/script_runner_test.go`:
+
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSubstrateScript_ExtractsAndExecs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Provide a project-layer override so the resolver finds the script.
+	dir := filepath.Join(tmp, "scripts")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptBody := "#!/bin/sh\necho hello-from-stub\n"
+	scriptPath := filepath.Join(dir, "demo-script.sh")
+	if err := os.WriteFile(scriptPath, []byte(scriptBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// runSubstrateScript should find the script via the resolver, write it
+	// to a temp file with exec permissions, and run it. The body should
+	// flow back to the caller via stdout.
+	out, err := runSubstrateScriptCaptured("scripts/demo-script.sh", []string{})
+	if err != nil {
+		t.Fatalf("runSubstrateScript failed: %v", err)
+	}
+	if !strings.Contains(out, "hello-from-stub") {
+		t.Fatalf("expected stub output, got %q", out)
+	}
+}
+
+func TestRunSubstrateScript_FailsCleanly_OnMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	err := runSubstrateScript("scripts/no-such-script-anywhere.sh", []string{})
+	if err == nil {
+		t.Fatal("expected error for non-existent script")
+	}
+}
+```
+
+(Note: `runSubstrateScriptCaptured` is a test-only helper; production `runSubstrateScript` writes to stdout/stderr directly. Test helper captures via tempfile redirection. Optional — can also do `runSubstrateScript` test by checking exit status of a known-true script body and a known-false body.)
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```
+cd cmd/darken && go test -run TestRunSubstrateScript -count=1
+```
+
+Expected: undefined symbols.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/darken/script_runner.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// runSubstrateScript reads a substrate-relative script via the resolver,
+// extracts it to a temp file with exec permissions, runs it with the
+// given args, and cleans up the temp file. Stdout and stderr are
+// inherited so the user sees script progress in-place.
+//
+// Path is substrate-relative (e.g. "scripts/stage-creds.sh"), not an
+// OS path. The resolver layers project-local → user override → embedded.
+func runSubstrateScript(substratePath string, args []string) error {
+	body, err := substrateResolver().ReadFile(substratePath)
+	if err != nil {
+		return fmt.Errorf("substrate script %s: %w", substratePath, err)
+	}
+
+	tmp, err := os.CreateTemp("", "darken-script-*.sh")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
+		return err
+	}
+
+	c := exec.Command("bash", append([]string{tmp.Name()}, args...)...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// runSubstrateScriptCaptured is the test-only variant that returns stdout
+// as a string. Production callers use runSubstrateScript above.
+func runSubstrateScriptCaptured(substratePath string, args []string) (string, error) {
+	body, err := substrateResolver().ReadFile(substratePath)
+	if err != nil {
+		return "", fmt.Errorf("substrate script %s: %w", substratePath, err)
+	}
+
+	tmp, err := os.CreateTemp("", "darken-script-*.sh")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
+		return "", err
+	}
+
+	out, err := exec.Command("bash", append([]string{tmp.Name()}, args...)...).CombinedOutput()
+	return string(out), err
+}
+
+// _ silences "unused" if the build uses only one form.
+var _ = filepath.Join
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+```
+go test -run TestRunSubstrateScript -count=1 ./cmd/darken
+```
+
+- [ ] **Step 5: Wire into spawn.go**
+
+Replace the two `runShell(filepath.Join(root, "scripts", ...))` calls with `runSubstrateScript("scripts/...", ...)`:
+
+```go
+// before:
+if err := runShell(filepath.Join(root, "scripts", "stage-creds.sh"), "all"); err != nil {
+    fmt.Fprintln(os.Stderr, "spawn: stage-creds non-fatal:", err)
+}
+if err := runShell(filepath.Join(root, "scripts", "stage-skills.sh"), *harnessType); err != nil {
+    return fmt.Errorf("stage-skills failed: %w", err)
+}
+
+// after:
+if err := runSubstrateScript("scripts/stage-creds.sh", []string{"all"}); err != nil {
+    fmt.Fprintln(os.Stderr, "spawn: stage-creds non-fatal:", err)
+}
+if err := runSubstrateScript("scripts/stage-skills.sh", []string{*harnessType}); err != nil {
+    return fmt.Errorf("stage-skills failed: %w", err)
+}
+```
+
+The `root` variable is no longer needed for these two calls; trim if it's not used elsewhere in `runSpawn`.
+
+- [ ] **Step 6: Run all tests + spawn smoke**
+
+```
+go test ./... -count=1
+go vet ./... && gofmt -l cmd/ internal/
+```
+
+- [ ] **Step 7: Commit**
+
+```
+fix(spawn): use substrate resolver to extract scripts at runtime
+
+darken spawn called <cwd>/scripts/stage-creds.sh and stage-skills.sh
+directly. New repos created via `darken init` don't have a scripts/
+dir — those live only in darkish-factory. The Phase 1+2 substrate
+resolver was supposed to handle this; spawn.go was never wired through.
+
+New helper runSubstrateScript reads the script body via the resolver
+(layered: flag → env → user → project → embedded), writes it to a
+temp file with exec perms, runs it, cleans up. Same script body that
+shipped with this binary; no host-side dependency on darkish-factory.
+
+Tests cover the success path (script extracted + executed) and miss
+path (resolver fails through; clean error).
+```
+
+---
+
+### Task 2: Same fix for `bootstrap.go`
+
+**Why:** `bootstrap.go`'s `ensureHubSecrets` and `ensureAllSkillsStaged` also call `runShell(filepath.Join(root, "scripts", ...))`. Same root-cause as Task 1.
+
+**Files:**
+- Modify: `cmd/darken/bootstrap.go`
+
+- [ ] **Step 1: Audit the runShell calls in bootstrap.go**
+
+```
+grep -nE 'runShell|filepath\.Join.*scripts' cmd/darken/bootstrap.go
+```
+
+Expected: 2 sites — `ensureHubSecrets` and `ensureAllSkillsStaged`.
+
+- [ ] **Step 2: Replace with runSubstrateScript**
+
+`ensureHubSecrets`:
+
+```go
+func ensureHubSecrets() error {
+    return runSubstrateScript("scripts/stage-creds.sh", []string{"all"})
+}
+```
+
+`ensureAllSkillsStaged`:
+
+```go
+func ensureAllSkillsStaged() error {
+    root, err := repoRoot()
+    if err != nil {
+        return err
+    }
+    dirs, err := os.ReadDir(filepath.Join(root, ".scion", "templates"))
+    if err != nil {
+        // No project-local templates is fine; embedded substrate provides them.
+        // Iterate the embedded template list instead.
+        return ensureAllSkillsStagedFromEmbedded()
+    }
+    for _, d := range dirs {
+        if !d.IsDir() || d.Name() == "base" {
+            continue
+        }
+        if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
+            fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
+        }
+    }
+    return nil
+}
+
+// ensureAllSkillsStagedFromEmbedded iterates the embedded .scion/templates/
+// list when the working repo has no project-local templates dir.
+func ensureAllSkillsStagedFromEmbedded() error {
+    entries, err := fs.ReadDir(substrate.EmbeddedFS(), "data/.scion/templates")
+    if err != nil {
+        return err
+    }
+    for _, e := range entries {
+        if !e.IsDir() || e.Name() == "base" {
+            continue
+        }
+        if err := runSubstrateScript("scripts/stage-skills.sh", []string{e.Name()}); err != nil {
+            fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", e.Name(), err)
+        }
+    }
+    return nil
+}
+```
+
+(Add `io/fs` and substrate imports if not already present.)
+
+- [ ] **Step 3: Tests pass**
+
+```
+go test ./... -count=1
+```
+
+The existing `TestBootstrapStepsAreOrdered` should still pass — its stubs catch the bash invocation regardless of whether the script comes from CWD or temp.
+
+- [ ] **Step 4: Commit**
+
+```
+fix(bootstrap): use substrate resolver for stage-* scripts
+
+ensureHubSecrets + ensureAllSkillsStaged now extract scripts from the
+embedded substrate (same pattern as Task 1's spawn.go fix). When the
+working repo has no project-local .scion/templates/, iterate the
+embedded template list instead of erroring.
+```
+
+---
+
+### Task 3: New `darken status` subcommand
+
+**Why:** Backs the statusLine config that Task 5 will scaffold into init'd repos. Outputs a one-line status: orchestrator mode + substrate hash + active worker count. Must be fast (called every prompt by Claude Code).
+
+**Files:**
+- Create: `cmd/darken/status.go`
+- Create: `cmd/darken/status_test.go`
+- Modify: `cmd/darken/main.go` (register subcommand)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusOutputFormat(t *testing.T) {
+	out, err := captureStdout(func() error { return runStatus(nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Format: [darken: orchestrator-mode | substrate <12-hex>]
+	if !strings.HasPrefix(out, "[darken:") {
+		t.Fatalf("status output missing [darken: prefix: %q", out)
+	}
+	if !strings.Contains(out, "substrate ") {
+		t.Fatalf("status output missing substrate hash: %q", out)
+	}
+	if !strings.Contains(out, "orchestrator-mode") {
+		t.Fatalf("status output missing mode label: %q", out)
+	}
+}
+
+func TestStatusRejectsArgs(t *testing.T) {
+	if err := runStatus([]string{"foo"}); err == nil {
+		t.Fatal("expected error when args provided")
+	}
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```go
+// Package main — `darken status` produces a single-line summary suitable
+// for Claude Code's statusLine.command. Must be fast — called every
+// prompt. Avoid external commands (no scion list, no docker calls).
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/danmestas/darken/internal/substrate"
+)
+
+func runStatus(args []string) error {
+	if len(args) > 0 {
+		return errors.New("usage: darken status")
+	}
+	hash := substrate.EmbeddedHash()
+	if len(hash) > 12 {
+		hash = hash[:12]
+	}
+	fmt.Printf("[darken: orchestrator-mode | substrate %s]\n", hash)
+	return nil
+}
+```
+
+(Future: append active worker count via `scion list --format json` parse, but only if it stays sub-100ms. Phase 5 ships static.)
+
+- [ ] **Step 3: Register in main.go**
+
+Add to subcommands:
+```go
+{"status", "print one-line status (statusLine-friendly)", runStatus},
+```
+
+- [ ] **Step 4: Tests + build**
+
+```
+go test ./cmd/darken/... -count=1
+make darken
+bin/darken status   # prints "[darken: orchestrator-mode | substrate ...]"
+```
+
+- [ ] **Step 5: Commit**
+
+```
+feat(cli): add darken status subcommand
+
+Backs the statusLine.command config that `darken init` will scaffold
+in subsequent task. Single-line output, fast — must run every prompt.
+No external command calls; reads only the embedded substrate hash.
+```
+
+---
+
+### Task 4: `darken init` scaffolds skills + bones init + statusLine + gitignore
+
+**Why:** The big init upgrade. After this, `darken init <repo>` produces a fully wired working repo.
+
+**Files:**
+- Modify: `cmd/darken/init.go`
+- Modify: `cmd/darken/init_test.go`
+- Modify: `internal/substrate/data/templates/CLAUDE.md.tmpl` (more directive)
+
+- [ ] **Step 1: Update CLAUDE.md template — be directive about announcing**
+
+In `internal/substrate/data/templates/CLAUDE.md.tmpl`, add a new section near the top:
+
+```
+## On every session start
+
+Your VERY FIRST output to the operator must be the line:
+
+> 🔧 **darken orchestrator-mode primed.** substrate `{{.SubstrateHash12}}` · workers ready · awaiting intent.
+
+Then load and apply the `orchestrator-mode` skill before responding to
+the operator's actual task. The skill body lives at
+`.claude/skills/orchestrator-mode/SKILL.md` (scaffolded by `darken init`).
+
+This announcement is the operator's only signal that the session is
+in orchestrator mode. Don't skip it.
+```
+
+(The `{{.SubstrateHash12}}` field gets passed in by `renderCLAUDE`. Update the template-rendering code to inject it.)
+
+- [ ] **Step 2: Update renderCLAUDE in init.go**
+
+```go
+data := struct {
+    RepoName        string
+    SubstrateHash12 string
+}{
+    RepoName:        filepath.Base(targetDir),
+    SubstrateHash12: firstN(substrate.EmbeddedHash(), 12),
+}
+```
+
+(Add a `firstN(s string, n int) string` helper somewhere.)
+
+- [ ] **Step 3: Add scaffolding helpers**
+
+In `init.go`, add four new helpers called after writing CLAUDE.md:
+
+```go
+// scaffoldSkill copies a skill from the embedded substrate into
+// .claude/skills/<name>/SKILL.md so Claude Code's project-local skill
+// discovery picks it up.
+func scaffoldSkill(targetDir, name string) error {
+    body, err := fs.ReadFile(substrate.EmbeddedFS(), "data/skills/"+name+"/SKILL.md")
+    if err != nil {
+        return err
+    }
+    dst := filepath.Join(targetDir, ".claude", "skills", name, "SKILL.md")
+    if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+        return err
+    }
+    return os.WriteFile(dst, body, 0o644)
+}
+
+// scaffoldStatusLine writes .claude/settings.local.json with a
+// statusLine.command pointing at `darken status`. If the file already
+// exists, leaves it alone (don't clobber other settings).
+func scaffoldStatusLine(targetDir string) error {
+    path := filepath.Join(targetDir, ".claude", "settings.local.json")
+    if _, err := os.Stat(path); err == nil {
+        return nil // existing settings; don't clobber
+    }
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+        return err
+    }
+    body := `{
+  "statusLine": {
+    "command": "darken status",
+    "type": "command"
+  }
+}
+`
+    return os.WriteFile(path, []byte(body), 0o644)
+}
+
+// scaffoldGitignore appends darken-related entries to <target>/.gitignore.
+// Idempotent — only appends entries not already present.
+func scaffoldGitignore(targetDir string) error {
+    path := filepath.Join(targetDir, ".gitignore")
+    var existing []byte
+    if b, err := os.ReadFile(path); err == nil {
+        existing = b
+    }
+    entries := []string{
+        "# darken: scion runtime + per-spawn worktrees + claude-code worktrees",
+        ".scion/agents/",
+        ".scion/skills-staging/",
+        ".scion/audit.jsonl",
+        ".claude/worktrees/",
+        ".claude/settings.local.json",
+        ".superpowers/",
+    }
+    var add []string
+    for _, e := range entries {
+        if !strings.Contains(string(existing), e) {
+            add = append(add, e)
+        }
+    }
+    if len(add) == 0 {
+        return nil
+    }
+    f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+    if err != nil {
+        return err
+    }
+    defer f.Close()
+    if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+        f.WriteString("\n")
+    }
+    for _, e := range add {
+        f.WriteString(e + "\n")
+    }
+    return nil
+}
+
+// runBonesInit shells out to `bones init` in the target dir if bones is
+// on PATH. Soft-fail: bones being missing is not fatal — operator
+// without bones still gets a usable orchestrator session.
+func runBonesInit(targetDir string) error {
+    if _, err := exec.LookPath("bones"); err != nil {
+        return nil // soft-fail; bones not on PATH
+    }
+    c := exec.Command("bones", "init")
+    c.Dir = targetDir
+    c.Stdout = os.Stdout
+    c.Stderr = os.Stderr
+    return c.Run()
+}
+```
+
+- [ ] **Step 4: Wire all four into runInit**
+
+In `runInit`, after `os.WriteFile(claudePath, ...)`:
+
+```go
+// Scaffold skills (project-local copies of the embedded host-mode skills)
+for _, skill := range []string{"orchestrator-mode", "subagent-to-subharness"} {
+    if err := scaffoldSkill(target, skill); err != nil {
+        fmt.Fprintf(os.Stderr, "init: skill scaffold %s failed: %v\n", skill, err)
+    } else {
+        fmt.Printf("scaffolded .claude/skills/%s/SKILL.md\n", skill)
+    }
+}
+
+// Scaffold statusLine + gitignore
+if err := scaffoldStatusLine(target); err != nil {
+    fmt.Fprintf(os.Stderr, "init: statusLine scaffold failed: %v\n", err)
+} else {
+    fmt.Println("scaffolded .claude/settings.local.json")
+}
+if err := scaffoldGitignore(target); err != nil {
+    fmt.Fprintf(os.Stderr, "init: .gitignore append failed: %v\n", err)
+} else {
+    fmt.Println("appended darken entries to .gitignore")
+}
+
+// bones init (soft-fail if bones not on PATH)
+if err := runBonesInit(target); err != nil {
+    fmt.Fprintf(os.Stderr, "init: bones init failed: %v\n", err)
+} else if _, err := exec.LookPath("bones"); err == nil {
+    fmt.Println("ran `bones init` for workspace bootstrap")
+}
+```
+
+- [ ] **Step 5: Update tests**
+
+Add to `init_test.go`:
+
+```go
+func TestInitScaffoldsSkills(t *testing.T) {
+    tmp := t.TempDir()
+    t.Setenv("DARKEN_REPO_ROOT", tmp)
+    if err := runInit([]string{tmp}); err != nil {
+        t.Fatal(err)
+    }
+    for _, skill := range []string{"orchestrator-mode", "subagent-to-subharness"} {
+        path := filepath.Join(tmp, ".claude", "skills", skill, "SKILL.md")
+        if _, err := os.Stat(path); err != nil {
+            t.Fatalf("skill %s not scaffolded: %v", skill, err)
+        }
+    }
+}
+
+func TestInitWritesStatusLineSettings(t *testing.T) {
+    tmp := t.TempDir()
+    t.Setenv("DARKEN_REPO_ROOT", tmp)
+    if err := runInit([]string{tmp}); err != nil {
+        t.Fatal(err)
+    }
+    body, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.local.json"))
+    if err != nil {
+        t.Fatalf("settings.local.json not created: %v", err)
+    }
+    if !strings.Contains(string(body), `"command": "darken status"`) {
+        t.Fatalf("settings missing statusLine.command: %s", body)
+    }
+}
+
+func TestInitAppendsGitignore(t *testing.T) {
+    tmp := t.TempDir()
+    t.Setenv("DARKEN_REPO_ROOT", tmp)
+    // Plant a pre-existing .gitignore to confirm append (not overwrite).
+    os.WriteFile(filepath.Join(tmp, ".gitignore"), []byte("# pre-existing\n*.log\n"), 0o644)
+
+    if err := runInit([]string{tmp}); err != nil {
+        t.Fatal(err)
+    }
+    body, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+    if !strings.Contains(string(body), "# pre-existing") {
+        t.Fatalf("init clobbered existing .gitignore: %s", body)
+    }
+    if !strings.Contains(string(body), ".scion/agents/") {
+        t.Fatalf("init didn't append darken entries: %s", body)
+    }
+}
+
+func TestInitSecondRunIsIdempotent(t *testing.T) {
+    tmp := t.TempDir()
+    t.Setenv("DARKEN_REPO_ROOT", tmp)
+    if err := runInit([]string{tmp}); err != nil {
+        t.Fatal(err)
+    }
+    body1, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+    if err := runInit([]string{tmp}); err != nil {
+        t.Fatal(err)
+    }
+    body2, _ := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+    if string(body1) != string(body2) {
+        t.Fatalf("second init mutated .gitignore (not idempotent):\nwas: %q\nnow: %q", body1, body2)
+    }
+}
+```
+
+- [ ] **Step 6: Smoke + commit**
+
+```
+go test ./cmd/darken/... -count=1
+make darken
+bin/darken init /tmp/init-smoke
+ls -la /tmp/init-smoke/.claude/skills/  # both skills present
+cat /tmp/init-smoke/.claude/settings.local.json
+cat /tmp/init-smoke/.gitignore
+rm -rf /tmp/init-smoke
+```
+
+Commit:
+```
+feat(init): scaffold skills + bones init + statusLine + gitignore
+
+darken init now produces a fully-wired working repo:
+- .claude/skills/orchestrator-mode/SKILL.md (extracted from embed)
+- .claude/skills/subagent-to-subharness/SKILL.md (extracted from embed)
+- .claude/settings.local.json (statusLine → darken status)
+- .gitignore appends (.scion/agents/, .scion/skills-staging/,
+  .scion/audit.jsonl, .claude/worktrees/, .superpowers/)
+- bones init in the target dir (soft-fail if bones not on PATH)
+
+CLAUDE.md template now directs Claude to announce orchestrator mode
+on first response. The substrate hash is rendered into the announce
+line so operators see at a glance which substrate version is loaded.
+
+All scaffolding is idempotent — re-running darken init is safe.
+```
+
+---
+
+### Task 5: Fix Makefile path (agent-infra → bones)
+
+**Why:** `images/Makefile:17` defaults `AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra`. The repo was renamed to `bones` (per agent-infra git history). Fresh clones don't have agent-infra; `make prebuild-bones` errors with "no such file."
+
+**Files:**
+- Modify: `images/Makefile`
+
+- [ ] **Step 1: Change default path**
+
+```
+- AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra
++ BONES_SOURCE_PATH ?= $(HOME)/projects/bones
+```
+
+- [ ] **Step 2: Rename references in `prebuild-bones` target**
+
+```
+cd $(BONES_SOURCE_PATH) && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/bones ./cmd/bones && \
+  ...
+```
+
+(All four backends.)
+
+- [ ] **Step 3: Sync embed data + drift guard**
+
+```
+make sync-embed-data
+bash scripts/test-embed-drift.sh
+```
+
+- [ ] **Step 4: Smoke test prebuild from clean state**
+
+```
+rm -rf images/{claude,codex,pi,gemini}/bin
+make -C images prebuild-bones
+ls images/claude/bin/bones  # should exist
+```
+
+- [ ] **Step 5: Commit**
+
+```
+fix(images/Makefile): rename AGENT_INFRA_PATH → BONES_SOURCE_PATH
+
+agent-infra was renamed to bones upstream. The default path
+$(HOME)/projects/agent-infra no longer exists on fresh machines.
+Updates the variable name + default to track the rename.
+
+Operators with a non-default path keep their existing override:
+  make -C images prebuild-bones BONES_SOURCE_PATH=/some/other/path
+```
+
+---
+
+### Task 6: Final verification + push + PR
+
+- [ ] **Full test suite**
+- [ ] **Lint** (`go vet`, `gofmt`)
+- [ ] **Build + manual smoke**:
+  - `bin/darken status` prints status line
+  - `bin/darken init /tmp/init-test` produces all expected files
+  - `bin/darken spawn ...` against /tmp/init-test (with bones on PATH for `bones init`) goes further than before — at minimum gets past the stage-creds + stage-skills steps without "no such script" errors
+- [ ] **Drift guard**: `bash scripts/test-embed-drift.sh` PASS
+- [ ] **Push branch + open PR**
+
+PR body should:
+- Cite the live edgesync-fslite session that surfaced the bugs
+- Operator action items: tag v0.1.4 after merge to ship the fix to brew users
+- Backward-compat note: existing repos created via prior `darken init` will be missing `.claude/skills/`; operators should `darken init --force` to refresh OR run a new helper if Phase 5 ships one (defer to Phase 6 if needed).
+
+---
+
+## Done definition
+
+Phase 5 ships when:
+
+1. All Go tests pass (`go test ./... -count=1`)
+2. `bin/darken init /tmp/fresh-repo` produces:
+   - CLAUDE.md (with substrate hash injected)
+   - `.claude/skills/orchestrator-mode/SKILL.md`
+   - `.claude/skills/subagent-to-subharness/SKILL.md`
+   - `.claude/settings.local.json` with statusLine → `darken status`
+   - `.gitignore` with darken entries appended
+   - `bones init`'d if bones is on PATH
+3. `bin/darken spawn ...` from a fresh-init'd repo extracts scripts from embedded substrate; doesn't error on missing CWD scripts
+4. `bin/darken status` prints `[darken: orchestrator-mode | substrate <12-hex>]`
+5. `bash scripts/test-embed-drift.sh` PASS
+6. `make -C images prebuild-bones` works with the corrected path
+7. PR open, CI green, ready for review
+
+## Operator validation post-merge
+
+After tag `v0.1.4` (which Phase 5 should also propose):
+
+```bash
+brew upgrade darken
+darken version  # v0.1.4
+
+# Test the full flow on a fresh repo
+mkdir -p /tmp/darken-test
+cd /tmp/darken-test
+git init
+darken init .
+ls -la .claude/skills/  # should show both skills
+cat CLAUDE.md | grep "darken orchestrator-mode primed"  # should match
+
+# Open Claude Code
+claude code
+# First response should start with "🔧 darken orchestrator-mode primed..."
+
+# Status line at the bottom of the Claude Code UI should show:
+# [darken: orchestrator-mode | substrate ee346ff63f0a]
+
+# Try a spawn
+# > "have a researcher produce a brief on /tmp/darken-test/README.md"
+# Should NOT error with "no such script" — should reach scion broker
+```
+
+## What Phase 6 might pick up
+
+- A `darken init --refresh` flag for existing repos to pull in new scaffolding (skills, settings, gitignore) without overwriting CLAUDE.md
+- `darken doctor` detection of the "init was run on an old version" case
+- Active worker count in `darken status` (if scion list stays fast)
+- Bones-side skill bundling — currently bones doesn't ship discoverable skills; if it does, scaffold those too

--- a/docs/superpowers/plans/2026-04-28-darken-phase-6-init-verify-and-refresh.md
+++ b/docs/superpowers/plans/2026-04-28-darken-phase-6-init-verify-and-refresh.md
@@ -1,0 +1,1002 @@
+# Darken Phase 6 — Init Verify + Refresh + Prereq Checks
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close audit items 6-8 — give the operator a way to verify an init'd repo is correct, refresh it after `brew upgrade darken`, and fail-fast at init time when prereqs are missing.
+
+**Architecture:** Three additions to existing `cmd/darken/` files. New `runInitDoctor()` that asserts every scaffold from Phase 5 is present and well-formed. New `--refresh` and broadened `--force` flags on `darken init` that re-extract embedded skills/templates without clobbering customizations (unless `--force`). New `verifyInitPrereqs()` called at the top of `runInit` that errors with install hints when bones / scion / Docker are missing. All read paths use the substrate resolver from Phase 1+2 — no new architecture.
+
+**Tech Stack:** Go 1.23+, stdlib only. No new dependencies. Reuses `internal/substrate.Resolver`, `internal/substrate.EmbeddedFS`, and the existing `doctor.go` reporting pattern.
+
+**Precondition:** Phase 5 (`docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md`) must be merged before Phase 6 begins. Phase 6 calls Phase 5's helpers (`scaffoldSkill`, `scaffoldStatusLine`, `scaffoldGitignore`, `runBonesInit`, `renderCLAUDE`). The implementer should branch from `main` after the Phase 5 merge commit, not stack on Phase 5's open PR.
+
+---
+
+## File structure
+
+### Modified
+- `cmd/darken/init.go` — adds `--refresh` flag, broadens `--force`, calls `verifyInitPrereqs()` at start, refactors scaffolding into reusable helpers
+- `cmd/darken/init_test.go` — adds tests for `--refresh`, `--force` behavior with refresh, prereq checks
+- `cmd/darken/doctor.go` — adds `--init` flag dispatch in `runDoctor` to a new `runInitDoctor()`
+- `cmd/darken/doctor_test.go` — adds tests for `darken doctor --init`
+
+### Created
+- `cmd/darken/init_verify.go` — new file holding `runInitDoctor()` and prereq-check helpers; keeps init.go from getting too big
+
+### NOT modified
+- `internal/substrate/` — Phase 1+2 resolver + Phase 2 embed are already what we need
+- `internal/substrate/data/templates/CLAUDE.md.tmpl` — template stays as-is from Phase 5
+
+---
+
+## Tasks
+
+### Task 1: `runInitDoctor()` — scoped per-init verification
+
+**Why:** Operator wants a single command to confirm "is this repo's darken init complete and current?" Today they have to inspect files manually.
+
+**Files:**
+- Create: `cmd/darken/init_verify.go`
+- Create test additions in: `cmd/darken/doctor_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/darken/doctor_test.go`:
+
+```go
+func TestInitDoctor_PassesOnCompleteInit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Plant a complete init scaffold (matches what Phase 5's runInit produces).
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken orchestrator-mode\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"),
+		[]byte("---\nname: orchestrator-mode\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness", "SKILL.md"),
+		[]byte("---\nname: subagent-to-subharness\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "settings.local.json"),
+		[]byte(`{"statusLine":{"command":"darken status","type":"command"}}`), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".gitignore"),
+		[]byte(".scion/agents/\n.scion/skills-staging/\n.scion/audit.jsonl\n.claude/worktrees/\n"), 0o644)
+
+	report, err := runInitDoctor(tmp)
+	if err != nil {
+		t.Fatalf("expected init doctor to pass on complete scaffold; got: %v\nreport:\n%s", err, report)
+	}
+	for _, want := range []string{"OK", "CLAUDE.md", "orchestrator-mode", "subagent-to-subharness", "statusLine", ".gitignore"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
+	}
+}
+
+func TestInitDoctor_FailsOnMissingCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	// no CLAUDE.md planted
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when CLAUDE.md missing")
+	}
+	if !strings.Contains(report, "CLAUDE.md") {
+		t.Fatalf("report should call out CLAUDE.md: %s", report)
+	}
+	if !strings.Contains(report, "darken init") {
+		t.Fatalf("report should suggest `darken init`: %s", report)
+	}
+}
+
+func TestInitDoctor_FailsOnMissingSkills(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+	// skills NOT scaffolded
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when skills missing")
+	}
+	if !strings.Contains(report, "orchestrator-mode") {
+		t.Fatalf("report should call out orchestrator-mode skill: %s", report)
+	}
+}
+
+func TestInitDoctor_FailsOnMissingStatusLine(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"), []byte("name: orchestrator-mode"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness", "SKILL.md"), []byte("name: subagent-to-subharness"), 0o644)
+	// no settings.local.json planted
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when settings.local.json missing")
+	}
+	if !strings.Contains(report, "statusLine") && !strings.Contains(report, "settings.local.json") {
+		t.Fatalf("report should call out missing statusLine config: %s", report)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```bash
+cd /Users/dmestas/projects/darkish-factory
+go test -run TestInitDoctor ./cmd/darken/... -count=1
+```
+
+Expected: undefined: `runInitDoctor`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/darken/init_verify.go`:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// initCheck describes a single required-file check inside an init'd repo.
+// failHint is shown when the check fails — should be a one-liner with the
+// remediation command the operator should run.
+type initCheck struct {
+	name     string
+	path     string
+	check    func(absPath string) error
+	failHint string
+}
+
+// runInitDoctor runs the per-init verification pass against the given
+// target directory. Returns a formatted report and an error if any
+// check failed. Mirrors the doctorBroad/doctorHarness pattern.
+func runInitDoctor(target string) (string, error) {
+	checks := []initCheck{
+		{
+			name:     "CLAUDE.md present",
+			path:     "CLAUDE.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init " + target + "` to scaffold",
+		},
+		{
+			name:     "orchestrator-mode skill scaffolded",
+			path:     ".claude/skills/orchestrator-mode/SKILL.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init --refresh` to extract from binary",
+		},
+		{
+			name:     "subagent-to-subharness skill scaffolded",
+			path:     ".claude/skills/subagent-to-subharness/SKILL.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init --refresh` to extract from binary",
+		},
+		{
+			name:     "settings.local.json with statusLine command",
+			path:     ".claude/settings.local.json",
+			check:    statusLineConfigValid,
+			failHint: "run `darken init --refresh` to recreate",
+		},
+		{
+			name:     ".gitignore has darken entries",
+			path:     ".gitignore",
+			check:    gitignoreHasDarkenEntries,
+			failHint: "run `darken init --refresh` to append entries",
+		},
+	}
+
+	var sb strings.Builder
+	var failed []string
+	for _, c := range checks {
+		abs := filepath.Join(target, c.path)
+		if err := c.check(abs); err != nil {
+			fmt.Fprintf(&sb, "FAIL  %s — %v\n", c.name, err)
+			fmt.Fprintf(&sb, "      remediation: %s\n", c.failHint)
+			failed = append(failed, c.name)
+		} else {
+			fmt.Fprintf(&sb, "OK    %s\n", c.name)
+		}
+	}
+
+	if len(failed) > 0 {
+		return sb.String(), fmt.Errorf("%d init checks failed: %s",
+			len(failed), strings.Join(failed, ", "))
+	}
+	return sb.String(), nil
+}
+
+// fileNonEmpty asserts the path exists and is non-zero size.
+func fileNonEmpty(absPath string) error {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("missing or inaccessible: %s", absPath)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("empty file: %s", absPath)
+	}
+	return nil
+}
+
+// statusLineConfigValid asserts settings.local.json parses as JSON and
+// has a statusLine.command field set.
+func statusLineConfigValid(absPath string) error {
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("missing settings.local.json")
+	}
+	var cfg struct {
+		StatusLine struct {
+			Command string `json:"command"`
+			Type    string `json:"type"`
+		} `json:"statusLine"`
+	}
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if cfg.StatusLine.Command == "" {
+		return fmt.Errorf("statusLine.command not set")
+	}
+	return nil
+}
+
+// gitignoreHasDarkenEntries asserts the four canonical darken-related
+// gitignore entries are present.
+func gitignoreHasDarkenEntries(absPath string) error {
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("missing .gitignore")
+	}
+	want := []string{
+		".scion/agents/",
+		".scion/skills-staging/",
+		".claude/worktrees/",
+	}
+	var missing []string
+	for _, w := range want {
+		if !strings.Contains(string(body), w) {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing entries: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+```bash
+go test -run TestInitDoctor ./cmd/darken/... -count=1
+```
+
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Lint**
+
+```bash
+go vet ./cmd/darken/... && gofmt -l cmd/
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/darken/init_verify.go cmd/darken/doctor_test.go
+git commit -m "feat(cli): runInitDoctor verifies scaffolds in an init'd repo
+
+Five checks cover Phase 5's init scaffolds: CLAUDE.md present,
+both host-mode skills scaffolded, settings.local.json has
+statusLine.command, .gitignore has darken entries.
+
+Each FAIL surfaces a remediation hint. Tests cover the happy path
+and three failure modes (missing CLAUDE.md, missing skills,
+missing statusLine config)."
+```
+
+---
+
+### Task 2: Wire `--init` flag into `runDoctor`
+
+**Why:** Expose `runInitDoctor` as `darken doctor --init` so operators have a single command surface.
+
+**Files:**
+- Modify: `cmd/darken/doctor.go`
+- Modify: `cmd/darken/doctor_test.go`
+
+- [ ] **Step 1: Read the current `runDoctor` signature**
+
+```bash
+grep -A 12 "^func runDoctor" cmd/darken/doctor.go
+```
+
+Expected: `runDoctor` dispatches on `args[0]` for per-harness mode.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `cmd/darken/doctor_test.go`:
+
+```go
+func TestDoctor_InitFlagDispatchesToInitDoctor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	// minimal init: just CLAUDE.md, missing skills → doctor --init should FAIL
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+
+	out, err := captureStdout(func() error { return runDoctor([]string{"--init"}) })
+	if err == nil {
+		t.Fatalf("expected runDoctor --init to fail with missing skills; got nil err\noutput:\n%s", out)
+	}
+	if !strings.Contains(out, "orchestrator-mode") {
+		t.Fatalf("expected output to call out missing orchestrator-mode skill, got: %s", out)
+	}
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+```bash
+go test -run TestDoctor_InitFlag ./cmd/darken/... -count=1
+```
+
+Expected: dispatch doesn't recognize `--init`; either falls through to `doctorBroad` (which won't fail correctly) or errors differently.
+
+- [ ] **Step 4: Implement the dispatch**
+
+Modify `cmd/darken/doctor.go`'s `runDoctor` to handle `--init`:
+
+```go
+func runDoctor(args []string) error {
+	// New: --init triggers per-init scaffold verification (Phase 6).
+	for _, a := range args {
+		if a == "--init" {
+			root, err := repoRoot()
+			if err != nil {
+				return err
+			}
+			report, err := runInitDoctor(root)
+			fmt.Print(report)
+			return err
+		}
+	}
+
+	// Existing dispatch follows below — no change.
+	if len(args) >= 1 {
+		report, err := doctorHarness(args[0])
+		fmt.Println(report)
+		return err
+	}
+	report, err := doctorBroad()
+	fmt.Println(report)
+	return err
+}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+```bash
+go test -run TestDoctor ./cmd/darken/... -count=1
+```
+
+Expected: all `TestDoctor*` PASS, including the new one and the existing 4 (`TestDoctorReportsMissingScion`, `TestDoctorHarnessChecksImageSecretAndStaging`, `TestDoctorHarnessReadsUserOverridesLayer`, `TestDoctorHarnessPostMortemMapsAuthError`).
+
+- [ ] **Step 6: Lint**
+
+```bash
+go vet ./cmd/darken/... && gofmt -l cmd/
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/darken/doctor.go cmd/darken/doctor_test.go
+git commit -m "feat(cli): darken doctor --init dispatches to runInitDoctor
+
+Operator runs \`darken doctor --init\` from inside an init'd repo
+to verify the scaffold is complete. Falls through to per-harness
+or broad checks when --init isn't present."
+```
+
+---
+
+### Task 3: `darken init --refresh` — re-scaffold without overwriting CLAUDE.md
+
+**Why:** After `brew upgrade darken`, operators need a way to pull newer skill bodies / settings into existing init'd repos without clobbering customizations to CLAUDE.md.
+
+**Files:**
+- Modify: `cmd/darken/init.go`
+- Modify: `cmd/darken/init_test.go`
+
+- [ ] **Step 1: Read the current `runInit` shape**
+
+```bash
+grep -A 30 "^func runInit" cmd/darken/init.go
+```
+
+Expected: parses `--dry-run` and `--force`; writes CLAUDE.md if not exists or `--force`; calls scaffold helpers (`scaffoldSkill`, `scaffoldStatusLine`, `scaffoldGitignore`, `runBonesInit`).
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `cmd/darken/init_test.go`:
+
+```go
+func TestInitRefresh_PreservesCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Initial init creates the scaffold.
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	// Operator customizes CLAUDE.md.
+	customCLAUDE := "# Custom CLAUDE.md\n\nMy own content here.\n"
+	if err := os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte(customCLAUDE), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --refresh should NOT overwrite CLAUDE.md.
+	if err := runInit([]string{"--refresh", tmp}); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(tmp, "CLAUDE.md"))
+	if string(got) != customCLAUDE {
+		t.Fatalf("CLAUDE.md should be preserved, got:\n%s", got)
+	}
+}
+
+func TestInitRefresh_UpdatesSkills(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	// Operator stomps on a skill with stale content.
+	skillPath := filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("STALE CONTENT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --refresh should re-extract from embedded substrate.
+	if err := runInit([]string{"--refresh", tmp}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(skillPath)
+	if string(got) == "STALE CONTENT" {
+		t.Fatal("skill body should have been refreshed from embedded substrate")
+	}
+	if !strings.Contains(string(got), "name: orchestrator-mode") {
+		t.Fatalf("refreshed skill missing frontmatter: %s", string(got)[:100])
+	}
+}
+
+func TestInitRefreshForce_OverwritesCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	customCLAUDE := "# Custom\n"
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte(customCLAUDE), 0o644)
+
+	// --refresh --force regenerates CLAUDE.md.
+	if err := runInit([]string{"--refresh", "--force", tmp}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(tmp, "CLAUDE.md"))
+	if string(got) == customCLAUDE {
+		t.Fatal("--refresh --force should regenerate CLAUDE.md")
+	}
+	if !strings.Contains(string(got), "darken orchestrator-mode") {
+		t.Fatalf("regenerated CLAUDE.md missing template content: %s", got)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests, verify they fail**
+
+```bash
+go test -run TestInitRefresh ./cmd/darken/... -count=1
+```
+
+Expected: `--refresh` flag not recognized.
+
+- [ ] **Step 4: Implement the flag in `runInit`**
+
+Modify `cmd/darken/init.go`'s `runInit` to add the `refresh` flag and gate CLAUDE.md write semantics:
+
+```go
+func runInit(args []string) error {
+	flags := flag.NewFlagSet("init", flag.ContinueOnError)
+	dryRun := flags.Bool("dry-run", false, "print actions without executing")
+	force := flags.Bool("force", false, "overwrite existing CLAUDE.md / settings (use with --refresh)")
+	refresh := flags.Bool("refresh", false, "re-scaffold an existing init; preserves CLAUDE.md unless --force")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	pos := flags.Args()
+	target := "."
+	if len(pos) > 0 {
+		target = pos[0]
+	}
+	target, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(target); err != nil {
+		return fmt.Errorf("target dir does not exist: %s", target)
+	}
+
+	claudePath := filepath.Join(target, "CLAUDE.md")
+	exists := false
+	if _, err := os.Stat(claudePath); err == nil {
+		exists = true
+	}
+
+	// Decide whether to write CLAUDE.md.
+	// Refresh mode: skip CLAUDE.md unless --force.
+	// Non-refresh mode (initial init): write if not exists or --force.
+	writeCLAUDE := false
+	switch {
+	case *refresh && *force:
+		writeCLAUDE = true // explicit regeneration
+	case *refresh:
+		writeCLAUDE = false // preserve customizations
+	case exists && !*force:
+		writeCLAUDE = false // initial init, file already there, no force → skip
+	default:
+		writeCLAUDE = true // initial init, missing file → write
+	}
+
+	if *dryRun {
+		if writeCLAUDE {
+			fmt.Printf("would create %s\n", claudePath)
+		} else {
+			fmt.Printf("would skip %s (use --force to overwrite)\n", claudePath)
+		}
+		return nil
+	}
+
+	if writeCLAUDE {
+		body, err := renderCLAUDE(target)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
+			return err
+		}
+		fmt.Printf("wrote %s\n", claudePath)
+	} else if exists && !*refresh {
+		fmt.Printf("skipped %s (already exists; use --force to overwrite)\n", claudePath)
+	}
+
+	// Skills, settings, gitignore, bones init: always run; idempotent and
+	// safe to re-execute. --refresh re-extracts skills from embedded
+	// substrate (overwrites the SKILL.md files in place).
+	for _, skill := range []string{"orchestrator-mode", "subagent-to-subharness"} {
+		if err := scaffoldSkill(target, skill); err != nil {
+			fmt.Fprintf(os.Stderr, "init: skill scaffold %s failed: %v\n", skill, err)
+		} else {
+			fmt.Printf("scaffolded .claude/skills/%s/SKILL.md\n", skill)
+		}
+	}
+	if err := scaffoldStatusLine(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: statusLine scaffold failed: %v\n", err)
+	}
+	if err := scaffoldGitignore(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: .gitignore append failed: %v\n", err)
+	}
+	if err := runBonesInit(target); err != nil {
+		fmt.Fprintf(os.Stderr, "init: bones init failed: %v\n", err)
+	}
+
+	return nil
+}
+```
+
+(Note: the existing `scaffoldSkill` from Phase 5 already overwrites — verify by checking its implementation. If it currently checks for existence first and skips, modify it to always overwrite when called. The `os.WriteFile` call should not check existence.)
+
+- [ ] **Step 5: Verify `scaffoldSkill` overwrites unconditionally**
+
+```bash
+grep -A 15 "^func scaffoldSkill" cmd/darken/init.go
+```
+
+Expected: uses `os.WriteFile` directly, which truncates+writes. If it has an early-return on exists, remove that.
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+```bash
+go test -run TestInit ./cmd/darken/... -count=1
+```
+
+Expected: all `TestInit*` PASS, including the 3 new + the 4 from Phase 5 (idempotent, force, dry-run, scaffolds).
+
+- [ ] **Step 7: Lint**
+
+```bash
+go vet ./cmd/darken/... && gofmt -l cmd/
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/darken/init.go cmd/darken/init_test.go
+git commit -m "feat(cli): darken init --refresh re-scaffolds without clobbering CLAUDE.md
+
+After \`brew upgrade darken\`, operators run \`darken init --refresh\`
+to pull newer skill bodies / statusLine config into existing
+init'd repos. CLAUDE.md is preserved by default (operator may have
+customized it); --force regenerates from the embedded template.
+
+Skills, statusLine config, .gitignore entries, and bones init all
+run on --refresh — they're idempotent and safe to re-execute."
+```
+
+---
+
+### Task 4: Init-time prereq checks
+
+**Why:** Today missing bones / scion / Docker surfaces mid-spawn with cryptic errors. Phase 6 surfaces them at init time with one-liner remediations.
+
+**Files:**
+- Modify: `cmd/darken/init.go` — call `verifyInitPrereqs(target)` at start
+- Modify: `cmd/darken/init_verify.go` — add `verifyInitPrereqs()` helper
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/darken/init_test.go`:
+
+```go
+func TestInit_FailsFastWhenBonesMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Replace PATH with a tmp dir that has scion + docker stubs but NO bones.
+	stubDir := t.TempDir()
+	for _, b := range []string{"scion", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when bones missing from PATH")
+	}
+	if !strings.Contains(err.Error(), "bones") {
+		t.Fatalf("error should mention bones: %v", err)
+	}
+	if !strings.Contains(err.Error(), "brew install") {
+		t.Fatalf("error should suggest install hint: %v", err)
+	}
+}
+
+func TestInit_FailsFastWhenScionMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when scion missing")
+	}
+	if !strings.Contains(err.Error(), "scion") {
+		t.Fatalf("error should mention scion: %v", err)
+	}
+}
+
+func TestInit_FailsFastWhenDockerMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when docker missing")
+	}
+	if !strings.Contains(err.Error(), "docker") {
+		t.Fatalf("error should mention docker: %v", err)
+	}
+}
+
+func TestInit_PassesWhenAllPrereqsPresent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatalf("init should pass with all prereqs on PATH: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+```bash
+go test -run TestInit_Fails ./cmd/darken/... -count=1
+```
+
+Expected: tests fail because no prereq check exists yet — runInit succeeds without checking PATH.
+
+- [ ] **Step 3: Implement `verifyInitPrereqs` in `init_verify.go`**
+
+Append to `cmd/darken/init_verify.go`:
+
+```go
+import (
+	"os/exec"
+)
+
+// prereqTool describes a binary the operator needs on PATH for darken
+// init to produce a working orchestrator-mode setup.
+type prereqTool struct {
+	name        string
+	installHint string
+}
+
+// verifyInitPrereqs returns a non-nil error listing all missing
+// prerequisite tools, with a one-liner install hint per tool. Called
+// at the top of runInit so failures surface upfront, not mid-spawn.
+func verifyInitPrereqs() error {
+	tools := []prereqTool{
+		{name: "bones", installHint: "brew install danmestas/tap/bones"},
+		{name: "scion", installHint: "see https://github.com/GoogleCloudPlatform/scion (make install)"},
+		{name: "docker", installHint: "install Docker Desktop or colima or podman"},
+	}
+	var missing []string
+	for _, t := range tools {
+		if _, err := exec.LookPath(t.name); err != nil {
+			missing = append(missing, fmt.Sprintf("  - %s not on PATH; install via: %s", t.name, t.installHint))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("darken init prereqs missing:\n%s", strings.Join(missing, "\n"))
+	}
+	return nil
+}
+```
+
+(Update the imports at the top of `init_verify.go` to add `os/exec`.)
+
+- [ ] **Step 4: Wire `verifyInitPrereqs()` into `runInit`**
+
+Modify `cmd/darken/init.go`'s `runInit` to call the prereq check at the start, after flag parsing:
+
+```go
+func runInit(args []string) error {
+	flags := flag.NewFlagSet("init", flag.ContinueOnError)
+	// ... existing flag definitions ...
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	// Phase 6: prereq check — fail fast if bones/scion/docker missing.
+	if err := verifyInitPrereqs(); err != nil {
+		return err
+	}
+
+	// ... rest of runInit unchanged ...
+}
+```
+
+- [ ] **Step 5: Run the tests, verify they pass**
+
+```bash
+go test -run TestInit ./cmd/darken/... -count=1
+```
+
+Expected: all 4 new prereq tests PASS, plus existing tests still pass (they now plant the 3 stubs as part of t.Setenv("PATH", ...) where needed).
+
+**IMPORTANT:** the existing Phase 5 init tests (`TestInitScaffoldsCLAUDE`, `TestInitIsIdempotent`, `TestInitForceOverwrites`, `TestInitDryRun`, `TestInitScaffoldsSkills`, `TestInitWritesStatusLineSettings`, `TestInitAppendsGitignore`, `TestInitSecondRunIsIdempotent`) DON'T plant prereq stubs and will now fail. Update each to add the same stub-setup-prereqs preamble. Add a test helper:
+
+```go
+// stubPrereqs plants no-op bones/scion/docker stubs on PATH for tests
+// that don't care about prereq checks (just want runInit to proceed).
+func stubPrereqs(t *testing.T) {
+	t.Helper()
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion", "docker"} {
+		if err := os.WriteFile(filepath.Join(stubDir, b),
+			[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", stubDir)
+}
+```
+
+…and call `stubPrereqs(t)` at the top of each existing init test. (Add this helper to `cmd/darken/init_test.go`.)
+
+- [ ] **Step 6: Re-run all tests**
+
+```bash
+go test ./cmd/darken/... -count=1
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Lint**
+
+```bash
+go vet ./cmd/darken/... && gofmt -l cmd/
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/darken/init.go cmd/darken/init_verify.go cmd/darken/init_test.go
+git commit -m "feat(cli): darken init fails fast on missing prereqs
+
+verifyInitPrereqs runs at the top of runInit and errors if bones,
+scion, or docker is missing from PATH. Each missing tool gets a
+one-liner install hint.
+
+Today these surface mid-spawn with cryptic broker errors; Phase 6
+surfaces them at init time. Test stubs plant no-op binaries to
+satisfy the check; new stubPrereqs helper in init_test.go is
+called by all existing init tests."
+```
+
+---
+
+### Task 5: Final verification + push + PR
+
+- [ ] **Step 1: Run the full suite**
+
+```bash
+go test ./... -count=1
+```
+
+Expected: all 3 packages green (cmd/darken, internal/staging, internal/substrate).
+
+- [ ] **Step 2: Lint + format**
+
+```bash
+go vet ./...
+gofmt -l cmd/ internal/
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Build + smoke**
+
+```bash
+make darken
+bin/darken --help          # confirm subcommand list unchanged
+bin/darken doctor --help   # verify --init flag exists if doctor surfaces flag help
+
+# Manual smoke: init a tmp dir, doctor it, refresh, doctor again
+TMP=$(mktemp -d)
+bin/darken init "$TMP"
+bin/darken doctor --init   # expects PASS but DARKEN_REPO_ROOT may need to point at $TMP
+DARKEN_REPO_ROOT="$TMP" bin/darken doctor --init   # cleaner
+DARKEN_REPO_ROOT="$TMP" bin/darken init --refresh "$TMP"
+DARKEN_REPO_ROOT="$TMP" bin/darken doctor --init   # still PASSes after refresh
+rm -rf "$TMP"
+```
+
+- [ ] **Step 4: Drift guard (sanity)**
+
+```bash
+bash scripts/test-embed-drift.sh
+```
+
+Expected: PASS (Phase 6 doesn't touch internal/substrate/data/).
+
+- [ ] **Step 5: Sync embed data + commit (only if drift)**
+
+If the drift guard FAILed (unexpected — Phase 6 doesn't change embed):
+
+```bash
+make sync-embed-data
+git add internal/substrate/data
+git commit -m "chore: sync embed data after Phase 6 changes"
+```
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feat/darken-phase-6-init-verify-and-refresh
+```
+
+(The branch is created by the agent at the start of Phase 6 work. If you're continuing from `feat/darken-phase-5-init-completeness`, branch off main first — Phase 6 should not stack on Phase 5's open PR.)
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --repo danmestas/darken \
+  --title "Phase 6: init verify + refresh + prereq checks" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 6 of the darken DX roadmap (spec at \`docs/superpowers/specs/2026-04-28-darken-DX-roadmap-design.md\`). Closes audit items 6-8.
+
+## What lands
+
+- **\`darken doctor --init\`** — scoped doctor pass that asserts every Phase 5 scaffold is present and well-formed (CLAUDE.md, both skills, settings.local.json statusLine config, .gitignore entries). Each FAIL surfaces a remediation hint pointing at the next command to run.
+
+- **\`darken init --refresh\`** — re-runs scaffolding without overwriting CLAUDE.md. Pulls newer skill bodies + statusLine config from the binary's embedded substrate. Operator's path post-\`brew upgrade darken\` to inherit fixes.
+
+- **\`darken init --force\`** broadened — when used with \`--refresh\`, regenerates CLAUDE.md from the embedded template. Without --refresh, --force keeps Phase 5's behavior (overwrite an existing CLAUDE.md on initial init).
+
+- **Init-time prereq checks** — \`darken init\` errors fast if bones, scion, or docker are missing from PATH. Each missing tool gets a one-liner install hint. Today these surface mid-spawn; Phase 6 surfaces them upfront.
+
+## Test plan
+
+- [x] go test ./... -count=1 — all 3 packages green (12+ new tests across init + doctor)
+- [x] go vet, gofmt — clean
+- [x] make darken — builds
+- [x] bin/darken doctor --init — passes on a fresh init'd repo
+- [x] bin/darken init --refresh - leaves customized CLAUDE.md alone, refreshes skills
+- [x] bin/darken init --refresh --force - regenerates everything
+- [x] bin/darken init in env without bones/scion/docker - errors with install hints
+- [x] scripts/test-embed-drift.sh — PASS
+- [ ] **Operator validation**: tag v0.1.5 after merge, brew upgrade darken, run darken doctor --init in an existing init'd repo
+
+## Operator action items post-merge
+
+\`\`\`bash
+git tag -a v0.1.5 -m "darken v0.1.5 — init verify + refresh + prereq checks"
+git push origin v0.1.5
+gh run watch
+\`\`\`
+EOF
+)"
+```
+
+- [ ] **Step 8: Verify CI green**
+
+```bash
+gh run list --repo danmestas/darken --limit 1
+```
+
+(If CI is set up to run on PR; otherwise this is a no-op until merge.)
+
+---
+
+## Done definition
+
+Phase 6 ships when:
+
+1. `go test ./... -count=1` — all green (Phase 5 tests + ~10 new tests in init_test.go and doctor_test.go)
+2. `bin/darken doctor --init` from a fresh `darken init`'d repo prints `OK` for all 5 checks and exits 0
+3. `bin/darken doctor --init` from a partially-init'd repo (missing skill, say) prints FAIL + remediation hint and exits 1
+4. `bin/darken init --refresh` against a repo with customized CLAUDE.md leaves CLAUDE.md alone, updates skills + settings + gitignore
+5. `bin/darken init --refresh --force` against the same regenerates CLAUDE.md from the embedded template
+6. `bin/darken init` in an env without bones/scion/docker errors with one-liner install hints, exits 1, doesn't write any files
+7. PR open, CI green, ready for review
+
+## What Phase 7 picks up
+
+- Async spawn (returns at "ready" state)
+- Cold-start progress on stderr
+- `darken spawn --watch` for legacy blocking behavior
+- Error mapping for broker-handshake failures via the existing `darken doctor` remediation table

--- a/docs/superpowers/specs/2026-04-28-darken-DX-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-28-darken-DX-roadmap-design.md
@@ -1,0 +1,188 @@
+# Darken DX Roadmap — Phases 5-9
+
+**Status:** approved (in-conversation, 2026-04-28)
+**Author:** dmestas
+**Source PRs:** TBD (Phase 5 plan exists at `docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md`)
+
+## Context
+
+A live orchestrator session in `~/projects/edgesync-fslite` surfaced multiple gaps in `darken init` and `darken spawn`. A subsequent `dx-audit` (`docs/...` not committed; reproduced inline below) scored the "init a new project" workflow at 2.6/10 today — broken without manual intervention. Phase 5 (already planned) gets that workflow to ~8/10. This spec defines what the **rest** of the path to "great" (10/10) looks like, decomposed into four additional phases (6-9).
+
+## Audit summary (input to this spec)
+
+| Workflow | Frequency | Today | After Phase 5 | After Phase 9 |
+|---|---|---|---|---|
+| Init a new project | Per-project | 2/10 | 8/10 | 9/10 |
+| Verify init worked | Per-project | 2/10 | 7/10 | 9/10 |
+| First spawn after init | Per-project | ~5/10 | 6/10 | 9/10 |
+| Routine orchestrator session | Daily | ~6/10 | 7/10 | 9/10 |
+| Recovery / update | When broken | 3/10 | 4/10 | 8/10 |
+
+**Today's overall:** 2.6/10. **Post-Phase-9 target:** 8.6/10 (cap below 10 because operator-grade is asymptotic; multi-machine + collab is non-goal).
+
+## Goals
+
+After all five phases ship:
+
+- `darken init <fresh-repo>` produces a working orchestrator session with zero manual recovery
+- Operator can verify init worked at any time via a single command
+- First spawn after init has visible progress, async dispatch by default, ~10s ready-time confirmation
+- Daily use surfaces "what's running / what happened" via scion's web dashboard for workers + Claude Code chat for the host orchestrator
+- Worker hangs auto-recover up to a threshold; substrate-hash drift after `brew upgrade` is detected and explained
+
+## Non-goals
+
+- **Multi-machine sync** — laptop ↔ desktop hub-secret transfer
+- **Multi-project portfolio management** — listing all darken'd repos, jumping between them
+- **Collab / teammates** — multi-operator escalation routing, shared init state
+- **Darken-side web UI** — scion ships a web dashboard; we wrap it
+- **Mode A pivot** — host orchestrator (Mode B) stays the default; containerized orchestrator remains an option but isn't the focus
+- **`tmux`-wrap host orchestrator into the dashboard** — noted as future work, not in scope here
+
+## Phase decomposition
+
+Each phase ships as one PR, executed sequentially with eval-and-merge between.
+
+| Phase | Workflow it fixes | New top-level commands | Implementation skill |
+|---|---|---|---|
+| **5** (in flight) | A. Init scaffolding completeness | `darken status` | superpowers:writing-plans → executing-plans |
+| **6** | A. Init verify + refresh + prereqs | `darken doctor --init`, `darken init --refresh` | writing-plans |
+| **7** | B. First-spawn UX | (modifies `darken spawn`) | writing-plans |
+| **8** | C. Routine observability | `darken dashboard`, `darken history` | writing-plans |
+| **9** | D. Recovery + update | `darken redispatch`, `darken upgrade-init` | writing-plans |
+
+## Cross-cutting decisions
+
+These apply across all 5 phases.
+
+1. **Observability split is natural, not a problem to solve** — scion's web dashboard for workers + Claude Code chat for the host orchestrator. Two windows by design.
+2. **Spawn returns at "ready" state, not at completion** — `darken spawn` polls scion broker for "agent ready" within a timeout (~15s), returns once ready. Failed handshake (auth, image missing) maps to a remediation hint via the existing `darken doctor` table.
+3. **`darken init` is fully self-contained** — embedded skills + scripts + statusLine + bones init + gitignore append. No host-side dependency on a darkish-factory clone.
+4. **Substrate hash is the version coherence anchor** — every `darken status`, `darken doctor`, `darken history` row stamps it. Mismatches between binary and project skills trigger drift warnings.
+5. **State stays append-only files** — no SQLite of our own, no daemon. `.scion/audit.jsonl` is canonical for darken history. Scion's hub.db is read-only to us (via API/CLI).
+6. **Mode B is the default forever** — host Claude Code is the orchestrator; Mode A (containerized) is the override.
+
+## Per-phase scope
+
+### Phase 5 — Init completeness (planned)
+
+`docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md` covers the full task list. Summary:
+
+- Substrate resolver in `spawn.go` and `bootstrap.go` (extracts embedded scripts to temp at runtime)
+- `darken init` scaffolds `.claude/skills/{orchestrator-mode,subagent-to-subharness}/SKILL.md`
+- `darken init` runs `bones init` (soft-fail if absent)
+- `darken init` writes `.claude/settings.local.json` with statusLine → `darken status`
+- `darken init` appends `.gitignore` entries
+- New `darken status` subcommand
+- Makefile fix: `AGENT_INFRA_PATH` → `BONES_SOURCE_PATH` (agent-infra was renamed bones)
+
+Closes audit items 1-5.
+
+### Phase 6 — Init verify + refresh + prereqs
+
+- **`darken doctor --init`** — scoped doctor pass that asserts an init'd repo has all expected files (CLAUDE.md, both skills, settings.local.json, gitignore entries, bones workspace). Reports per-item PASS/FAIL with remediation. Backs audit #6.
+- **`darken init --refresh`** — re-runs scaffolding without overwriting CLAUDE.md unless `--force`. Pulls newer skill bodies from the binary's embedded substrate. The path operators take after `brew upgrade darken` to inherit substrate fixes. Backs audit #7.
+- **Init-time prereq checks** — `darken init` errors fast if `bones`/`scion`/Docker missing, with one-liner install hints. Today these surface mid-spawn; Phase 6 surfaces at init. Backs audit #8.
+
+### Phase 7 — First-spawn UX
+
+- **Async spawn (Mode D from brainstorm)** — `darken spawn` polls scion broker for the agent's lifecycle state up to a configurable timeout (default 15s, override via `DARKEN_SPAWN_READY_TIMEOUT`). Returns once the agent transitions out of `Starting` (typically into `Thinking` or `Waiting` per scion's lifecycle states). Failed handshake (auth, image missing, etc.) surfaces as exit-1 with broker error mapped to a remediation hint via the existing `darken doctor` mapping table. **Open question:** verify what scion exposes as the "ready" predicate — `scion list --format json` lifecycle field is the most likely surface; will confirm during Phase 7 implementation.
+- **Cold-start progress** — while spawn waits for "ready", print one-line progress to stderr: `[spawning researcher-1] container starting → broker handshake → ready (12.3s)`. Quiet on success, loud on failure.
+- **`darken spawn --watch`** flag for the legacy "block + tail" mode if operator wants today's behavior. Default is async.
+
+Open question (deferred): timeout calibration. Cold-start times vary by image. Will need a sane default + env override.
+
+### Phase 8 — Routine observability
+
+- **`darken dashboard`** — opens scion's web dashboard URL in the operator's default browser. Detection: parse `scion server status` to confirm web is enabled (default port 8080 in workstation mode). If web is OFF, friendly error: `scion server restart --workstation` (or `--enable-web`).
+- **`darken history`** — reads `.scion/audit.jsonl` from CWD, prints a tabular summary: timestamp / decision_id / harness / type / outcome. Filters: `--last <N>`, `--since <duration>` (Go `time.ParseDuration` syntax: `5m`, `1h`, `24h`), `--format json` (for `jq` piping). Audit-log schema gets documented (was implicit before).
+- **Status line enrichment** — `darken status` (already in Phase 5) gains optional active-worker count if `scion list` runs sub-100ms. Fallback: `--no-workers` flag for embedded-hash-only output.
+
+### Phase 9 — Recovery + update
+
+- **`darken redispatch <agent>`** — kills the existing agent (via `scion stop`) and re-spawns with the same task. Wraps the §7 loop's "10-minute heartbeat → kill + redispatch" pattern. Worker worktree preserved across redispatch (treat as fresh start; commits are the durable state, in-flight uncommitted work is acceptable to lose).
+- **Substrate-hash drift detection** — `darken doctor` adds a "Project skills hash matches binary substrate" check. Mismatch on `<repo>/.claude/skills/orchestrator-mode/SKILL.md` vs the hash from `darken version` triggers a warning + "run `darken upgrade-init`" suggestion.
+- **`darken upgrade-init`** — convenience wrapper: `darken init --refresh` against CWD then `darken doctor --init` to verify. Single command for the post-`brew upgrade darken` operator action.
+- **Worker auto-redispatch policy** — orchestrator-mode skill already says "loop up to 3 times before escalating to the operator with the failure trace." Phase 9 makes that policy executable: orchestrator detects hang via heartbeat, calls `darken redispatch` automatically, escalates after N. Implementation lives in the orchestrator skill (no Go code change required) but Phase 9 documents the contract.
+
+## CLI surface (consolidated)
+
+**New commands across phases 5-9:**
+
+| Command | Phase | Purpose |
+|---|---|---|
+| `darken status` | 5 | one-line status for statusLine (mode + substrate hash; future: + worker count) |
+| `darken init --refresh` | 6 | re-scaffold an existing init'd repo from current binary |
+| `darken init --force` | 6 | overwrite existing CLAUDE.md / settings during refresh |
+| `darken doctor --init` | 6 | verify an init'd repo has all expected scaffolds |
+| `darken dashboard` | 8 | open scion's web dashboard URL in browser |
+| `darken history` | 8 | tabular view of `.scion/audit.jsonl` |
+| `darken redispatch <agent>` | 9 | kill + re-spawn with same task |
+| `darken upgrade-init` | 9 | refresh + doctor in one command |
+
+**Modified existing commands:**
+
+| Command | Phase | Change |
+|---|---|---|
+| `darken spawn` | 7 | default async (returns at "ready"); `--watch` for old blocking behavior |
+| `darken spawn` | 7 | cold-start progress on stderr |
+| `darken spawn` | 7 | broker errors mapped via existing remediation table |
+| `darken init` | 5 | scaffolds skills + statusLine + gitignore + bones init |
+| `darken init` | 6 | adds prereq checks at start; fail fast |
+| `darken doctor` | 9 | adds substrate-hash drift check |
+| `darken status` | 8 | optional active-worker count if `scion list` is fast |
+
+**Subcommand structure stays flat** — no `darken obs <subcmd>` namespace nesting. Each command is one word at the top level. ~13 commands total after Phase 9.
+
+## State / persistence model
+
+```
+~/.scion/hub.db                 SQLite — scion's state (agents, groves); we read via API/CLI, never write
+~/.scion/dev-token              Auto-written by scion at server start; used for hub API auth
+~/.config/darken/               User-scoped overrides (skills, templates) — manual ops only
+
+Per project:
+  CLAUDE.md                       Scaffolded by darken init
+  .claude/skills/<name>/          Project copies of host-mode skills
+  .claude/settings.local.json     Claude Code statusLine config
+  .scion/audit.jsonl              Append-only decision log; canonical for darken history
+  .scion/agents/<name>/           Scion's per-spawn worktrees (gitignored)
+```
+
+**Darken does NOT introduce its own state DB.** No SQLite, no daemon, no JSON config file beyond `settings.local.json` (which is Claude Code's). Everything queryable lives in scion's hub state (read via API/CLI) or `.scion/audit.jsonl` (read by `darken history`).
+
+Substrate hash is the version anchor — lives in:
+- The binary (`darken version` reports first-12-chars)
+- Stat'd hashes of project skills (Phase 9 drift detection)
+- Audit log entries (so `darken history` can show which substrate version made each decision)
+
+## Discoverability
+
+- `darken --help` lists all top-level commands with one-line descriptions (already does for current subset)
+- `darken doctor` post-mortem messages reference the relevant new subcommand by name (e.g., "run `darken upgrade-init` to refresh stale skills")
+- README's Quick Start gets one new line per phase as they ship
+
+## Risks + open questions
+
+1. **Async spawn timeout calibration (Phase 7)** — cold-start times vary by image (claude vs codex, first vs cached pull). Will need a sane default (15s) + env override. Risk: too short → spurious failures; too long → operator waits when something's already broken.
+
+2. **Substrate-hash drift remediation UX (Phase 9)** — `darken upgrade-init` could clobber operator customizations under `.claude/skills/`. Mitigation: refresh writes side-by-side `SKILL.md.new`, operator diffs and merges. Slightly more work; safer.
+
+3. **`darken history` performance (Phase 8)** — `.scion/audit.jsonl` could grow large over months. Linear scan acceptable up to ~1MB; beyond that we'd want rotation (`.scion/audit.jsonl.<date>`). Phase 8 ships linear; rotation lands in a Phase 10+ if anyone hits it.
+
+4. **`darken redispatch` blast radius (Phase 9)** — `scion stop` + new spawn risks orphaning partial work in the worker's worktree. Decision: preserve worktree, treat redispatch as fresh start; commits are the durable state.
+
+5. **Scion's web dashboard may not be enabled by default (Phase 8)** — `--enable-web` flag is required (or `--workstation` mode for combo). If operator's scion server was started without it, `darken dashboard` errors with a one-liner remediation suggesting `scion server restart --workstation`.
+
+## Versioning
+
+- Phase 5 ships under `v0.1.4` (or whatever is current at the time of merge)
+- Each subsequent phase bumps the patch version: 5→v0.1.4, 6→v0.1.5, 7→v0.1.6, 8→v0.1.7, 9→v0.1.8
+- After Phase 9 ships, consider `v0.2.0` to mark "operator-grade complete for the solo path"
+
+## Cross-references
+
+- Audit input: in-conversation; reproduced in this doc's Audit Summary section
+- Phase 5 plan: `docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md`
+- Original substrate spec: `docs/superpowers/specs/2026-04-27-darken-installable-substrate-design.md`
+- Scion docs: https://googlecloudplatform.github.io/scion/hub-user/dashboard/, https://googlecloudplatform.github.io/scion/hub-admin/hub-server/

--- a/images/Makefile
+++ b/images/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY         ?= local
 TAG              ?= latest
-AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra
+BONES_SOURCE_PATH ?= $(HOME)/projects/bones
 
 # prebuild-bones: cross-compile the unified bones CLI for linux/arm64.
 # Required before running `make claude` because agent-infra and its dependency
@@ -31,7 +31,7 @@ prebuild-bones:
 	# agent-tasks pair) don't get COPY'd into the Docker image.
 	rm -rf claude/bin codex/bin pi/bin gemini/bin
 	mkdir -p claude/bin codex/bin pi/bin gemini/bin
-	cd $(AGENT_INFRA_PATH) && \
+	cd $(BONES_SOURCE_PATH) && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/bones ./cmd/bones && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/bones ./cmd/bones && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/bones ./cmd/bones && \

--- a/internal/substrate/data/images/Makefile
+++ b/internal/substrate/data/images/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY         ?= local
 TAG              ?= latest
-AGENT_INFRA_PATH ?= $(HOME)/projects/agent-infra
+BONES_SOURCE_PATH ?= $(HOME)/projects/bones
 
 # prebuild-bones: cross-compile the unified bones CLI for linux/arm64.
 # Required before running `make claude` because agent-infra and its dependency
@@ -31,7 +31,7 @@ prebuild-bones:
 	# agent-tasks pair) don't get COPY'd into the Docker image.
 	rm -rf claude/bin codex/bin pi/bin gemini/bin
 	mkdir -p claude/bin codex/bin pi/bin gemini/bin
-	cd $(AGENT_INFRA_PATH) && \
+	cd $(BONES_SOURCE_PATH) && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/claude/bin/bones ./cmd/bones && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/codex/bin/bones ./cmd/bones && \
 	  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(CURDIR)/pi/bin/bones ./cmd/bones && \

--- a/internal/substrate/data/templates/CLAUDE.md.tmpl
+++ b/internal/substrate/data/templates/CLAUDE.md.tmpl
@@ -4,6 +4,19 @@ This repo is initialized for the Darkish Factory orchestration substrate.
 By default, Claude Code in this repo operates as **the orchestrator** for
 the §7 pipeline running against this working repo.
 
+## On every session start
+
+Your VERY FIRST output to the operator must be the line:
+
+> 🔧 **darken orchestrator-mode primed.** substrate `{{.SubstrateHash12}}` · workers ready · awaiting intent.
+
+Then load and apply the `orchestrator-mode` skill before responding to
+the operator's actual task. The skill body lives at
+`.claude/skills/orchestrator-mode/SKILL.md` (scaffolded by `darken init`).
+
+This announcement is the operator's only signal that the session is
+in orchestrator mode. Don't skip it.
+
 **On session start, invoke the `orchestrator-mode` skill** to load the
 full §7 loop, role roster, escalation classifier, and host-mode protocol.
 Workers spawn as containerized subharnesses via `darken spawn`; their

--- a/templates/CLAUDE.md.tmpl
+++ b/templates/CLAUDE.md.tmpl
@@ -4,6 +4,19 @@ This repo is initialized for the Darkish Factory orchestration substrate.
 By default, Claude Code in this repo operates as **the orchestrator** for
 the §7 pipeline running against this working repo.
 
+## On every session start
+
+Your VERY FIRST output to the operator must be the line:
+
+> 🔧 **darken orchestrator-mode primed.** substrate `{{.SubstrateHash12}}` · workers ready · awaiting intent.
+
+Then load and apply the `orchestrator-mode` skill before responding to
+the operator's actual task. The skill body lives at
+`.claude/skills/orchestrator-mode/SKILL.md` (scaffolded by `darken init`).
+
+This announcement is the operator's only signal that the session is
+in orchestrator mode. Don't skip it.
+
 **On session start, invoke the `orchestrator-mode` skill** to load the
 full §7 loop, role roster, escalation classifier, and host-mode protocol.
 Workers spawn as containerized subharnesses via `darken spawn`; their


### PR DESCRIPTION
## Summary

Phase 5 of the darken DX roadmap. Closes the 5 gaps a live orchestrator session in \`~/projects/edgesync-fslite\` surfaced. Plus the unified DX-roadmap spec (Phases 5-9) and Phase 6's plan committed alongside.

After this merges + tag v0.1.4 + brew upgrade: \`darken init <fresh-repo> && cd <fresh-repo> && claude code\` produces a working orchestrator session that announces itself, has skills loaded, has bones workspace bootstrapped, and can spawn workers without errors.

## What lands

### Implementation (7 commits)

**Task 1 — \`spawn.go\` extracts scripts from embedded substrate** (\`285d18d\` + \`89ab42e\` refactor)
- New \`runSubstrateScript\` reads scripts via Phase 1+2 substrate resolver, writes to temp file with exec perms, runs, cleans up
- Extracted shared helper \`extractSubstrateScript\` to dedupe between production and test-only variants
- Replaces the two \`runShell(filepath.Join(root, \"scripts\", ...))\` calls in \`runSpawn\`

**Task 2 — \`bootstrap.go\` same fix** (\`531650a\` + \`43270de\` doc clarification)
- \`ensureHubSecrets\` and \`ensureAllSkillsStaged\` use \`runSubstrateScript\`
- New \`ensureAllSkillsStagedFromEmbedded\` fallback when working repo has no \`.scion/templates/\`
- Doc clarifications on fallback + embedded-error semantics

**Task 3 — new \`darken status\` subcommand** (\`2f3b083\`)
- Prints \`[darken: orchestrator-mode | substrate <12-hex>]\` for Claude Code's statusLine
- Fast — no external commands, just embedded hash

**Task 4 — \`darken init\` scaffolds skills + statusLine + gitignore + bones init** (\`09e38fb\`)
- Updated CLAUDE.md.tmpl with directive announcing orchestrator mode + substrate hash on first response
- \`.claude/skills/{orchestrator-mode,subagent-to-subharness}/SKILL.md\` extracted from embedded substrate
- \`.claude/settings.local.json\` with statusLine.command → \`darken status\`
- \`.gitignore\` appends (idempotent)
- \`bones init\` if bones is on PATH (soft-fail otherwise)
- All scaffolds idempotent — re-running darken init is safe

**Task 5 — Makefile path fix** (\`e3e6d98\`)
- \`AGENT_INFRA_PATH\` → \`BONES_SOURCE_PATH\` (default \`\$(HOME)/projects/bones\`)
- agent-infra was renamed to bones upstream

### Planning docs (3 commits)

- \`a25eb74\` — Phase 5 plan
- \`1fe884f\` — DX roadmap spec (Phases 5-9, approved in conversation)
- \`0c026f4\` — Phase 6 plan (next phase, ready when this merges)

## Substrate hash

\`551d7d7fcbcd\` → \`ef70558440dc\` (Task 4 added the announcement directive to CLAUDE.md.tmpl + Task 5 changed the embedded Makefile)

## Test plan

- [x] \`go test ./... -count=1\` — all 3 packages green (~30 tests including 6 new from this phase)
- [x] \`go vet ./...\`, \`gofmt -l cmd/ internal/\` — clean
- [x] \`make darken && bin/darken --help\` — \`status\` subcommand visible
- [x] \`bin/darken status\` — prints \`[darken: orchestrator-mode | substrate ef70558440dc]\`
- [x] \`bin/darken init /tmp/init-smoke\` — scaffolds CLAUDE.md, .claude/skills/, .claude/settings.local.json, .gitignore. \`bones init\` runs.
- [x] \`bash scripts/test-embed-drift.sh\` — PASS
- [x] End-to-end smoke against \`/tmp\` confirms all artifacts produced
- [ ] **Operator action post-merge:** tag v0.1.4 to ship via brew, then \`brew upgrade darken\`

## Operator action items

\`\`\`bash
git tag -a v0.1.4 -m \"darken v0.1.4 — init completeness + spawn resolver + statusLine\"
git push origin v0.1.4
gh run watch
\`\`\`

After v0.1.4 ships:
\`\`\`bash
brew upgrade darken
darken version  # confirm v0.1.4
darken status   # confirm new subcommand works
\`\`\`

## What Phase 6 picks up

Plan committed at \`docs/superpowers/plans/2026-04-28-darken-phase-6-init-verify-and-refresh.md\`. Closes audit items 6-8: \`darken doctor --init\`, \`darken init --refresh\`, init-time prereq checks. Branch off main after this merges.

## Cross-references

- Audit input: in-conversation; reproduced in spec doc
- Spec: \`docs/superpowers/specs/2026-04-28-darken-DX-roadmap-design.md\`
- Phase 5 plan: \`docs/superpowers/plans/2026-04-28-darken-phase-5-init-completeness.md\`
- Phase 6 plan: \`docs/superpowers/plans/2026-04-28-darken-phase-6-init-verify-and-refresh.md\`