### PR TITLE
fix(test): pick GOOS-appropriate opener in dashboard test

### DIFF
--- a/cmd/darken/dashboard_test.go
+++ b/cmd/darken/dashboard_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -49,7 +50,14 @@ Components:
   Hub API:         running
 `
 	stubScionServerStatus(t, statusOut)
-	logPath := stubOpener(t, "open")
+	// runDashboard picks the opener by GOOS: `open` on macOS, `xdg-open`
+	// on Linux. Mirror that here so the test exercises the same path
+	// the production code takes on the runner OS.
+	openerName := "open"
+	if runtime.GOOS == "linux" {
+		openerName = "xdg-open"
+	}
+	logPath := stubOpener(t, openerName)
 
 	if err := runDashboard(nil); err != nil {
 		t.Fatalf("dashboard failed: %v", err)


### PR DESCRIPTION
## Summary

Hotfix for a Phase 8 test bug that's been silently breaking releases since v0.1.8.

\`TestDashboard_DefaultURLOpened\` stubs the macOS \`open\` binary unconditionally, but the Linux CI runner uses \`xdg-open\` (per \`runtime.GOOS\` branching in \`runDashboard\`). The stub was never on PATH under the right name → real system \`xdg-open\` ran → exit 3 (no display) → goreleaser failed.

Net effect: v0.1.8 and v0.1.9 tags were created but the release workflow never published to the homebrew tap. The tap is still at v0.1.7.

## Fix

Branch on \`runtime.GOOS\` to pick the matching opener name. Mirrors what \`runDashboard\` itself does.

## Test plan

- [x] \`go test -run TestDashboard ./cmd/darken/... -count=1\` — 3/3 PASS on macOS
- [x] CI on this PR will exercise the Linux path

## Operator action post-merge

Re-tag the latest released code as v0.1.10 (skipping the broken v0.1.8 and v0.1.9 in the tap timeline; the GitHub tags exist but no tap formula was ever published for them).