### PR TITLE
fix(setup): unblock darken setup on Mac Docker Desktop

### DIFF
--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -8,3 +8,5 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/base/scion-agent.yaml
+++ b/.scion/templates/base/scion-agent.yaml
@@ -8,3 +8,5 @@ default_harness_config: claude
 model: claude-sonnet-4-6
 max_turns: 50
 max_duration: 3600
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/darwin/scion-agent.yaml
+++ b/.scion/templates/darwin/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/darwin/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/designer/scion-agent.yaml
+++ b/.scion/templates/designer/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/designer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/planner-t1/scion-agent.yaml
+++ b/.scion/templates/planner-t1/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t1/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/planner-t2/scion-agent.yaml
+++ b/.scion/templates/planner-t2/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t2/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/planner-t3/scion-agent.yaml
+++ b/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/planner-t4/scion-agent.yaml
+++ b/.scion/templates/planner-t4/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t4/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/researcher/scion-agent.yaml
+++ b/.scion/templates/researcher/scion-agent.yaml
@@ -8,3 +8,5 @@ model: claude-sonnet-4-6
 max_turns: 30
 max_duration: "1h"
 detached: false
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/reviewer/scion-agent.yaml
+++ b/.scion/templates/reviewer/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/reviewer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/sme/scion-agent.yaml
+++ b/.scion/templates/sme/scion-agent.yaml
@@ -17,3 +17,5 @@ volumes:
     read_only: true
 # Codex auth comes from the user-scope hub secret 'codex_auth' (set via:
 # scion hub secret set --type file --target /home/scion/.codex/auth.json codex_auth @~/.codex/auth.json)
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/.scion/templates/verifier/scion-agent.yaml
+++ b/.scion/templates/verifier/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/verifier/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -44,7 +44,7 @@ func runSpawn(args []string) error {
 		cmd = append(cmd, "--harness", *backend, "--image", image)
 	}
 	if len(posArgs) > 0 {
-		cmd = append(cmd, "--notify", posArgs[0])
+		cmd = append(cmd, posArgs...)
 	}
 	if *watch {
 		cmd = append(cmd, "--attach")

--- a/docs/superpowers/specs/2026-04-28-bones-inter-harness-comms-design.md
+++ b/docs/superpowers/specs/2026-04-28-bones-inter-harness-comms-design.md
@@ -1,0 +1,237 @@
+# Bones-Mediated Inter-Harness Communication
+
+**Status:** approved (in-conversation, 2026-04-28) — implementation deferred
+**Author:** dmestas
+**Source PRs:** TBD
+**Related specs:**
+- `2026-04-28-remote-human-comms-deferral-design.md` (defines the envelope schema this spec consumes)
+- `2026-04-28-roles-bases-template-collapse-design.md`
+
+## Context
+
+Today, Darkish Factory worker harnesses communicate via a single host-local file: `.scion/audit.jsonl`. The orchestrator (host-mode Claude Code) reads this file directly, and `scion look <agent>` exposes worker output. This works because every worker container shares one host's filesystem.
+
+This breaks the moment harnesses live in heterogeneous topologies:
+
+- Some workers in local Docker on the operator's laptop.
+- Some workers as Kubernetes Pods in a remote cluster.
+- Some workers on a teammate's broker.
+- Eventually: workers reachable only via Scion Hub WebSocket Control Channel (NAT-traversed).
+
+A worker on a remote broker cannot read or write `.scion/audit.jsonl` on the operator's laptop. Cross-host inter-harness comms requires a transport, not a shared file.
+
+## Goal
+
+Agents, orchestrators, and operators can exchange structured messages **regardless of where the harness physically runs**, using a stable in-container CLI (`bones msg`) whose backend transport is swappable without changing caller code.
+
+## Background — what Scion already gives us
+
+From `contributing/architecture/`, `concepts/`, `hub-user/messaging/`, `hub-user/runtime-broker/`:
+
+| Primitive | Where it lives | What it gives us |
+|---|---|---|
+| `runtime.Exec(ctx, id, cmd)` | Every Scion runtime (Docker, Podman, Apple, K8s) | Run an arbitrary command inside any agent container — even on a remote broker — through the same Go interface. |
+| WebSocket Control Channel | Hub ↔ Broker | Tunnels HTTP requests across NATs/firewalls. Message types: `request/response/event/stream_open/...`. HMAC-SHA256 auth. |
+| Message Broker Plugin | `hashicorp/go-plugin` over gRPC | Pluggable backends for "agent notifications and structured messaging" (docs: foundational stage). |
+| Hub Inbox Tray + SSE | Hub web UI | Real-time delivery to humans (deferred per spec #1). |
+
+`bones` is the unified CLI baked into every container image (`bones init|tasks|repo|...`), pre-built from `~/projects/agent-infra/cmd/bones`. It is the natural place for a `msg` subcommand — already on PATH, already compiled per-arch, already part of the smoke test (`images/<backend>/test-bones.sh`).
+
+## Goals
+
+After all phases ship:
+
+- Any worker can post a message addressed to another worker by role/name and have it delivered, regardless of broker location.
+- Any worker can post a status/notification to the orchestrator without writing to a host file directly.
+- The host-mode operator gets the same `darken inbox <agent>` view they have today.
+- Migration to Mode A (Hub mode) requires no caller-code change — only an env var swap (`BONES_MSG_ENDPOINT`).
+
+## Non-goals
+
+- Building a general pub/sub message bus.
+- Implementing exactly-once delivery semantics. At-least-once with idempotency keys (`corr_id` / message `id`) is sufficient.
+- Replacing `.scion/audit.jsonl` immediately — Phase A keeps it as the backing store.
+- Encrypting messages in transit beyond what the transport already provides (TLS for HTTP, HMAC for Hub channel).
+- Inter-grove messaging. Scope is intra-grove only; per Scion's identity model, agents can only reach peers within `grove--agent` boundary.
+
+## Envelope schema
+
+Defined fully in spec #1 (remote-human-comms-deferral). Reproduced here for reference:
+
+```json
+{
+  "schema_version": "1",
+  "id": "uuid-v4",
+  "ts": "<RFC3339>",
+  "from": {"kind": "agent|orchestrator|operator", "name": "...", "role": "...", "grove": "..."},
+  "to":   {"kind": "agent|orchestrator|operator|broadcast", "name": "...", "role": null},
+  "severity": "info|warn|error|urgent",
+  "kind": "report|question|status|ask_user|notification",
+  "subject": "...",
+  "body": "...",
+  "actionable": true,
+  "corr_id": "...",
+  "links": [...]
+}
+```
+
+The schema is a strict subset of Scion's Inbox / Discord webhook payload shape, so Phase C transports require no transform.
+
+## CLI surface (`bones msg`)
+
+Lives in `~/projects/agent-infra/cmd/bones/msg/` (new package). Subcommands:
+
+```
+bones msg send --to <name|role> --kind <kind> --severity <sev> --subject "..." [--body @file] [--corr <id>]
+bones msg recv [--for <name>] [--since <ts>] [--limit N]    # one-shot
+bones msg tail [--for <name>] [--since <ts>]                # streaming (long-poll or SSE)
+bones msg poll [--for <name>] --until <kind|corr_id>        # block until match
+bones msg ack  <message-id>                                  # mark read
+bones msg deliver --payload <stdin|file>                     # internal: receive a pushed message
+```
+
+`bones msg` reads its endpoint from env in priority order:
+
+1. `BONES_MSG_ENDPOINT` — explicit override (Phase B+).
+2. `BONES_MSG_FILE` — path to JSONL store (Phase A; default `.scion/audit.jsonl` mounted into container).
+3. Default: stderr-error with "no transport configured."
+
+`from` is auto-populated from `$SCION_AGENT_NAME`, `$SCION_AGENT_ROLE`, `$SCION_GROVE_ID` (already injected by Scion per architecture docs).
+
+## Phase A — Extract the API (no behavior change)
+
+**Outcome**: same single-host topology, but every read/write goes through a stable CLI surface and conforms to the envelope schema.
+
+### Changes
+
+1. **Add `bones msg` subcommand** (in `agent-infra/cmd/bones/msg/`) that wraps file I/O against `BONES_MSG_FILE` (default `/workspace/.scion/audit.jsonl` since `/workspace` is the bind-mounted host file).
+2. **Migrate orchestrator-side audit reads** in `bin/darken` to read messages via the same JSONL format with the new envelope schema. Existing audit lines need a one-time backfill — write a small migrator that wraps legacy lines into envelopes (mark `schema_version: "0"` if pre-existing).
+3. **Add `darken inbox <agent>`** that reads & filters envelopes by `to.name`, `corr_id`, severity, etc. — replaces ad-hoc `scion look` for messaging concerns. `scion look` continues to work for raw container output.
+4. **Update images smoke test**: `test-bones.sh` already verifies `bones --help` runs cleanly; extend to `bones msg --help`.
+
+### Acceptance
+
+- A worker can `bones msg send --to orchestrator --kind status --subject "PR ready"` and the orchestrator sees it via `darken inbox orchestrator`.
+- All envelope fields populate correctly from env.
+- Legacy `.scion/audit.jsonl` lines are still readable (migrator covers them).
+
+### What does NOT change
+
+- Workers still write to a host-mounted file. No network transport yet.
+- Cross-broker scenarios still don't work — but the API contract is now stable, so callers won't break in Phase B.
+
+## Phase B — Host-bridged HTTP transport
+
+**Outcome**: workers running on different brokers (local Docker + remote K8s, etc.) can reach each other through an orchestrator-side router, **without requiring Scion Hub mode**.
+
+### Architecture
+
+```
+                ┌─────────────────────────────────┐
+                │   darken-msg-router (host)      │
+                │   listens on TCP :9810          │
+                │   persists to .scion/audit.jsonl│
+                │   routes by (grove, recipient)  │
+                └────┬──────────────────┬─────────┘
+                     │                  │
+       host.docker.internal      kubectl exec / runtime.Exec
+                     │                  │
+              ┌──────▼──────┐    ┌──────▼─────────┐
+              │ local Docker│    │ remote K8s pod │
+              │  (bones msg)│    │   (bones msg)  │
+              └─────────────┘    └────────────────┘
+```
+
+### Components
+
+**`darken-msg-router`** — small Go service launched alongside `darken init` (or on demand via `darken msg-router start`):
+
+- HTTP server on a configurable port (default 9810). Endpoints:
+  - `POST /v1/send` — accepts envelope, persists, queues delivery.
+  - `GET /v1/recv?for=<name>&since=<ts>&limit=N` — long-poll fetch.
+  - `GET /v1/tail?for=<name>` — SSE stream.
+  - `POST /v1/ack` — mark read.
+  - `GET /healthz`.
+- Persistence: append-only `.scion/audit.jsonl` (same file Phase A used). Optional SQLite index for fast `since`/`recipient` queries.
+- Delivery: pull-based (recipients poll via `bones msg tail`). No push needed in Phase B.
+- Auth: HMAC token issued at agent provisioning time, injected as `BONES_MSG_TOKEN`. Router signs responses; workers verify.
+
+### Container reachability
+
+Three cases. The router defaults to listening on the host's `0.0.0.0:9810`; the network configuration determines reachability:
+
+| Worker location | How worker reaches router | Implementation |
+|---|---|---|
+| Local Docker | `host.docker.internal:9810` | Already works on Docker Desktop macOS/Windows. On Linux, set `--add-host=host.docker.internal:host-gateway` in the runtime args. |
+| Local Podman | `host.containers.internal:9810` | Native in Podman ≥ 4.0. |
+| Remote K8s | Pull-based via `runtime.Exec(podID, ["bones","msg","deliver","--payload",b64])` | The orchestrator-side router pushes deliveries to remote pods using Scion's Runtime interface — no inbound reachability needed. |
+| Apple `container` | Set `BONES_MSG_ENDPOINT` to the host's LAN IP. | Documented in operator setup. |
+
+The K8s case uses `runtime.Exec` as a unidirectional push: when a message arrives for a recipient on a remote broker, the router walks the agent registry (Scion's Hub or local cache), finds the broker, and exec's a `bones msg deliver` command inside the recipient container to drop the payload at a known path (`/run/scion/inbox/<id>.json`). The recipient's `bones msg tail` watches that directory.
+
+### Changes
+
+1. **New binary**: `darken-msg-router` in `cmd/darken-msg-router/` (Go). Imports `pkg/runtime` from the Scion source tree to reuse `runtime.Exec` for K8s push.
+2. **Lifecycle hook**: `darken init` provisions an HMAC token, writes the router config, optionally starts the router via systemd / launchd.
+3. **Bones backend**: add `bones msg` HTTP transport. Selected when `BONES_MSG_ENDPOINT` is set (overrides file backend). Falls back to file backend if router is unreachable (graceful degradation).
+4. **Per-agent provisioning**: `bin/darken spawn` injects `BONES_MSG_ENDPOINT=http://<host-gateway>:9810` and `BONES_MSG_TOKEN=...` into the container env.
+
+### Security
+
+- HMAC token per agent, scoped by `grove--agent` (matches Scion's identity boundary).
+- Router refuses messages from agents whose `from` doesn't match their token's identity.
+- TLS optional in Phase B (loopback / LAN). Mandatory if router ever binds to a non-loopback interface.
+- Persistence file remains chmod 600.
+
+### Acceptance
+
+- A worker on local Docker can `bones msg send --to <name>` and a worker on a remote K8s broker receives it within ~5s of the next `tail`/`poll`.
+- Router survives Claude Code session restart (state is in `.scion/audit.jsonl`).
+- File backend still works when router is down.
+
+## Phase C — Mode A graduation
+
+**Outcome**: when (if) we go Mode A, swap the router for Scion's Message Broker Plugin. Caller code unchanged.
+
+### Changes
+
+1. **Implement a Message Broker Plugin** (`darkish-broker-plugin`) that satisfies Scion's plugin contract (gRPC service over `hashicorp/go-plugin`). It accepts the same envelope shape and routes through the Hub WebSocket Control Channel.
+2. **Bones backend**: when `BONES_MSG_ENDPOINT=hub://...`, route to the plugin's gRPC socket. (`hashicorp/go-plugin` plugins expose a Unix socket at provisioning time; Scion docs document the path conventions in `concepts/` plugin section.)
+3. **Decommission `darken-msg-router`**: keep available for users who don't run a Hub. The Bones backend selector picks based on env.
+
+### Open questions for Phase C
+
+- The Scion plugin contract for Message Broker is "foundational stage" per `concepts/`. Confirm the gRPC service definition is stable before committing to a plugin implementation. If not stable, stay on Phase B until it is.
+- Whether to use Scion's Inbox Tray as the human-facing surface (requires Mode A) or keep `darken inbox <agent>` as the host-side view. Likely both.
+
+## Migration plan
+
+| Step | Owner | Trigger |
+|---|---|---|
+| 1. Land envelope schema in spec #1 | Done in this commit | — |
+| 2. Implement `bones msg` Phase A subcommands | TBD | After spec #3 lands (touches the same images) |
+| 3. Backfill migrator for legacy `audit.jsonl` lines | TBD | Same PR as #2 |
+| 4. `darken inbox` host-side reader | TBD | Same PR as #2 |
+| 5. Phase B router + HTTP backend in bones | TBD | When ≥1 worker needs to run on a non-host runtime |
+| 6. Phase B K8s push via `runtime.Exec` | TBD | Same PR as #5, behind a `--enable-k8s-push` flag if it adds risk |
+| 7. Phase C plugin | TBD | Mode A pivot trigger fires |
+
+## Risks
+
+- **`runtime.Exec` push requires the orchestrator to import Scion source.** Today `bin/darken` shells out to `scion`. We'd need to either (a) call `scion exec <pod> -- bones msg deliver ...` (cleaner) or (b) link `pkg/runtime` directly (faster). Prefer (a) — it preserves the "configs + hooks + agent definitions on top of a substrate" pivot from PR #1.
+- **Two transports diverge.** File backend and HTTP backend must produce byte-identical envelopes. Mitigated by a shared envelope-encoder library inside `bones`.
+- **`bones` rebuild discipline.** Adding subcommands means re-running `make -C images prebuild-bones` and re-baking images. Document in operator runbook.
+- **Audit-log bifurcation.** If both `bin/darken` and `darken-msg-router` write to the same JSONL file, contention is real. Phase B router takes ownership of the file; `bin/darken` reads only.
+
+## Open questions
+
+- **Authentication model for human operator.** Today the operator IS the host orchestrator process; no auth needed. Phase B router-to-CLI auth: trivial (loopback). If we ever support a remote operator (e.g., laptop ↔ desktop), spec #1 re-opens.
+- **Retention policy.** `.scion/audit.jsonl` grows unbounded. Define a rotation policy (size-based, e.g., 100 MB) before Phase B ships.
+- **Schema evolution.** When fields get added (`schema_version: "2"`), do old workers ignore unknowns gracefully? Yes by spec — but verify `bones` JSON decoder is permissive.
+- **Broadcast semantics.** `to.kind: broadcast` — fan out to all agents in grove? All agents matching a role? Punt to Phase A discussion; simplest is "all agents in grove except sender."
+
+## Dependencies
+
+- Spec #1 (envelope schema) — accepted in same commit.
+- Spec #3 (roles/bases collapse) — independent but touches the same image rebuild pipeline; coordinate landing order.
+- `agent-infra` repo public-availability — currently private. `bones` rebuilds need source access. Document in operator runbook.

--- a/docs/superpowers/specs/2026-04-28-remote-human-comms-deferral-design.md
+++ b/docs/superpowers/specs/2026-04-28-remote-human-comms-deferral-design.md
@@ -1,0 +1,93 @@
+# Remote Human Comms — Deferral & Envelope Interoperability
+
+**Status:** approved (in-conversation, 2026-04-28)
+**Author:** dmestas
+**Source PRs:** TBD
+**Related specs:**
+- `2026-04-28-bones-inter-harness-comms-design.md` (consumes the envelope defined here)
+- `2026-04-28-roles-bases-template-collapse-design.md`
+
+## Context
+
+Eventually Darkish Factory operators will want remote human notifications — "agent X is blocked, ping me on my phone." A naïve build of this from scratch would duplicate primitives that the Scion substrate already ships:
+
+| Need | Scion primitive (already exists) | Reference |
+|---|---|---|
+| Persistent message tray for humans | Hub Inbox Tray + SSE | `hub-user/messaging/` |
+| External notification | Discord webhook integration | `hub-admin/hub-server/` (Discord Integration) |
+| "Agent needs human input" semantics | `ask_user` tool → state flips to `WAITING_FOR_INPUT` + persistent message | `hub-user/messaging/` |
+| Programmatic delivery backend | Message Broker Plugin (`hashicorp/go-plugin` + gRPC) | `concepts/`, `glossary/` |
+
+Building our own remote-comms stack would compete with these. But adopting Scion's path requires going Hub-mode (Mode A) — OAuth, `GITHUB_TOKEN`, hub server, broker registration — none of which is justified by current operator volume (one human, host mode).
+
+## Decision
+
+**Don't build remote-to-human comms now.** Defer until either of these is true:
+
+1. We have ≥2 human operators or one human running ≥2 machines that need a unified inbox.
+2. We pivot to Mode A for an unrelated reason (e.g., remote-broker compute) — at which point Inbox/Discord come "free."
+
+## What we DO commit to today
+
+Make the message envelope used internally a **strict subset** of the shape Scion's Inbox/Discord adapter accepts. This means flipping the switch later is a transport swap, not a schema migration or a content-rewrite.
+
+This work is small and lives entirely inside spec #2 (bones-inter-harness-comms). It is called out here to explicitly assign the responsibility.
+
+## Envelope schema (target — also in spec #2)
+
+```json
+{
+  "schema_version": "1",
+  "id": "uuid-v4",
+  "ts": "2026-04-28T18:32:11Z",
+  "from": {
+    "kind": "agent|orchestrator|operator",
+    "name": "researcher-1",
+    "role": "researcher",
+    "grove": "darkish-factory"
+  },
+  "to": {
+    "kind": "agent|orchestrator|operator|broadcast",
+    "name": "planner-t1",
+    "role": null
+  },
+  "severity": "info|warn|error|urgent",
+  "kind": "report|question|status|ask_user|notification",
+  "subject": "short headline (≤80 chars)",
+  "body": "markdown-ok longer text",
+  "actionable": true,
+  "corr_id": "optional-thread-id",
+  "links": [
+    {"label": "PR #42", "url": "https://github.com/..."}
+  ]
+}
+```
+
+**Why this shape:**
+
+- `severity` maps 1:1 to Discord color coding (info=blue, warn=yellow, error=red, urgent=red+mention) per Scion's documented behavior.
+- `kind: ask_user` is the trigger for Scion's `WAITING_FOR_INPUT` state flip — preserve the term verbatim.
+- `actionable: true` aligns with Inbox Tray "needs attention" filtering.
+- `links` is forward-compatible with Inbox contextual links ("link directly to the agent that sent them").
+- `from.grove` will already be populated when Mode A activates; harmless empty/static today.
+
+## Non-goals
+
+- Building a notification daemon, mobile app, push service, or webhook adapter ourselves.
+- Writing a Discord webhook adapter (Scion ships one — we'd just configure `discord_webhook_url` if Mode A activates).
+- Defining a richer envelope than Scion expects (we'd just have to trim it later).
+
+## Migration trigger / re-open conditions
+
+Re-open this spec and write an addendum when **any** of:
+
+- Operator runs Darkish Factory across ≥2 machines and wants unified notifications.
+- Mode A pivot lands (Hub server stood up for another reason).
+- An agent flow needs `ask_user` semantics that block until a human responds — the file-based audit log is wrong substrate for that; promote to Inbox at that point.
+
+Until then: bones (#2) writes envelopes that conform to this schema. If we ever export them to Scion, the export is a transport adapter, not a transform.
+
+## Open questions
+
+- **Threading**: Scion's Inbox Tray semantics for `corr_id` aren't documented in the public docs we scraped. Confirm via source or punt to Phase C of #2.
+- **Attachments**: Do we want `attachments: [{path, mime}]` in the envelope today? Lean no; revisit if a worker ever needs to ship a binary diff or screenshot to a human.

--- a/docs/superpowers/specs/2026-04-28-roles-bases-template-collapse-design.md
+++ b/docs/superpowers/specs/2026-04-28-roles-bases-template-collapse-design.md
@@ -1,0 +1,350 @@
+# Roles + Bases — Collapse 14 Templates into Per-Spawn Agent-Config Overrides
+
+**Status:** approved (in-conversation, 2026-04-28) — implementation deferred
+**Author:** dmestas
+**Source PRs:** TBD
+**Related specs:**
+- `2026-04-28-bones-inter-harness-comms-design.md`
+- `2026-04-28-remote-human-comms-deferral-design.md`
+
+## Context
+
+`.scion/templates/` currently holds 14 directories — one per role (plus a `base` placeholder):
+
+```
+admin/  base/  darwin/  designer/  orchestrator/
+planner-t1/ planner-t2/ planner-t3/ planner-t4/
+researcher/ reviewer/ sme/ tdd-implementer/ verifier/
+```
+
+Each contains the same three files:
+
+- `agents.md` — role-specific instructions
+- `system-prompt.md` — role-specific system prompt
+- `scion-agent.yaml` — manifest
+
+A representative manifest (`planner-t1/scion-agent.yaml`):
+
+```yaml
+schema_version: "1"
+description: "Planner T1 - think-then-do; small bug fixes; no plan doc"
+agent_instructions: agents.md
+system_prompt: system-prompt.md
+default_harness_config: claude
+image: local/darkish-claude:latest
+model: claude-sonnet-4-6
+max_turns: 15
+max_duration: "30m"
+detached: false
+skills:
+  - danmestas/agent-skills/skills/hipp
+volumes:
+  - source: ./.scion/skills-staging/planner-t1/
+    target: /home/scion/skills/role/
+    read_only: true
+```
+
+**Problem**: most fields are duplicated across roles. The 14 manifests differ only in:
+
+- `description`, `agent_instructions`, `system_prompt` (always different — these ARE the role)
+- `model`, `max_turns`, `max_duration` (occasionally different)
+- `image` / `default_harness_config` (varies by harness flavor — claude/gemini/codex/pi)
+- `skills` and `volumes.source` path (varies by role's skill bundle)
+
+Updating shared config (e.g., bumping the image tag) requires touching 14 files. Adding a new role means copy-pasting a directory. Manifest drift is a real risk.
+
+## Background — Scion primitives we can lean on
+
+From `reference/agent-config/` and `contributing/architecture/`:
+
+| Primitive | What it gives us |
+|---|---|
+| **Template chain** (`base` field) | Manifests can declare a base template; configs merge bottom-up (base first, leaf wins). |
+| **Per-instance `scion-agent.yaml`** | The active-agent manifest at `.scion/agents/<name>/scion-agent.yaml` can override any field. CLI flags override that. |
+| **`home/` directory tree** | Templates ship a `home/` dir that gets copied into the agent's container home — useful for shared dotfiles, tooling. |
+| **Resolution order** | CLI flag > per-agent override > template chain (leaf→base) > settings (profile/harness/runtime) > env vars > embedded defaults. |
+| **`services` block** | Sidecar containers (e.g., headless browser) declared per-template. |
+
+These mean: a template doesn't have to be the unit of role identity. **Role identity can live in role manifests merged into a base template at spawn time.**
+
+## Goal
+
+Reduce 14 role-specific templates to **3–4 base templates** (one per harness flavor) plus a flat `roles/` directory of per-role manifests. `bin/darken spawn` materializes a per-spawn agent-config overlay that references the base template and injects role identity.
+
+## Goals
+
+After implementation:
+
+- Editing a role is **one file** (`roles/<role>.md` or `roles/<role>.yaml`).
+- Bumping a shared image, env var, or skill is **one base** edit (`templates/darken-claude-base/scion-agent.yaml`).
+- Adding a new role costs **one markdown body + one INDEX.yaml row**.
+- Role discovery still works: `darken roles list`, `darken roles show <role>`.
+- Per-role skill bundles still mount at the conventional `/home/scion/skills/role/` path.
+- No regressions in existing spawn flows (`bin/darken spawn researcher-1 --type researcher`).
+
+## Non-goals
+
+- Replacing Scion's template format. We use it as designed (chain merge); we just stop writing one template per role.
+- Eliminating the `.scion/skills-staging/` per-role staging directories. Those continue to exist; the manifests just point at them dynamically.
+- Reducing role expressiveness. Anything a current template can do (sidecars, custom env, GPU requests, k8s overrides), the new shape can also do.
+- Migrating skills out of role bundles into base templates. Out of scope.
+
+## Target structure
+
+```
+.scion/
+├── templates/
+│   ├── darken-claude-base/
+│   │   ├── home/                       # shared dotfiles (optional)
+│   │   ├── system-prompt.md            # generic prompt; roles append
+│   │   └── scion-agent.yaml            # claude harness wiring, image, default env
+│   ├── darken-gemini-base/
+│   │   └── ... (same shape, gemini harness)
+│   ├── darken-codex-base/
+│   │   └── ... (codex harness)
+│   └── darken-pi-base/                 # pi = generic harness for utility containers
+│       └── ...
+├── roles/
+│   ├── INDEX.yaml                      # roster + role→base + overrides
+│   ├── researcher/
+│   │   ├── agents.md                   # agent_instructions
+│   │   └── system-prompt.md            # appended to base prompt (optional)
+│   ├── planner-t1/
+│   │   ├── agents.md
+│   │   └── system-prompt.md
+│   └── ... (one dir per role)
+└── skills-staging/                     # unchanged — per-role skill bundles
+    ├── researcher/
+    ├── planner-t1/
+    └── ...
+```
+
+### Base template manifest (`darken-claude-base/scion-agent.yaml`)
+
+```yaml
+schema_version: "1"
+description: "Darken Claude base — claude harness wiring + shared defaults"
+default_harness_config: claude
+image: local/darkish-claude:latest
+model: claude-sonnet-4-6
+max_turns: 30
+max_duration: "60m"
+detached: true
+# system_prompt and agent_instructions intentionally NOT set —
+# they are supplied per-spawn from roles/<role>/.
+env:
+  DARKEN_HARNESS_FLAVOR: claude
+```
+
+### `roles/INDEX.yaml`
+
+```yaml
+schema_version: "1"
+roles:
+  researcher:
+    base: darken-claude-base
+    instructions: roles/researcher/agents.md
+    system_prompt_append: roles/researcher/system-prompt.md
+    skills_staging: .scion/skills-staging/researcher/
+    skills:
+      - danmestas/agent-skills/skills/hipp
+    overrides:
+      max_turns: 15
+      max_duration: "30m"
+      detached: false
+  planner-t1:
+    base: darken-claude-base
+    instructions: roles/planner-t1/agents.md
+    system_prompt_append: roles/planner-t1/system-prompt.md
+    skills_staging: .scion/skills-staging/planner-t1/
+    skills:
+      - danmestas/agent-skills/skills/hipp
+    overrides:
+      max_turns: 15
+      max_duration: "30m"
+      detached: false
+  darwin:
+    base: darken-pi-base
+    instructions: roles/darwin/agents.md
+    skills_staging: .scion/skills-staging/darwin/
+    overrides: {}
+  # ... (one entry per role)
+```
+
+The INDEX is the **single source of truth** for the roster. `darken roles list` reads it. `darken spawn --type <role>` looks up the entry.
+
+## Spawn flow change
+
+### Today
+
+```
+bin/darken spawn researcher-1 --type researcher
+  → calls scion start with --template researcher
+  → scion reads .scion/templates/researcher/scion-agent.yaml
+  → scion creates the agent
+```
+
+### Target
+
+```
+bin/darken spawn researcher-1 --type researcher
+  → reads .scion/roles/INDEX.yaml → resolves "researcher" → base + overrides
+  → reads roles/researcher/agents.md (instructions body)
+  → reads roles/researcher/system-prompt.md (append to base prompt)
+  → materializes .scion/agents/researcher-1/scion-agent.yaml as the OVERLAY:
+        agent_instructions: <inlined body or relative ref>
+        system_prompt:      <merged prompt>
+        skills:             [<from INDEX>]
+        volumes:
+          - source: .scion/skills-staging/researcher/
+            target: /home/scion/skills/role/
+            read_only: true
+        max_turns:    15        # from INDEX overrides
+        max_duration: 30m       # from INDEX overrides
+        detached:     false
+  → calls scion start --template darken-claude-base
+        (and Scion merges the per-agent overlay on top — its documented behavior)
+```
+
+The per-agent manifest at `.scion/agents/<name>/scion-agent.yaml` is exactly the merge layer Scion's resolution logic step 3 (CLI > **per-agent override** > template chain > settings) is designed for. We're using the substrate as documented.
+
+## CLI surface (`bin/darken`)
+
+New / changed subcommands:
+
+```
+darken roles list                    # print INDEX.yaml roster as table
+darken roles show <role>             # print resolved manifest for a role (preview merge)
+darken roles validate                # check INDEX entries against base templates / skills paths
+darken spawn <name> --type <role>    # unchanged signature; new resolution internals
+darken spawn <name> --base darken-claude-base \
+                    --instructions <path>      # bypass INDEX for ad-hoc spawns
+```
+
+## Migration plan (one-shot, single PR)
+
+### Step 1 — Inventory the diffs
+
+Diff all 14 current `scion-agent.yaml` manifests pairwise. Categorize each field:
+
+- **Always identical across roles using the same harness** → goes into the base template.
+- **Always-different per role** (`agent_instructions`, `system_prompt`, `description`, `volumes.source`) → goes into `roles/<role>/` files or INDEX entry.
+- **Sometimes-different** (`model`, `max_turns`, `max_duration`, `detached`) → goes into `INDEX.yaml` per-role `overrides:` map; left absent in the base default.
+
+Output: a small markdown table in the migration PR description, e.g.:
+
+| Field | Same across all? | Lift to base? | Note |
+|---|---|---|---|
+| `image` | Within harness flavor, yes | Yes (per-base) | claude→`darkish-claude:latest` etc. |
+| `model` | No (planners use sonnet, others may differ) | No — INDEX override | |
+| `max_turns` | No | INDEX override | |
+| `agent_instructions` | No (always different) | No — `roles/<role>/agents.md` | |
+| ... | | | |
+
+### Step 2 — Build base templates
+
+Create `.scion/templates/darken-{claude,gemini,codex,pi}-base/`. Populate each with:
+
+- `scion-agent.yaml` (the lifted-common fields).
+- A minimal `home/` if existing templates had shared home content (audit current `home/` dirs first; if none, omit).
+- A minimal generic `system-prompt.md` if the role-level prompts share common preamble — otherwise leave empty and let roles supply the full prompt.
+
+### Step 3 — Move role bodies
+
+For each existing template `<role>/`:
+
+1. Copy `agents.md` → `.scion/roles/<role>/agents.md`.
+2. Copy `system-prompt.md` → `.scion/roles/<role>/system-prompt.md`.
+3. Add the role's row to `INDEX.yaml` with `base`, `instructions`, `system_prompt_append`, `skills_staging`, `skills`, and any `overrides`.
+4. Delete the original `.scion/templates/<role>/` directory.
+
+### Step 4 — Rewrite `bin/darken spawn`
+
+Replace the current "pass `--template <role>` to scion" path with the overlay assembler:
+
+- Read `INDEX.yaml`.
+- Read role `agents.md` and (if present) `system-prompt.md`.
+- Merge with base template's `system-prompt.md` (concatenation: base then role).
+- Materialize the per-agent overlay file at `.scion/agents/<name>/scion-agent.yaml`.
+- Invoke `scion start --template <base>` with the agent-name flag pointing at the same dir.
+
+### Step 5 — Add `darken roles` subcommands
+
+`list`, `show`, `validate` — pure read operations against `INDEX.yaml` plus light filesystem probes.
+
+### Step 6 — Tests
+
+- Unit test the INDEX resolver (given an INDEX entry + base manifest, produces a correct overlay).
+- Integration test: spawn each role end-to-end and assert `agent_instructions`, `system_prompt`, `skills`, and `volumes` all resolve to the same content the old templates would have produced.
+- Snapshot test the INDEX schema with a JSON Schema or CUE definition (catch typos before they hit runtime).
+
+### Step 7 — Documentation
+
+- Update `CLAUDE.md`'s "13-role roster" reference.
+- Document in `docs/CLI.md` the new `darken roles` subcommands.
+- Add a one-paragraph "How roles work" section pointing at `roles/INDEX.yaml`.
+
+### Step 8 — Cleanup
+
+- Remove `.scion/templates/<role>/` for the 13 role-specific templates.
+- Keep `.scion/templates/base/` only if it had a non-trivial purpose; otherwise delete.
+
+## Risks
+
+- **Discoverability regression**: `ls .scion/templates/` no longer shows the roster. Mitigated by `darken roles list` and a brief note in `CLAUDE.md`.
+- **Overlay merge semantics drift**: if Scion ever changes how per-agent manifests merge with templates, our spawn flow breaks. Pin behavior with the integration test in Step 6.
+- **Skill staging path coupling**: `INDEX.yaml`'s `skills_staging` paths must match `.scion/skills-staging/` directory layout. Validate at `darken roles validate` time.
+- **Mid-migration breakage**: this is a single-PR change. Don't ship half-migrated. Use a feature branch and verify all 14 roles still spawn before merging.
+
+## Open questions
+
+### 1. Per-role `home/` overlays
+
+Some roles (e.g., `darwin` which interacts with macOS configs, or future browser-using roles) may need extra dotfiles or scripts in `/home/<user>/`. Two options:
+
+**A. Each role optionally has `roles/<role>/home/`** that the spawner copies on top of the base's `home/`. Cleanest, preserves base immutability.
+
+**B. Keep `home/` exclusively in base templates.** If a role needs different home content, it gets its own base template (e.g., `darken-claude-darwin-base`).
+
+Lean **A**. Add to INDEX schema as `home_overlay: roles/<role>/home/` (optional). Defer implementation until first role demands it.
+
+### 2. Multiple bases per role (cross-harness flexibility)
+
+Should a role be allowed to declare it works with `claude` OR `gemini`, picked at spawn time? E.g., `--type researcher --harness gemini`?
+
+INDEX could become:
+
+```yaml
+researcher:
+  bases:
+    claude: darken-claude-base
+    gemini: darken-gemini-base
+  default_base: claude
+  instructions: ...
+```
+
+Useful for cost/perf trades; complicates resolution. **Defer** — add only when first concrete need surfaces. For now, one base per role.
+
+### 3. `system_prompt_append` semantics
+
+When the base has a system prompt and the role has one too, do we:
+
+- **Concatenate** (base + "\n\n---\n\n" + role)
+- **Replace** (role wins entirely)
+- **Template** (base has `{{role_prompt}}` interpolation point)
+
+Lean **concatenate** (simplest, transparent in `darken roles show`). Templating is over-engineering. Replace is fine if base prompts are empty (likely the common case).
+
+### 4. INDEX.yaml schema versioning
+
+Add `schema_version: "1"` to INDEX from day one. When fields evolve, write a migrator. (Lesson learned: spawn-time format evolution is costly without versioning.)
+
+### 5. Where INDEX lives
+
+`.scion/roles/INDEX.yaml` is project-scoped. Should it be checked in? **Yes** — roles are part of the project's substrate, like templates were. Globbed `darken-*-base` templates remain the common scaffolding (potentially shipped via `darken init` or `make darken` like today).
+
+## Dependencies
+
+- Spec #2 (bones inter-harness comms) — independent design, but image rebuilds happen together.
+- Spec #1 (remote human comms deferral) — independent.
+- No external (Scion) dependency: this spec uses Scion's documented template-chain + per-agent-override merge, no new substrate features.

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -75,7 +75,26 @@ if [[ -f "${CREDS_FILE}" ]]; then
   fi
 fi
 
-# --- 3. Hand off to scion ----------------------------------------------------
+# --- 3. Pre-clone workspace (work around sciontool go-git Mac FUSE bug) ------
+#
+# sciontool's built-in `git init` (via go-git) fails silently on Docker
+# Desktop's fakeowner FUSE filesystem with empty stderr. The shell C git
+# binary works fine. Pre-clone here so sciontool sees "Workspace already
+# populated, skipping git clone" and bypasses its broken go-git path.
+#
+# Only runs in Hub mode (when SCION_GIT_CLONE_URL is set). Local-mode
+# worktree spawns get a populated /workspace via host bind-mount.
+if [[ -n "${SCION_GIT_CLONE_URL:-}" && -n "${GITHUB_TOKEN:-}" && ! -d /workspace/.git ]]; then
+  echo "darkish-prelude: pre-cloning workspace via shell git (sciontool go-git workaround)" >&2
+  AUTH_URL="https://x-access-token:${GITHUB_TOKEN}@${SCION_GIT_CLONE_URL#https://}"
+  if git clone --depth "${SCION_GIT_DEPTH:-1}" -b "${SCION_GIT_BRANCH:-main}" "${AUTH_URL}" /workspace 2>&1 | sed 's/x-access-token:[^@]*@/x-access-token:***@/g' >&2; then
+    echo "darkish-prelude: pre-clone complete" >&2
+  else
+    echo "darkish-prelude: pre-clone FAILED — sciontool will likely fail too" >&2
+  fi
+fi
+
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # Direct invocation (`bash scripts/stage-skills.sh`) still works via the
 # BASH_SOURCE fallback.
 REPO="${DARKEN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-CANONICAL="${HOME}/projects/agent-skills/skills"
+CANONICAL="${HOME}/projects/agent-config/skills"
 
 usage() {
   cat <<EOF >&2

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # Direct invocation (`bash scripts/stage-skills.sh`) still works via the
 # BASH_SOURCE fallback.
 REPO="${DARKEN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-CANONICAL="${HOME}/projects/agent-skills/skills"
+CANONICAL="${HOME}/projects/agent-config/skills"
 
 usage() {
   cat <<EOF >&2


### PR DESCRIPTION
## Summary

- Unblocks `darken setup` on Mac Docker Desktop. Five fixes ship together because they're all hit in sequence on a fresh-repo onboarding run; landing them piecewise leaves the workflow broken.
- Memorializes three design specs from the 2026-04-28 session (deferred implementation).
- Operator must add `127.0.0.1  host.docker.internal` to `/etc/hosts` after `brew upgrade` for the Hub-URL fix to work.

## Commits

1. **fix(skills)**: rename agent-skills → agent-config repo path. Live + embedded substrate copies of `stage-skills.sh`. Stopgap; bundling spec is in this PR.
2. **fix(spawn)**: pass task as positional arg (was `--notify <task>`, which is a Hub-only boolean flag — broke every spawn).
3. **fix(image)**: pre-clone workspace in `images/claude/darkish-prelude.sh` to bypass sciontool's go-git `PlainInit` failure on Docker Desktop's fakeowner FUSE mount. Codex/gemini/pi prelude scripts get the same treatment in a follow-up.
4. **fix(templates)**: hardcode `hub.endpoint: http://host.docker.internal:8080` across all 14 role manifests. Required because scion's broker injects its self-URL (`localhost:8080`) into containers, ignoring `settings.yaml`'s top-level `hub.endpoint`. Per-template override is the only path that propagates.
5. **docs(specs)**: three deferred-implementation specs — remote-human-comms-deferral, bones-inter-harness-comms, roles-bases-template-collapse.

## Test plan

- [ ] `brew upgrade darken` after release picks up new version
- [ ] `echo "127.0.0.1  host.docker.internal" | sudo tee -a /etc/hosts` (one-time)
- [ ] `darken bootstrap` (idempotent) succeeds
- [ ] In a fresh repo, `darken init && darken setup`:
    - [ ] bones init failure no longer aborts setup
    - [ ] hub secrets push succeeds (or cleanly degrades)
    - [ ] stage-skills resolves all 14 roles (with `~/projects/agent-config` cloned)
    - [ ] doctor reports the actual scion daemon liveness
- [ ] `darken spawn smoke-1 --type planner-t2 "say hello and exit"` reaches `Phase: running` and exits cleanly
- [ ] Dashboard at http://localhost:8080 shows the live agent and terminal output

## Known gaps

- Other harness images (`codex`, `gemini`, `pi`) need the same prelude pre-clone patch — pending verification.
- Hardcoded host.docker.internal in templates is brittle; proper fix is upstream scion broker advertise-URL OR centralized config knob.
- The systematic-debugging session is documented in commit messages; planner pass will produce a formal TDD plan + design spec covering all 9 substrate bugs we identified.