### PR TITLE
Phase 6: init verify + refresh + prereq checks

### DIFF
--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -16,6 +16,20 @@ type check struct {
 }
 
 func runDoctor(args []string) error {
+	// New: --init triggers per-init scaffold verification (Phase 6).
+	for _, a := range args {
+		if a == "--init" {
+			root, err := repoRoot()
+			if err != nil {
+				return err
+			}
+			report, err := runInitDoctor(root)
+			fmt.Print(report)
+			return err
+		}
+	}
+
+	// Existing dispatch follows below — no change.
 	if len(args) >= 1 {
 		report, err := doctorHarness(args[0])
 		fmt.Println(report)

--- a/cmd/darken/doctor_test.go
+++ b/cmd/darken/doctor_test.go
@@ -92,3 +92,79 @@ func TestDoctorHarnessPostMortemMapsAuthError(t *testing.T) {
 		t.Fatalf("post-mortem should map auth error to stage-creds remediation, got %q", report)
 	}
 }
+
+func TestInitDoctor_PassesOnCompleteInit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Plant a complete init scaffold (matches what Phase 5's runInit produces).
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken orchestrator-mode\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"),
+		[]byte("---\nname: orchestrator-mode\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness", "SKILL.md"),
+		[]byte("---\nname: subagent-to-subharness\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "settings.local.json"),
+		[]byte(`{"statusLine":{"command":"darken status","type":"command"}}`), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".gitignore"),
+		[]byte(".scion/agents/\n.scion/skills-staging/\n.scion/audit.jsonl\n.claude/worktrees/\n"), 0o644)
+
+	report, err := runInitDoctor(tmp)
+	if err != nil {
+		t.Fatalf("expected init doctor to pass on complete scaffold; got: %v\nreport:\n%s", err, report)
+	}
+	for _, want := range []string{"OK", "CLAUDE.md", "orchestrator-mode", "subagent-to-subharness", "statusLine", ".gitignore"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
+	}
+}
+
+func TestInitDoctor_FailsOnMissingCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	// no CLAUDE.md planted
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when CLAUDE.md missing")
+	}
+	if !strings.Contains(report, "CLAUDE.md") {
+		t.Fatalf("report should call out CLAUDE.md: %s", report)
+	}
+	if !strings.Contains(report, "darken init") {
+		t.Fatalf("report should suggest `darken init`: %s", report)
+	}
+}
+
+func TestInitDoctor_FailsOnMissingSkills(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+	// skills NOT scaffolded
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when skills missing")
+	}
+	if !strings.Contains(report, "orchestrator-mode") {
+		t.Fatalf("report should call out orchestrator-mode skill: %s", report)
+	}
+}
+
+func TestInitDoctor_FailsOnMissingStatusLine(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"), []byte("name: orchestrator-mode"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness", "SKILL.md"), []byte("name: subagent-to-subharness"), 0o644)
+	// no settings.local.json planted
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected error when settings.local.json missing")
+	}
+	if !strings.Contains(report, "statusLine") && !strings.Contains(report, "settings.local.json") {
+		t.Fatalf("report should call out missing statusLine config: %s", report)
+	}
+}

--- a/cmd/darken/doctor_test.go
+++ b/cmd/darken/doctor_test.go
@@ -151,6 +151,21 @@ func TestInitDoctor_FailsOnMissingSkills(t *testing.T) {
 	}
 }
 
+func TestDoctor_InitFlagDispatchesToInitDoctor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+	// minimal init: just CLAUDE.md, missing skills → doctor --init should FAIL
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken\n"), 0o644)
+
+	out, err := captureStdout(func() error { return runDoctor([]string{"--init"}) })
+	if err == nil {
+		t.Fatalf("expected runDoctor --init to fail with missing skills; got nil err\noutput:\n%s", out)
+	}
+	if !strings.Contains(out, "orchestrator-mode") {
+		t.Fatalf("expected output to call out missing orchestrator-mode skill, got: %s", out)
+	}
+}
+
 func TestInitDoctor_FailsOnMissingStatusLine(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)

