### PR TITLE
docs: move CLI reference to docs/CLI.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ You are running inside the Darkish Factory orchestration substrate. By default i
 
 ## Substrate
 
-- **`bin/darken`** (build with `make darken`) — operator CLI. See README's CLI Reference for the full surface (~19 commands across Lifecycle / Operations / Inspection / Targeted setup / Authoring). The `darken orchestrate` subcommand prints the orchestrator skill body for piping into a fresh session.
+- **`bin/darken`** (build with `make darken`) — operator CLI. See [docs/CLI.md](docs/CLI.md) for the full surface (~19 commands across Lifecycle / Operations / Inspection / Targeted setup / Authoring). The `darken orchestrate` subcommand prints the orchestrator skill body for piping into a fresh session.
 - **`.scion/templates/<role>/`** — 13 harness manifests. The `orchestrator` template is for the containerized orchestrator deployment (Mode A); host mode (Mode B, this CLAUDE.md) uses the skill instead.
 - **`.scion/skills-staging/<role>/`** — per-harness skill bundles, mounted read-only into containers.
 - **`scion server` must be running.** `scion list` shows live agents.

--- a/README.md
+++ b/README.md
@@ -43,61 +43,7 @@ Open Claude Code in the project; CLAUDE.md auto-loads the orchestrator-mode skil
 
 ## CLI Reference
 
-`darken --help` lists everything in registration order. The grouping below is by purpose.
-
-### Lifecycle
-
-Use these for the standard project lifecycle.
-
-| Command | Purpose |
-|---|---|
-| `darken setup` | One-shot fresh-repo onboarding (init + bootstrap) |
-| `darken upgrade-init` | Refresh project scaffolds after `brew upgrade darken` |
-| `darken uninstall-init` | Remove project scaffolds (preserves customizations + .scion/ runtime state) |
-| `darken init` | Project-only scaffolds (CLAUDE.md, .claude/skills/, .gitignore). Prefer `setup` for first-time use. |
-
-### Operations (the §7 loop)
-
-Run, watch, and recover sub-harness workers.
-
-| Command | Purpose |
-|---|---|
-| `darken spawn <name> --type <role> [task]` | Start an agent (async; default: returns at "ready") |
-| `darken redispatch <name>` | Kill + re-spawn an agent with the same role |
-| `darken list` | Pass-through to `scion list` |
-| `darken apply` | Review + apply darwin recommendations |
-
-### Inspection
-
-Check state, recent decisions, and version coherence.
-
-| Command | Purpose |
-|---|---|
-| `darken doctor [--init \| <harness>]` | Preflight + post-mortem health checks |
-| `darken status` | One-line statusLine output (mode + substrate hash) |
-| `darken dashboard` | Open scion's web UI in the default browser |
-| `darken history` | Tabular view of `.scion/audit.jsonl` |
-| `darken version` | Binary version + embedded substrate hash |
-
-### Targeted setup
-
-Use these for surgical operations when full `setup` is overkill.
-
-| Command | Purpose |
-|---|---|
-| `darken bootstrap` | Machine prereqs + per-harness skill staging |
-| `darken creds [<backend>]` | Refresh hub secrets |
-| `darken images` | Wrap `make -C images` |
-| `darken skills <harness> [--diff \| --add SKILL \| --remove SKILL]` | Manage staged skills per harness |
-
-### Authoring
-
-| Command | Purpose |
-|---|---|
-| `darken create-harness <name>` | Scaffold a new harness directory |
-| `darken orchestrate` | Print host-mode orchestrator skill body (for piping into a fresh Claude Code session) |
-
-`darken doctor` runs preflight + per-harness checks. `darken doctor <role>` shows which substrate layer (override / project / embedded) served that role's manifest.
+See [docs/CLI.md](docs/CLI.md) for the grouped command reference (Lifecycle / Operations / Inspection / Targeted setup / Authoring). `darken --help` lists everything in registration order.
 
 ### Customizing the substrate
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,57 @@
+# `darken` CLI Reference
+
+`darken --help` lists everything in registration order. The grouping below is by purpose.
+
+## Lifecycle
+
+Use these for the standard project lifecycle.
+
+| Command | Purpose |
+|---|---|
+| `darken setup` | One-shot fresh-repo onboarding (init + bootstrap) |
+| `darken upgrade-init` | Refresh project scaffolds after `brew upgrade darken` |
+| `darken uninstall-init` | Remove project scaffolds (preserves customizations + .scion/ runtime state) |
+| `darken init` | Project-only scaffolds (CLAUDE.md, .claude/skills/, .gitignore). Prefer `setup` for first-time use. |
+
+## Operations (the §7 loop)
+
+Run, watch, and recover sub-harness workers.
+
+| Command | Purpose |
+|---|---|
+| `darken spawn <name> --type <role> [task]` | Start an agent (async; default: returns at "ready") |
+| `darken redispatch <name>` | Kill + re-spawn an agent with the same role |
+| `darken list` | Pass-through to `scion list` |
+| `darken apply` | Review + apply darwin recommendations |
+
+## Inspection
+
+Check state, recent decisions, and version coherence.
+
+| Command | Purpose |
+|---|---|
+| `darken doctor [--init \| <harness>]` | Preflight + post-mortem health checks |
+| `darken status` | One-line statusLine output (mode + substrate hash) |
+| `darken dashboard` | Open scion's web UI in the default browser |
+| `darken history` | Tabular view of `.scion/audit.jsonl` |
+| `darken version` | Binary version + embedded substrate hash |
+
+## Targeted setup
+
+Use these for surgical operations when full `setup` is overkill.
+
+| Command | Purpose |
+|---|---|
+| `darken bootstrap` | Machine prereqs + per-harness skill staging |
+| `darken creds [<backend>]` | Refresh hub secrets |
+| `darken images` | Wrap `make -C images` |
+| `darken skills <harness> [--diff \| --add SKILL \| --remove SKILL]` | Manage staged skills per harness |
+
+## Authoring
+
+| Command | Purpose |
+|---|---|
+| `darken create-harness <name>` | Scaffold a new harness directory |
+| `darken orchestrate` | Print host-mode orchestrator skill body (for piping into a fresh Claude Code session) |
+
+`darken doctor` runs preflight + per-harness checks. `darken doctor <role>` shows which substrate layer (override / project / embedded) served that role's manifest.


### PR DESCRIPTION
## Summary

The grouped CLI reference belongs under `docs/`, not inline in the README. v0.1.13 misread "docs section" as "README section"; this PR relocates the content.

## Changes

- New `docs/CLI.md` carrying the full grouped reference (Lifecycle / Operations / Inspection / Targeted setup / Authoring — 19 subcommands)
- `README.md` keeps its `## CLI Reference` H2 but the body collapses to a brief pointer (`See [docs/CLI.md](docs/CLI.md)`). The `Customizing the substrate` and `Updating` H3 subsections stay in the README, untouched
- `CLAUDE.md` substrate bullet pointer repointed at `docs/CLI.md`

## Test plan

- [x] `git diff --stat` confirms only the three doc files changed
- [x] No code changes; `go test ./...` impact = nil

## Operator action post-merge

No re-tag — this rides into the next functional release.