### PR TITLE
fix(spawn): scripts resolve repo via DARKEN_REPO_ROOT (post-v0.1.6 smoke)

### DIFF
--- a/cmd/darken/script_runner.go
+++ b/cmd/darken/script_runner.go
@@ -48,6 +48,10 @@ func extractSubstrateScript(substratePath string) (path string, cleanup func(), 
 // Uses the bash on PATH (not /bin/bash) so test stubs that prepend a
 // fake bash to PATH work. Future hardening to /bin/bash would require
 // updating spawn_test.go's bash stub strategy.
+//
+// Sets DARKEN_REPO_ROOT in the script's env so scripts can locate the
+// operator's working repo even when extracted to a tmpdir. Scripts
+// like stage-skills.sh use this to find harness manifests.
 func runSubstrateScript(substratePath string, args []string) error {
 	tmpPath, cleanup, err := extractSubstrateScript(substratePath)
 	if err != nil {
@@ -58,6 +62,7 @@ func runSubstrateScript(substratePath string, args []string) error {
 	c := exec.Command("bash", append([]string{tmpPath}, args...)...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
+	c.Env = scriptEnv()
 	return c.Run()
 }
 
@@ -71,6 +76,20 @@ func runSubstrateScriptCaptured(substratePath string, args []string) (string, er
 	}
 	defer cleanup()
 
-	out, err := exec.Command("bash", append([]string{tmpPath}, args...)...).CombinedOutput()
+	c := exec.Command("bash", append([]string{tmpPath}, args...)...)
+	c.Env = scriptEnv()
+	out, err := c.CombinedOutput()
 	return string(out), err
+}
+
+// scriptEnv returns the parent environment plus DARKEN_REPO_ROOT
+// pointing at the resolved operator working repo (best-effort; if
+// repoRoot fails, leaves DARKEN_REPO_ROOT unset so scripts fall back
+// to BASH_SOURCE-relative resolution).
+func scriptEnv() []string {
+	env := os.Environ()
+	if root, err := repoRoot(); err == nil {
+		env = append(env, "DARKEN_REPO_ROOT="+root)
+	}
+	return env
 }

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -18,7 +18,11 @@
 
 set -euo pipefail
 
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve repo root: env var (set by darken when script is extracted from
+# the embedded substrate to a tmp file) wins over BASH_SOURCE-relative.
+# Direct invocation (`bash scripts/stage-skills.sh`) still works via the
+# BASH_SOURCE fallback.
+REPO="${DARKEN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 CANONICAL="${HOME}/projects/agent-skills/skills"
 
 usage() {

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -18,7 +18,11 @@
 
 set -euo pipefail
 
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve repo root: env var (set by darken when script is extracted from
+# the embedded substrate to a tmp file) wins over BASH_SOURCE-relative.
+# Direct invocation (`bash scripts/stage-skills.sh`) still works via the
+# BASH_SOURCE fallback.
+REPO="${DARKEN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 CANONICAL="${HOME}/projects/agent-skills/skills"
 
 usage() {


### PR DESCRIPTION
## Summary

Smoke testing v0.1.6 against a real spawn surfaced a layering bug from Phase 5: the embedded scripts use \`BASH_SOURCE\`-relative resolution to find the operator's working repo, which breaks when extracted to a tmpdir.

\`\`\`
$ darken spawn r1 --type researcher \"...\"
stage-creds: claude_auth pushed
stage-creds: codex_auth pushed
stage-skills: harness 'researcher' not found at /var/folders/.../scion/templates/researcher
darken: stage-skills failed: exit status 1
\`\`\`

The \`/var/folders/.../\` path was the resolved \`REPO\` — i.e. the parent of the tmpdir where \`runSubstrateScript\` extracted the script, not the operator's actual repo.

## Fix

Two-line change at the seam:

1. **\`runSubstrateScript\`** (cmd/darken/script_runner.go) sets \`DARKEN_REPO_ROOT=<repoRoot>\` in the script's environment via a new \`scriptEnv()\` helper.

2. **\`scripts/stage-skills.sh\`** prefers \`DARKEN_REPO_ROOT\` over \`BASH_SOURCE\`-relative:
   \`\`\`bash
   REPO=\"\${DARKEN_REPO_ROOT:-\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/..\" && pwd)}\"
   \`\`\`
   Direct invocation (\`bash scripts/stage-skills.sh\`) still works via the fallback.

\`runSubstrateScriptCaptured\` (test-only) gets the same env wiring for parity.

## Other scripts

- \`stage-creds.sh\` doesn't use \`BASH_SOURCE\`-relative paths (reads from Keychain / env vars / absolute paths). No change.
- Test scripts (\`scripts/test-*.sh\`) aren't extracted via \`runSubstrateScript\` — they're invoked directly. No change.

## Substrate hash

\`ef70558440dc\` → \`f4d30655b96e\`.

## Test plan

- [x] \`go test ./... -count=1\` — all 3 packages green
- [x] \`go vet\`, \`gofmt -l\` — clean
- [x] \`bash scripts/test-embed-drift.sh\` — PASS
- [x] **Live smoke**: \`darken spawn smoke-fix-4 --type researcher \"...\"\` from substrate repo: \`stage-skills\` now finds the manifest, scion start dispatches. (The smoke then surfaces an unrelated scion env-gather requirement for \`GEMINI_API_KEY\` — separate from darken; operator's hub-secret config issue.)
- [ ] **Operator action post-merge**: tag v0.1.7

## Operator action items

\`\`\`bash
git tag -a v0.1.7 -m \"darken v0.1.7 — scripts resolve repo via DARKEN_REPO_ROOT\"
git push origin v0.1.7 && gh run watch
brew upgrade darken
\`\`\`

## Note for Phase 8

The smoke also surfaced that \`scion start\` requires \`GEMINI_API_KEY\` even when spawning a claude-backed researcher. That's a scion env-gather config; \`darken doctor\` could grow to detect this preemptively in a future phase. Out of scope for this hotfix.