### PR TITLE
chore(embed): sync substrate data for v0.1.14 release

### DIFF
--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -8,3 +8,5 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/base/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/base/scion-agent.yaml
@@ -8,3 +8,5 @@ default_harness_config: claude
 model: claude-sonnet-4-6
 max_turns: 50
 max_duration: 3600
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/darwin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/darwin/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/darwin/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/designer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/planner-t1/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t1/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t1/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t2/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/planner-t4/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t4/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t4/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/researcher/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/researcher/scion-agent.yaml
@@ -8,3 +8,5 @@ model: claude-sonnet-4-6
 max_turns: 30
 max_duration: "1h"
 detached: false
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/reviewer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/reviewer/scion-agent.yaml
@@ -16,3 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/reviewer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/sme/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/sme/scion-agent.yaml
@@ -17,3 +17,5 @@ volumes:
     read_only: true
 # Codex auth comes from the user-scope hub secret 'codex_auth' (set via:
 # scion hub secret set --type file --target /home/scion/.codex/auth.json codex_auth @~/.codex/auth.json)
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,3 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/.scion/templates/verifier/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/verifier/scion-agent.yaml
@@ -14,3 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/verifier/
     target: /home/scion/skills/role/
     read_only: true
+hub:
+  endpoint: http://host.docker.internal:8080

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -75,7 +75,26 @@ if [[ -f "${CREDS_FILE}" ]]; then
   fi
 fi
 
-# --- 3. Hand off to scion ----------------------------------------------------
+# --- 3. Pre-clone workspace (work around sciontool go-git Mac FUSE bug) ------
+#
+# sciontool's built-in `git init` (via go-git) fails silently on Docker
+# Desktop's fakeowner FUSE filesystem with empty stderr. The shell C git
+# binary works fine. Pre-clone here so sciontool sees "Workspace already
+# populated, skipping git clone" and bypasses its broken go-git path.
+#
+# Only runs in Hub mode (when SCION_GIT_CLONE_URL is set). Local-mode
+# worktree spawns get a populated /workspace via host bind-mount.
+if [[ -n "${SCION_GIT_CLONE_URL:-}" && -n "${GITHUB_TOKEN:-}" && ! -d /workspace/.git ]]; then
+  echo "darkish-prelude: pre-cloning workspace via shell git (sciontool go-git workaround)" >&2
+  AUTH_URL="https://x-access-token:${GITHUB_TOKEN}@${SCION_GIT_CLONE_URL#https://}"
+  if git clone --depth "${SCION_GIT_DEPTH:-1}" -b "${SCION_GIT_BRANCH:-main}" "${AUTH_URL}" /workspace 2>&1 | sed 's/x-access-token:[^@]*@/x-access-token:***@/g' >&2; then
+    echo "darkish-prelude: pre-clone complete" >&2
+  else
+    echo "darkish-prelude: pre-clone FAILED — sciontool will likely fail too" >&2
+  fi
+fi
+
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.


### PR DESCRIPTION
## Summary

- Pre-release embed-drift hook in v0.1.14's tag CI failed because canonical edits (14 templates + claude prelude) weren't propagated to `internal/substrate/data/`. This PR runs `make sync-embed-data` and commits the result.
- Pure mechanical sync. No semantic change.

## Test plan

- [ ] Merge this PR
- [ ] Force-update the v0.1.14 tag to point at the new HEAD (or cut v0.1.15)
- [ ] Release CI passes
- [ ] `brew upgrade darken` picks up the new version

## Background

`scripts/test-embed-drift.sh` is a goreleaser pre-hook that compares hashes of canonical files (`scripts/`, `images/<backend>/`, `.scion/templates/`) against their embedded copies in `internal/substrate/data/`. v0.1.14's first commit (`fix(skills)`) updated both canonical and embedded copies of `stage-skills.sh` correctly, but subsequent commits (`fix(image)`, `fix(templates)`) only updated canonical. The hook caught the resulting drift before any release artifact was published.

The `Makefile`'s `sync-embed-data` target is the documented remedy.