--- a/cmd/darken/init.go
+++ b/cmd/darken/init.go
@@ -17,6 +17,7 @@ func runInit(args []string) error {
 	flags := flag.NewFlagSet("init", flag.ContinueOnError)
 	dryRun := flags.Bool("dry-run", false, "print actions without executing")
 	force := flags.Bool("force", false, "overwrite existing CLAUDE.md")
+	refresh := flags.Bool("refresh", false, "re-scaffold skills/statusLine/.gitignore without clobbering CLAUDE.md (use --force with --refresh to also regenerate CLAUDE.md)")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -41,18 +42,36 @@ func runInit(args []string) error {
 		exists = true
 	}
 
+	// Decision matrix for whether to write CLAUDE.md.
+	// --refresh + --force: explicit regeneration → write
+	// --refresh alone:     preserve operator customizations → skip
+	// initial init + --force:  force overwrite → write
+	// initial init + exists:   skip (preserve existing)
+	// initial init + missing:  write
+	var writeCLAUDE bool
+	switch {
+	case *refresh && *force:
+		writeCLAUDE = true
+	case *refresh:
+		writeCLAUDE = false
+	case *force:
+		writeCLAUDE = true
+	case !exists:
+		writeCLAUDE = true
+	default:
+		writeCLAUDE = false
+	}
+
 	if *dryRun {
-		if exists && !*force {
-			fmt.Printf("would skip %s (already exists; use --force to overwrite)\n", claudePath)
-		} else {
+		if writeCLAUDE {
 			fmt.Printf("would create %s\n", claudePath)
+		} else {
+			fmt.Printf("would skip %s (already exists; use --force to overwrite)\n", claudePath)
 		}
 		return nil
 	}
 
-	if exists && !*force {
-		fmt.Printf("skipped %s (already exists; use --force to overwrite)\n", claudePath)
-	} else {
+	if writeCLAUDE {
 		body, err := renderCLAUDE(target)
 		if err != nil {
 			return err
@@ -61,6 +80,12 @@ func runInit(args []string) error {
 			return err
 		}
 		fmt.Printf("wrote %s\n", claudePath)
+	} else if exists {
+		if *refresh {
+			fmt.Printf("preserved %s (use --refresh --force to regenerate)\n", claudePath)
+		} else {
+			fmt.Printf("skipped %s (already exists; use --force to overwrite)\n", claudePath)
+		}
 	}
 
 	// Scaffold skills (project-local copies of the embedded host-mode skills)

--- a/cmd/darken/init.go
+++ b/cmd/darken/init.go
@@ -22,6 +22,11 @@ func runInit(args []string) error {
 		return err
 	}
 
+	// Phase 6: prereq check — fail fast if bones/scion/docker missing.
+	if err := verifyInitPrereqs(); err != nil {
+		return err
+	}
+
 	pos := flags.Args()
 	target := "."
 	if len(pos) > 0 {

--- a/cmd/darken/init_test.go
+++ b/cmd/darken/init_test.go
@@ -163,3 +163,78 @@ func TestInitSecondRunIsIdempotent(t *testing.T) {
 		t.Fatalf("second init mutated .gitignore (not idempotent):\nwas: %q\nnow: %q", body1, body2)
 	}
 }
+
+func TestInitRefresh_PreservesCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Initial init creates the scaffold.
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	// Operator customizes CLAUDE.md.
+	customCLAUDE := "# Custom CLAUDE.md\n\nMy own content here.\n"
+	if err := os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte(customCLAUDE), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --refresh should NOT overwrite CLAUDE.md.
+	if err := runInit([]string{"--refresh", tmp}); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(tmp, "CLAUDE.md"))
+	if string(got) != customCLAUDE {
+		t.Fatalf("CLAUDE.md should be preserved, got:\n%s", got)
+	}
+}
+
+func TestInitRefresh_UpdatesSkills(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	// Operator stomps on a skill with stale content.
+	skillPath := filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("STALE CONTENT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --refresh should re-extract from embedded substrate.
+	if err := runInit([]string{"--refresh", tmp}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(skillPath)
+	if string(got) == "STALE CONTENT" {
+		t.Fatal("skill body should have been refreshed from embedded substrate")
+	}
+	if !strings.Contains(string(got), "name: orchestrator-mode") {
+		t.Fatalf("refreshed skill missing frontmatter: %s", string(got)[:100])
+	}
+}
+
+func TestInitRefreshForce_OverwritesCLAUDE(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+	customCLAUDE := "# Custom\n"
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte(customCLAUDE), 0o644)
+
+	// --refresh --force regenerates CLAUDE.md.
+	if err := runInit([]string{"--refresh", "--force", tmp}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(tmp, "CLAUDE.md"))
+	if string(got) == customCLAUDE {
+		t.Fatal("--refresh --force should regenerate CLAUDE.md")
+	}
+	if !strings.Contains(string(got), "darken orchestrator-mode") {
+		t.Fatalf("regenerated CLAUDE.md missing template content: %s", got)
+	}
+}

--- a/cmd/darken/init_test.go
+++ b/cmd/darken/init_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestInitScaffoldsCLAUDE(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -29,6 +30,7 @@ func TestInitScaffoldsCLAUDE(t *testing.T) {
 }
 
 func TestInitIsIdempotent(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -42,6 +44,7 @@ func TestInitIsIdempotent(t *testing.T) {
 }
 
 func TestInitForceOverwrites(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -68,6 +71,7 @@ func TestInitForceOverwrites(t *testing.T) {
 }
 
 func TestInitDryRun(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -83,22 +87,22 @@ func TestInitDryRun(t *testing.T) {
 	}
 }
 
-// stubBones plants a no-op bones script at the front of PATH so
-// runBonesInit finds an executable and treats it as installed but
-// the script does nothing destructive in the test's tmp dir.
-func stubBones(t *testing.T) {
+// stubPrereqs plants no-op bones/scion/docker stubs on PATH for tests
+// that don't care about prereq checks (just want runInit to proceed).
+func stubPrereqs(t *testing.T) {
 	t.Helper()
-	dir := t.TempDir()
-	body := "#!/usr/bin/env bash\nexit 0\n"
-	path := filepath.Join(dir, "bones")
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
-		t.Fatal(err)
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion", "docker"} {
+		if err := os.WriteFile(filepath.Join(stubDir, b),
+			[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PATH", stubDir)
 }
 
 func TestInitScaffoldsSkills(t *testing.T) {
-	stubBones(t)
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 	if err := runInit([]string{tmp}); err != nil {
@@ -113,7 +117,7 @@ func TestInitScaffoldsSkills(t *testing.T) {
 }
 
 func TestInitWritesStatusLineSettings(t *testing.T) {
-	stubBones(t)
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 	if err := runInit([]string{tmp}); err != nil {
@@ -129,7 +133,7 @@ func TestInitWritesStatusLineSettings(t *testing.T) {
 }
 
 func TestInitAppendsGitignore(t *testing.T) {
-	stubBones(t)
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 	// Plant a pre-existing .gitignore to confirm append (not overwrite).
@@ -148,7 +152,7 @@ func TestInitAppendsGitignore(t *testing.T) {
 }
 
 func TestInitSecondRunIsIdempotent(t *testing.T) {
-	stubBones(t)
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 	if err := runInit([]string{tmp}); err != nil {
@@ -165,6 +169,7 @@ func TestInitSecondRunIsIdempotent(t *testing.T) {
 }
 
 func TestInitRefresh_PreservesCLAUDE(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -190,6 +195,7 @@ func TestInitRefresh_PreservesCLAUDE(t *testing.T) {
 }
 
 func TestInitRefresh_UpdatesSkills(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -217,6 +223,7 @@ func TestInitRefresh_UpdatesSkills(t *testing.T) {
 }
 
 func TestInitRefreshForce_OverwritesCLAUDE(t *testing.T) {
+	stubPrereqs(t)
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
@@ -236,5 +243,81 @@ func TestInitRefreshForce_OverwritesCLAUDE(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "darken orchestrator-mode") {
 		t.Fatalf("regenerated CLAUDE.md missing template content: %s", got)
+	}
+}
+
+func TestInit_FailsFastWhenBonesMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Replace PATH with a tmp dir that has scion + docker stubs but NO bones.
+	stubDir := t.TempDir()
+	for _, b := range []string{"scion", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when bones missing from PATH")
+	}
+	if !strings.Contains(err.Error(), "bones") {
+		t.Fatalf("error should mention bones: %v", err)
+	}
+	if !strings.Contains(err.Error(), "brew install") {
+		t.Fatalf("error should suggest install hint: %v", err)
+	}
+}
+
+func TestInit_FailsFastWhenScionMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when scion missing")
+	}
+	if !strings.Contains(err.Error(), "scion") {
+		t.Fatalf("error should mention scion: %v", err)
+	}
+}
+
+func TestInit_FailsFastWhenDockerMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	err := runInit([]string{tmp})
+	if err == nil {
+		t.Fatal("expected init to fail when docker missing")
+	}
+	if !strings.Contains(err.Error(), "docker") {
+		t.Fatalf("error should mention docker: %v", err)
+	}
+}
+
+func TestInit_PassesWhenAllPrereqsPresent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	stubDir := t.TempDir()
+	for _, b := range []string{"bones", "scion", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	t.Setenv("PATH", stubDir)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatalf("init should pass with all prereqs on PATH: %v", err)
 	}
 }

--- a/cmd/darken/init_verify.go
+++ b/cmd/darken/init_verify.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -105,6 +106,34 @@ func statusLineConfigValid(absPath string) error {
 	}
 	if cfg.StatusLine.Command == "" {
 		return fmt.Errorf("statusLine.command not set")
+	}
+	return nil
+}
+
+// prereqTool describes a binary the operator needs on PATH for darken
+// init to produce a working orchestrator-mode setup.
+type prereqTool struct {
+	name        string
+	installHint string
+}
+
+// verifyInitPrereqs returns a non-nil error listing all missing
+// prerequisite tools, with a one-liner install hint per tool. Called
+// at the top of runInit so failures surface upfront, not mid-spawn.
+func verifyInitPrereqs() error {
+	tools := []prereqTool{
+		{name: "bones", installHint: "brew install danmestas/tap/bones"},
+		{name: "scion", installHint: "see https://github.com/GoogleCloudPlatform/scion (make install)"},
+		{name: "docker", installHint: "install Docker Desktop or colima or podman"},
+	}
+	var missing []string
+	for _, t := range tools {
+		if _, err := exec.LookPath(t.name); err != nil {
+			missing = append(missing, fmt.Sprintf("  - %s not on PATH; install via: %s", t.name, t.installHint))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("darken init prereqs missing:\n%s", strings.Join(missing, "\n"))
 	}
 	return nil
 }

--- a/cmd/darken/init_verify.go
+++ b/cmd/darken/init_verify.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// initCheck describes a single required-file check inside an init'd repo.
+// failHint is shown when the check fails — should be a one-liner with the
+// remediation command the operator should run.
+type initCheck struct {
+	name     string
+	path     string
+	check    func(absPath string) error
+	failHint string
+}
+
+// runInitDoctor runs the per-init verification pass against the given
+// target directory. Returns a formatted report and an error if any
+// check failed. Mirrors the doctorBroad/doctorHarness pattern.
+func runInitDoctor(target string) (string, error) {
+	checks := []initCheck{
+		{
+			name:     "CLAUDE.md present",
+			path:     "CLAUDE.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init " + target + "` to scaffold",
+		},
+		{
+			name:     "orchestrator-mode skill scaffolded",
+			path:     ".claude/skills/orchestrator-mode/SKILL.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init --refresh` to extract from binary",
+		},
+		{
+			name:     "subagent-to-subharness skill scaffolded",
+			path:     ".claude/skills/subagent-to-subharness/SKILL.md",
+			check:    fileNonEmpty,
+			failHint: "run `darken init --refresh` to extract from binary",
+		},
+		{
+			name:     "settings.local.json with statusLine command",
+			path:     ".claude/settings.local.json",
+			check:    statusLineConfigValid,
+			failHint: "run `darken init --refresh` to recreate",
+		},
+		{
+			name:     ".gitignore has darken entries",
+			path:     ".gitignore",
+			check:    gitignoreHasDarkenEntries,
+			failHint: "run `darken init --refresh` to append entries",
+		},
+	}
+
+	var sb strings.Builder
+	var failed []string
+	for _, c := range checks {
+		abs := filepath.Join(target, c.path)
+		if err := c.check(abs); err != nil {
+			fmt.Fprintf(&sb, "FAIL  %s — %v\n", c.name, err)
+			fmt.Fprintf(&sb, "      remediation: %s\n", c.failHint)
+			failed = append(failed, c.name)
+		} else {
+			fmt.Fprintf(&sb, "OK    %s\n", c.name)
+		}
+	}
+
+	if len(failed) > 0 {
+		return sb.String(), fmt.Errorf("%d init checks failed: %s",
+			len(failed), strings.Join(failed, ", "))
+	}
+	return sb.String(), nil
+}
+
+// fileNonEmpty asserts the path exists and is non-zero size.
+func fileNonEmpty(absPath string) error {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("missing or inaccessible: %s", absPath)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("empty file: %s", absPath)
+	}
+	return nil
+}
+
+// statusLineConfigValid asserts settings.local.json parses as JSON and
+// has a statusLine.command field set.
+func statusLineConfigValid(absPath string) error {
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("missing settings.local.json")
+	}
+	var cfg struct {
+		StatusLine struct {
+			Command string `json:"command"`
+			Type    string `json:"type"`
+		} `json:"statusLine"`
+	}
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if cfg.StatusLine.Command == "" {
+		return fmt.Errorf("statusLine.command not set")
+	}
+	return nil
+}
+
+// gitignoreHasDarkenEntries asserts the canonical darken-related
+// gitignore entries are present.
+func gitignoreHasDarkenEntries(absPath string) error {
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("missing .gitignore")
+	}
+	want := []string{
+		".scion/agents/",
+		".scion/skills-staging/",
+		".claude/worktrees/",
+	}
+	var missing []string
+	for _, w := range want {
+		if !strings.Contains(string(body), w) {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing entries: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Phase 6 of the darken DX roadmap. Closes audit items 6-8.

After this merges + tag v0.1.5 + brew upgrade: operators can verify init, refresh after upgrades, and get fast feedback if prereqs are missing — without ever encountering a confusing mid-spawn error.

## What lands (4 commits)

**Task 1: \`runInitDoctor\` + 4 tests** (\`5ff2165\`)
- New \`cmd/darken/init_verify.go\` with \`runInitDoctor(target)\`
- 5 checks: CLAUDE.md, both host-mode skills, settings.local.json statusLine, .gitignore entries
- Each FAIL surfaces remediation hint
- Tests: complete-init PASS, missing-CLAUDE FAIL, missing-skills FAIL, missing-statusLine FAIL

**Task 2: \`darken doctor --init\` flag dispatch** (\`a1ab248\`)
- \`runDoctor\` checks args for \`--init\` flag, dispatches to \`runInitDoctor\`
- Falls through to existing per-harness / broad checks otherwise
- Test confirms the flag reaches runInitDoctor

**Task 3: \`darken init --refresh\`** (\`013ef6f\`)
- New \`--refresh\` flag re-runs scaffolding without overwriting CLAUDE.md
- \`--refresh --force\` regenerates CLAUDE.md from embedded template
- Skills, statusLine, gitignore, bones init all run on refresh (idempotent)
- 3 new tests cover: preserves CLAUDE on refresh, updates skills on refresh, --force regenerates

**Task 4: Init-time prereq checks** (\`7eb416a\`)
- New \`verifyInitPrereqs()\` runs at top of \`runInit\`
- Errors fast if bones, scion, or docker missing from PATH
- One-liner install hint per missing tool
- 4 new tests + \`stubPrereqs(t)\` helper for hermetic test isolation
- 11 existing TestInit* tests updated to call stubPrereqs

## Test plan

- [x] \`go test ./... -count=1\` — 27 tests in cmd/darken (4 InitDoctor + 4 prereq + 19 other Init/Doctor + 6 main/spawn/etc.)
- [x] \`go vet\`, \`gofmt -l cmd/ internal/\` — clean
- [x] End-to-end: \`darken init /tmp/foo\` → \`darken doctor --init\` reports OK; delete a skill → FAIL with remediation; \`darken init --refresh\` restores → OK again
- [x] \`bash scripts/test-embed-drift.sh\` — PASS
- [ ] **Operator action post-merge:** tag v0.1.5

## Operator action items

\`\`\`bash
git tag -a v0.1.5 -m \"darken v0.1.5 — init verify + refresh + prereq checks\"
git push origin v0.1.5
gh run watch
brew upgrade darken
darken doctor --init  # in any init'd repo to verify
\`\`\`

## What Phase 7 picks up

Phase 7 plan can be written when this merges. Scope: async \`darken spawn\` (returns at \"ready\" state), cold-start progress on stderr, \`--watch\` flag for legacy blocking behavior.