### PR TITLE
fix(cli): make creds/skills/bootstrap work in init'd projects

### DIFF
--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/danmestas/darken/internal/substrate"
 )
@@ -66,51 +67,98 @@ func ensureHubSecrets() error {
 // Soft-fails per-harness so one missing skill canon doesn't abort
 // the whole bootstrap.
 func ensureAllSkillsStaged() error {
-	root, err := repoRoot()
+	templatesDir, cleanup, err := resolveTemplatesDir()
 	if err != nil {
 		return err
 	}
-	dirs, err := os.ReadDir(filepath.Join(root, ".scion", "templates"))
-	if err != nil {
-		// Any ReadDir failure (missing dir, permission denied, etc.) falls
-		// through to embedded. Permission-denied is unexpected here but
-		// safe to treat as "no project templates" — the operator's binary
-		// always carries a complete embedded substrate.
-		return ensureAllSkillsStagedFromEmbedded()
-	}
-	for _, d := range dirs {
-		if !d.IsDir() || d.Name() == "base" {
-			continue
+	defer cleanup()
+
+	return withTemplatesDirEnv(templatesDir, func() error {
+		dirs, err := os.ReadDir(templatesDir)
+		if err != nil {
+			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
 		}
-		if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
-			fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
+		for _, d := range dirs {
+			if !d.IsDir() || d.Name() == "base" {
+				continue
+			}
+			if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
+				fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
-// ensureAllSkillsStagedFromEmbedded iterates the embedded .scion/templates/
-// list when the working repo has no project-local templates dir.
-//
-// Returns the fs.ReadDir error directly (vs the project-layer path
-// which swallows per-template stage-skills errors). An embedded read
-// failure indicates a corrupt binary, which is fatal and should
-// surface; per-template failures are operator-config issues that
-// shouldn't abort the whole bootstrap.
-func ensureAllSkillsStagedFromEmbedded() error {
-	entries, err := fs.ReadDir(substrate.EmbeddedFS(), "data/.scion/templates")
+// withTemplatesDirEnv runs fn with DARKEN_TEMPLATES_DIR set to dir,
+// restoring the previous value (or unsetting) afterward. Used by
+// callers that need stage-skills.sh to read manifests from a specific
+// path (typically the resolved project-local-or-embedded location).
+func withTemplatesDirEnv(dir string, fn func() error) error {
+	prev, hadPrev := os.LookupEnv("DARKEN_TEMPLATES_DIR")
+	os.Setenv("DARKEN_TEMPLATES_DIR", dir)
+	defer func() {
+		if hadPrev {
+			os.Setenv("DARKEN_TEMPLATES_DIR", prev)
+		} else {
+			os.Unsetenv("DARKEN_TEMPLATES_DIR")
+		}
+	}()
+	return fn()
+}
+
+// resolveTemplatesDir returns a path containing per-harness manifest
+// dirs (each with scion-agent.yaml). Prefers the operator's project
+// templates if present; otherwise extracts the embedded substrate
+// templates to a tmpdir. The returned cleanup func is a no-op for the
+// project case and an os.RemoveAll for the embedded case.
+func resolveTemplatesDir() (string, func(), error) {
+	noop := func() {}
+
+	if root, err := repoRoot(); err == nil {
+		projectDir := filepath.Join(root, ".scion", "templates")
+		if info, statErr := os.Stat(projectDir); statErr == nil && info.IsDir() {
+			return projectDir, noop, nil
+		}
+	}
+
+	return extractEmbeddedTemplates()
+}
+
+// extractEmbeddedTemplates copies the embedded data/.scion/templates
+// tree to a tmpdir and returns its path. The cleanup func removes the
+// tmpdir; callers should defer it.
+func extractEmbeddedTemplates() (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "darken-templates-*")
 	if err != nil {
-		return err
+		return "", nil, err
 	}
-	for _, e := range entries {
-		if !e.IsDir() || e.Name() == "base" {
-			continue
+	cleanup := func() { os.RemoveAll(tmpDir) }
+
+	const root = "data/.scion/templates"
+	walkErr := fs.WalkDir(substrate.EmbeddedFS(), root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		if err := runSubstrateScript("scripts/stage-skills.sh", []string{e.Name()}); err != nil {
-			fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", e.Name(), err)
+		if path == root {
+			return nil
 		}
+		rel := strings.TrimPrefix(path, root+"/")
+		dst := filepath.Join(tmpDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		body, err := fs.ReadFile(substrate.EmbeddedFS(), path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dst, body, 0o644)
+	})
+	if walkErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("extract embedded templates: %w", walkErr)
 	}
-	return nil
+	return tmpDir, cleanup, nil
 }
 
 func finalDoctor() error {

--- a/cmd/darken/creds.go
+++ b/cmd/darken/creds.go
@@ -1,14 +1,8 @@
 package main
 
-import "path/filepath"
-
 func runCreds(args []string) error {
-	root, err := repoRoot()
-	if err != nil {
-		return err
-	}
 	if len(args) == 0 {
 		args = []string{"all"}
 	}
-	return runShell(filepath.Join(root, "scripts", "stage-creds.sh"), args...)
+	return runSubstrateScript("scripts/stage-creds.sh", args)
 }

--- a/cmd/darken/creds_test.go
+++ b/cmd/darken/creds_test.go
@@ -15,9 +15,9 @@ func TestCredsForwardsToScript(t *testing.T) {
 	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
 	_ = runCreds([]string{"claude"})
 	body, _ := os.ReadFile(log)
-	if !strings.Contains(string(body), "stage-creds.sh") {
-		t.Fatalf("creds did not invoke stage-creds.sh: %s", body)
-	}
+	// runSubstrateScript extracts the embedded script to a randomly-named
+	// tmpfile, so we no longer assert on "stage-creds.sh" in the path.
+	// The contract is that the forwarded backend arg reaches bash.
 	if !strings.Contains(string(body), "claude") {
 		t.Fatalf("backend arg `claude` not forwarded: %s", body)
 	}

--- a/cmd/darken/skills.go
+++ b/cmd/darken/skills.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"errors"
-	"path/filepath"
 )
 
 func runSkills(args []string) error {
 	if len(args) < 1 {
 		return errors.New("usage: darken skills <harness> [--diff|--add SKILL|--remove SKILL]")
 	}
-	root, err := repoRoot()
+	templatesDir, cleanup, err := resolveTemplatesDir()
 	if err != nil {
 		return err
 	}
-	return runShell(filepath.Join(root, "scripts", "stage-skills.sh"), args...)
+	defer cleanup()
+	return withTemplatesDirEnv(templatesDir, func() error {
+		return runSubstrateScript("scripts/stage-skills.sh", args)
+	})
 }

--- a/cmd/darken/skills_test.go
+++ b/cmd/darken/skills_test.go
@@ -15,8 +15,11 @@ func TestSkillsForwardsToScript(t *testing.T) {
 	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
 	_ = runSkills([]string{"sme", "--diff"})
 	body, _ := os.ReadFile(log)
-	if !strings.Contains(string(body), "stage-skills.sh") {
-		t.Fatalf("skills did not invoke stage-skills.sh: %s", body)
+	// runSubstrateScript extracts the embedded script to a randomly-named
+	// tmpfile, so we no longer assert on "stage-skills.sh" in the path.
+	// The contract is that harness + flags reach bash unchanged.
+	if !strings.Contains(string(body), "sme") {
+		t.Fatalf("harness `sme` not forwarded: %s", body)
 	}
 	if !strings.Contains(string(body), "--diff") {
 		t.Fatalf("--diff not forwarded: %s", body)

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -46,7 +46,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-MANIFEST_DIR="${REPO}/.scion/templates/${HARNESS}"
+# DARKEN_TEMPLATES_DIR is set by `darken bootstrap` to a tmpdir holding
+# the embedded substrate templates when the operator's project doesn't
+# carry its own .scion/templates/. Direct invocations (e.g. operator
+# running `bash scripts/stage-skills.sh researcher` from the darken
+# source repo) fall back to ${REPO}/.scion/templates which is the
+# original behavior.
+TEMPLATES_DIR="${DARKEN_TEMPLATES_DIR:-${REPO}/.scion/templates}"
+MANIFEST_DIR="${TEMPLATES_DIR}/${HARNESS}"
 if [[ ! -d "${MANIFEST_DIR}" ]]; then
   echo "stage-skills: harness '${HARNESS}' not found at ${MANIFEST_DIR}" >&2
   exit 1

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -46,7 +46,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-MANIFEST_DIR="${REPO}/.scion/templates/${HARNESS}"
+# DARKEN_TEMPLATES_DIR is set by `darken bootstrap` to a tmpdir holding
+# the embedded substrate templates when the operator's project doesn't
+# carry its own .scion/templates/. Direct invocations (e.g. operator
+# running `bash scripts/stage-skills.sh researcher` from the darken
+# source repo) fall back to ${REPO}/.scion/templates which is the
+# original behavior.
+TEMPLATES_DIR="${DARKEN_TEMPLATES_DIR:-${REPO}/.scion/templates}"
+MANIFEST_DIR="${TEMPLATES_DIR}/${HARNESS}"
 if [[ ! -d "${MANIFEST_DIR}" ]]; then
   echo "stage-skills: harness '${HARNESS}' not found at ${MANIFEST_DIR}" >&2
   exit 1


### PR DESCRIPTION
## Summary

Two substrate-resolver bugs that surface in real-world use against a project that ran `darken init` (i.e. not the darken source clone). Hit during a smoke session in `~/projects/edgesync-fslite`.

### Bug 1 — `darken creds` (and `darken skills`) shell out to non-existent paths

```
$ darken creds
bash: /Users/dmestas/projects/edgesync-fslite/scripts/stage-creds.sh: No such file or directory
darken: exit status 127
```

`runCreds` and `runSkills` were calling `runShell(filepath.Join(root, "scripts", "<name>.sh"), ...)`. The Phase 5 substrate-resolver migration converted `runSpawn` to `runSubstrateScript` (which extracts embedded scripts to a tmpfile) but missed these two. Fix: switch both to `runSubstrateScript`.

### Bug 2 — `darken bootstrap` per-harness `stage-skills.sh` fails

```
stage-skills: harness 'admin' not found at /Users/dmestas/projects/edgesync-fslite/.scion/templates/admin
bootstrap: stage-skills admin failed: exit status 1
... (×13 more)
```

`stage-skills.sh` hard-codes `MANIFEST_DIR=${REPO}/.scion/templates/<harness>`, but `darken init` doesn't scaffold those templates — they only live in the embedded substrate.

**Fix:** introduce `DARKEN_TEMPLATES_DIR` env var. `darken bootstrap` and `darken skills` now resolve a templates dir (project-local `<repo>/.scion/templates/` if present, otherwise extract embedded substrate templates to a tmp dir) and export the path so the script reads from the right place. Direct invocations (operator running `bash scripts/stage-skills.sh researcher` from the darken source repo) keep their existing default of `${REPO}/.scion/templates`.

New helpers in `cmd/darken/bootstrap.go`:
- `resolveTemplatesDir() (string, func(), error)` — project-first, embedded fallback
- `extractEmbeddedTemplates() (string, func(), error)` — walks `data/.scion/templates/` from the substrate to a tmpdir
- `withTemplatesDirEnv(dir, fn) error` — env-var hygiene wrapper

## Test plan

- [x] `go test ./... -count=1` — all green; updated `creds_test.go` + `skills_test.go` for the substrate-extraction path
- [x] Smoke in `/tmp/<git-repo>`: `darken init` → `darken creds claude` → `darken skills researcher` all succeed without `scripts/` or `.scion/templates/` in the operator's repo
- [x] `darken bootstrap` from a non-darken-source project no longer prints 14 `stage-skills` failures

## Operator action post-merge

Tag `v0.1.12`. (Or roll into `v0.2.0` per the DX roadmap.)

## Known scope gap (not fixed here, follow-up)

`darken skills <harness> --add SKILL` / `--remove SKILL` mutate the manifest. When the resolved templates dir is the embedded-extracted tmpdir, the mutation is lost on cleanup. Practical impact: an operator running `--add` against a project that hasn't customized its templates yet won't see the change persist. Out of scope for this hotfix; future fix should require project-local templates for mutation modes (or copy embedded → project on first `--add`).