### PR TITLE
plan: v0.1.16 darken setup fixes (11 bugs)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-darken-setup-fixes.md
+++ b/docs/superpowers/plans/2026-04-29-darken-setup-fixes.md
@@ -1,0 +1,651 @@
+# Darken setup fixes — TDD plan (v0.1.16)
+
+Status: draft (planner-t2)
+Date: 2026-04-29
+Companion spec: [`2026-04-29-darken-setup-fixes-design.md`](../specs/2026-04-29-darken-setup-fixes-design.md)
+
+## Goal
+
+Make `darken setup` succeed end-to-end on a clean machine — no manual
+`/etc/hosts` edits, no cross-repo clone of `agent-config`, no
+cross-grove template gaps, no print-before-success false positives,
+no daemon-down-but-doctor-OK lies, and orchestrator skills that bias
+toward subharness dispatch.
+
+## Architecture (per spec §3, condensed)
+
+1. Bundle canonical skills via `go:embed`, fed by `make vendor-skills`
+   from a build-time canonical source.
+2. Replace per-template hardcoded Hub URL with a substrate knob
+   (`${DARKEN_HUB_ENDPOINT}`) applied by a centralized `scion-cmd`
+   helper at spawn time. Pair with a doctor check (no auto-sudo).
+3. Rewrite `orchestrator-mode` and `subagent-to-subharness` skills
+   so subharness dispatch is the default when any of the 14 roles
+   fits the task. `Agent` is a documented fallback.
+
+## Task ordering
+
+Tasks are grouped into three waves. Within a wave, tasks are
+independent; between waves there are real dependencies (later waves
+depend on earlier waves' helpers).
+
+- **Wave A (unblock the rest):** centralized `scion-cmd` helper,
+  canonical roles constant, manifest substitution. (Bugs #5, #6
+  mechanism.)
+- **Wave B (the actual bugfixes):** #1 bones rerun, #3 stage-creds
+  ordering, #4 daemon liveness, #7 prelude propagation + sniff-test,
+  #8 broker provide, #9 doctor /etc/hosts, #10 templates upload.
+- **Wave C (substrate + skills):** #2 bundling pipeline, #11 skill
+  rewrite. These touch the most files; saved for last.
+
+Each task: failing test first, implementation, commit. No code in
+this plan — only file paths, test names, and assertions.
+
+---
+
+## Wave A — Centralized helpers (bugs #5, #6 mechanism)
+
+### Task A1 — `canonicalRoles` constant
+
+**Files touched:**
+- new: `cmd/darken/roles.go`
+- new: `cmd/darken/roles_test.go`
+
+**Failing test (`roles_test.go`):**
+- `TestCanonicalRoles_Has14_AndMatchesSpec` — asserts the slice
+  contains exactly these 14 names in alpha order:
+  `admin, base, darwin, designer, orchestrator, planner-t1,
+  planner-t2, planner-t3, planner-t4, researcher, reviewer, sme,
+  tdd-implementer, verifier`.
+- `TestCanonicalRoles_TemplatesExistOnDisk` — for each role, asserts
+  `.scion/templates/<role>/scion-agent.yaml` exists. Catches
+  manifest deletions / typos.
+
+**Implementation:**
+- Declare `var canonicalRoles = []string{…}` in `cmd/darken/roles.go`.
+- No behavior wired yet; later tasks consume it.
+
+**Commit:** `cmd/darken: introduce canonicalRoles constant (14 roles)`
+
+---
+
+### Task A2 — Spawn posArgs regression test
+
+**Files touched:**
+- existing: `cmd/darken/spawn_test.go`
+- (no production change — pinning the v0.1.15 inline fix)
+
+**Failing test (write first; should pass against v0.1.15 head, but
+becomes the regression guard for the upcoming refactor):**
+- `TestRunSpawn_PosArgsForwardedAsTaskString` — invokes
+  `runSpawn([]string{"agentname", "--type", "researcher", "do the
+  thing", "with multiple words"})` against a stubbed `scion`
+  binary on PATH. Asserts the stubbed scion received the trailing
+  positional words as a single task argument, not split by flag
+  parsing or `--`.
+- `TestRunSpawn_FailsWithoutType` — pre-existing safety net
+  (verify it still passes after the refactor).
+
+**Implementation:** none yet. Test pins existing behavior. The task
+that introduces `scion-cmd` (A3) must keep this green.
+
+**Commit:** `cmd/darken: regression test for spawn posArgs forwarding`
+
+---
+
+### Task A3 — `scion-cmd` helper
+
+**Files touched:**
+- new: `cmd/darken/scion_cmd.go`
+- new: `cmd/darken/scion_cmd_test.go`
+
+**Failing tests (`scion_cmd_test.go`):**
+- `TestScionCmd_SetsHubEndpointFromEnv` — when
+  `DARKEN_HUB_ENDPOINT=http://example:9090` is set, the resulting
+  `*exec.Cmd`'s env contains `SCION_HUB_ENDPOINT=http://example:9090`.
+- `TestScionCmd_DefaultsHubEndpoint` — with
+  `DARKEN_HUB_ENDPOINT` unset, `SCION_HUB_ENDPOINT` defaults to
+  `http://host.docker.internal:8080` (preserves v0.1.15 behavior).
+- `TestScionCmd_PropagatesRepoRoot` — `DARKEN_REPO_ROOT` is set
+  per `scriptEnv()`'s existing pattern.
+- `TestScionCmd_ArgsForwardedVerbatim` — `scionCmd(["spawn",
+  "name", "--type", "researcher", "do thing"])`'s `Args` matches
+  exactly the prefix `[scion, spawn, name, --type, researcher,
+  do thing]`.
+
+**Implementation:**
+- Add `scionCmd(args []string) *exec.Cmd` that wraps
+  `exec.Command("scion", args...)` with env set per the tests above.
+- Re-export `scriptEnv()` if needed (or inline the env logic and
+  unify in a follow-up).
+
+**Commit:** `cmd/darken: add scionCmd helper centralizing scion invocations`
+
+---
+
+### Task A4 — Migrate doctor + bootstrap call sites to `scionCmd`
+
+**Files touched:**
+- existing: `cmd/darken/doctor.go` (4 call sites: `checkScion`,
+  `checkScionServer`, `checkHubSecrets`, harness-secret list)
+- existing: `cmd/darken/bootstrap.go` (`ensureScionServer`)
+- existing: `cmd/darken/spawn.go` (the spawn invocation)
+- existing: tests for each (golden behavior pinned)
+
+**Failing test (per migration):** the existing tests for each
+function should keep passing. Add one assertion per migration that
+`scionCmd` is the construction path (e.g. via a small interface
+seam: a package-level `scionCmdFn` var defaulting to `scionCmd`,
+overridden in tests to record args).
+
+**Implementation:**
+- Replace `exec.Command("scion", …)` with `scionCmd([…])` in each
+  call site.
+- Run all existing tests; nothing else should change semantically.
+
+**Commit (one per file or one combined, implementer's call):**
+`cmd/darken: route scion invocations through scionCmd helper`
+
+---
+
+### Task A5 — Manifest `${DARKEN_HUB_ENDPOINT}` substitution
+
+**Files touched:**
+- existing: `.scion/templates/*/scion-agent.yaml` (all 14 — replace
+  hardcoded URL with literal `${DARKEN_HUB_ENDPOINT}`)
+- existing: `internal/substrate/data/.scion/templates/*/scion-agent.yaml`
+  (mirror)
+- new or extend: `cmd/darken/manifest.go` (substitution helper)
+- existing: `cmd/darken/manifest_test.go`
+
+**Failing tests:**
+- `TestManifest_SubstitutesHubEndpoint` — given a manifest body
+  containing `endpoint: ${DARKEN_HUB_ENDPOINT}`, with env
+  `DARKEN_HUB_ENDPOINT=http://example:9090`, returns body with
+  `endpoint: http://example:9090`.
+- `TestManifest_DefaultsHubEndpoint` — env unset → substitutes
+  `http://host.docker.internal:8080`.
+- `TestManifest_RestrictsExpansionToDarkenPrefix` — body containing
+  `$HOME` is left untouched (only `${DARKEN_*}` substitutes).
+- `TestManifest_AllTemplatesUseSubstitution` — sweeps all 14
+  templates, asserts each contains `${DARKEN_HUB_ENDPOINT}` and
+  no literal `host.docker.internal` string.
+
+**Implementation:**
+- Edit each of the 28 manifest files (project + embedded copies).
+- Add `expandManifest(body string) string` using `os.Expand` with
+  a custom mapper that ignores anything not matching `^DARKEN_`.
+- Wire `expandManifest` into the path that materializes a manifest
+  for spawn (likely upstream of `scion templates show` /
+  `scion spawn`'s manifest pickup — implementer decides exact
+  insertion point during implementation; see `cmd/darken/spawn.go`
+  + `cmd/darken/manifest.go`).
+
+**Commit:**
+1. `templates: replace hardcoded hub.endpoint with ${DARKEN_HUB_ENDPOINT}`
+2. `cmd/darken: expandManifest substitutes DARKEN_* env vars only`
+3. `cmd/darken: wire manifest expansion into spawn path`
+
+(One-task-multi-commit is fine; keep the test green at each.)
+
+---
+
+## Wave B — Bugfixes
+
+### Task B1 — Bug #1: `bones init` rerun no-ops
+
+**Files touched:**
+- existing: `cmd/darken/init.go` (`runBonesInit`)
+- existing: `cmd/darken/init_test.go`
+
+**Failing test (`init_test.go`):**
+- `TestRunBonesInit_AlreadyInitializedIsNoOp` — stub `bones` on PATH
+  to print `workspace already initialized` to stderr and exit 1.
+  Asserts `runBonesInit` returns nil and stdout contains
+  `bones init: workspace already initialized (skipping)`.
+- `TestRunBonesInit_RealFailureStillReturnsError` — stub `bones` to
+  exit 1 with stderr `bones: io error`. Asserts non-nil return.
+
+**Implementation:**
+- Capture combined output instead of inheriting.
+- Match `workspace already initialized` substring; if matched,
+  print the skip notice and return nil. Else preserve current
+  behavior.
+- Existing soft-fail-then-continue caller stays unchanged.
+
+**Commit:** `cmd/darken: bones init rerun is a clean no-op`
+
+---
+
+### Task B2 — Bug #3: `stage-creds.sh` print-after-push
+
+**Files touched:**
+- existing: `scripts/stage-creds.sh`
+- existing: `internal/substrate/data/scripts/stage-creds.sh`
+- new: `scripts/test-stage-creds-push-ordering.sh`
+  (or extend existing `scripts/test-stage-creds.sh`)
+
+**Failing test (`scripts/test-stage-creds-push-ordering.sh`):**
+- Stub `scion` on PATH that exits 1 (simulate failed PUT).
+- Run `stage-creds.sh claude` against a fixture keychain blob.
+- Assert: stdout does NOT contain `pushed (file →`.
+- Assert: exit non-zero.
+- Stub `scion` to exit 0; rerun; assert stdout DOES contain the
+  `pushed` line.
+
+**Implementation:**
+- In `push_file_secret` and `push_env_secret`, restructure:
+  ```
+  if scion hub secret set …; then
+    echo "stage-creds: ${name} pushed (…)"
+  else
+    return 1
+  fi
+  ```
+  No bare `echo` after `set -e` letting the success line print
+  before the call. Identical change in both copies (project + embedded).
+
+**Commit:**
+1. `scripts/stage-creds: print success only after scion PUT succeeds`
+2. `internal/substrate/data: mirror stage-creds.sh ordering fix`
+
+(Embed-drift test `scripts/test-embed-drift.sh` should already
+catch divergence between the two copies.)
+
+---
+
+### Task B3 — Bug #4: doctor daemon liveness
+
+**Files touched:**
+- existing: `cmd/darken/doctor.go` (`checkScionServer`)
+- existing: `cmd/darken/doctor_test.go`
+
+**Failing test (`doctor_test.go`):**
+- `TestCheckScionServer_FailsOnDaemonNotRunning` — stub `scion` to
+  print `Daemon: not running\n` to stdout and exit 0. Assert
+  `checkScionServer()` returns non-nil error mentioning "daemon".
+- `TestCheckScionServer_OkOnDaemonRunning` — stub prints
+  `Daemon: running\n`, exits 0. Assert nil error.
+- `TestCheckScionServer_AmbiguousIsWarn` — stub prints output with
+  no `Daemon:` line, exits 0. Assert non-nil error (treat ambiguous
+  as fail; the spec calls this WARN but unit-test-wise we promote
+  to fail until the doctor framework supports WARN return values).
+
+**Implementation:**
+- Capture combined output.
+- Scan for `Daemon: not running`, `Daemon: stopped`, `Daemon: running`.
+- Return error or nil per match.
+- Include raw output in the error message for ambiguous case.
+
+**Commit:** `cmd/darken/doctor: parse Daemon: line to detect dead scion server`
+
+---
+
+### Task B4 — Bug #7a: propagate prelude pre-clone to codex/gemini/pi
+
+**Files touched:**
+- existing: `images/codex/darkish-prelude.sh` (the v0.1.15 claude
+  patch is the reference)
+- existing: `images/gemini/darkish-prelude.sh`
+- existing: `images/pi/darkish-prelude.sh`
+- new or existing: `images/test-prelude-symmetry.sh`
+
+**Failing test (`images/test-prelude-symmetry.sh`):**
+- Diff the four `darkish-prelude.sh` files against each other,
+  ignoring backend-specific blocks (delimited by
+  `# backend-specific:start` / `# backend-specific:end`). Assert
+  the pre-clone workaround block is present and identical across
+  all four.
+
+**Implementation:**
+- Copy the v0.1.15 claude pre-clone block to the other three,
+  wrapped in `# darkish-prelude:pre-clone-workaround:start /
+  :end` markers.
+- Ensure the test diffs the marker blocks, not the whole file.
+
+**Commit:** `images: propagate sciontool pre-clone workaround to codex, gemini, pi preludes`
+
+---
+
+### Task B5 — Bug #7b: doctor sciontool sniff-test
+
+**Files touched:**
+- existing: `cmd/darken/doctor.go`
+- existing: `cmd/darken/doctor_test.go`
+
+**Failing test:**
+- `TestDoctor_SciontoolSniff_GatedByFlag` — invoking
+  `runDoctor([]string{})` does NOT run the sniff. Invoking
+  `runDoctor([]string{"--check=sciontool"})` does.
+- `TestDoctor_SciontoolSniff_DetectsEmptyStderrFailure` — stub
+  `docker run` to exit non-zero with empty stderr. Assert reported
+  as the FS-incompatibility pattern with the prelude-workaround
+  remediation hint.
+
+**Implementation:**
+- Add a `--check=sciontool` flag dispatch path in `runDoctor`.
+- Implementation runs the smallest available darkish image with
+  `sciontool init /tmp/test_grove`. Captures combined output.
+- On non-zero exit + empty stderr → FS-incompat (known pattern).
+- On non-zero exit + non-empty stderr → unrelated failure, report
+  the stderr as-is.
+
+**Commit:** `cmd/darken/doctor: add --check=sciontool sniff for FS+go-git incompatibility`
+
+---
+
+### Task B6 — Bug #8: bootstrap runs `scion broker provide`
+
+**Files touched:**
+- existing: `cmd/darken/bootstrap.go`
+- existing: `cmd/darken/bootstrap_test.go`
+
+**Failing test (`bootstrap_test.go`):**
+- `TestEnsureBrokerProvide_CallsScionBrokerProvide` — stub `scion`
+  on PATH that records its argv. Asserts `ensureBrokerProvide()`
+  invoked `scion broker provide`.
+- `TestEnsureBrokerProvide_PropagatesError` — stub exits 1; assert
+  non-nil return that surfaces the broker output.
+
+**Implementation:**
+- New step `{"broker provides current grove", ensureBrokerProvide}`
+  inserted in `runBootstrap`'s steps slice between
+  `ensureScionServer` and `ensureImages`.
+- `ensureBrokerProvide()` shells via `scionCmd([]string{"broker",
+  "provide"})`. (Grove identity assumed implicit; if the
+  implementer discovers scion needs an explicit grove arg, surface
+  it via the existing repo-root resolver and document.)
+
+**Commit:** `cmd/darken/bootstrap: provide current grove to broker`
+
+---
+
+### Task B7 — Bug #9: doctor detects missing /etc/hosts entry
+
+**Files touched:**
+- existing: `cmd/darken/doctor.go`
+- existing: `cmd/darken/doctor_test.go`
+
+**Failing test:**
+- `TestDoctor_HostDockerInternal_GatedByEndpoint` — when
+  `DARKEN_HUB_ENDPOINT=http://my-broker:9090`, the check is SKIPped.
+- `TestDoctor_HostDockerInternal_DetectsResolverFailure` — stub the
+  in-container probe to exit 2 (name not found). Assert FAIL with
+  remediation showing both the `/etc/hosts` one-liner AND the
+  `DARKEN_HUB_ENDPOINT` knob alternative.
+- `TestDoctor_HostDockerInternal_OkWhenResolves` — probe succeeds
+  → OK.
+
+**Implementation:**
+- New check function `checkHostDockerInternal()` in `doctor.go`.
+- Skip when `DARKEN_HUB_ENDPOINT` is set and doesn't contain
+  `host.docker.internal`.
+- Probe via `docker run --rm <smallest-darkish-image> getent hosts
+  host.docker.internal` (image guaranteed present after
+  `ensureImages`).
+- Add to `doctorBroad`'s checks slice after `checkImages` (so
+  image-missing is caught first; otherwise the probe spuriously
+  fails on image-not-built).
+
+**Commit:** `cmd/darken/doctor: detect host.docker.internal resolution failure`
+
+---
+
+### Task B8 — Bug #10: setup uploads all 14 templates at user scope
+
+**Files touched:**
+- existing: `cmd/darken/setup.go`
+- new: `cmd/darken/setup_uploads.go` (or inline; implementer's call)
+- existing: `cmd/darken/setup_test.go`
+
+**Failing test (`setup_test.go`):**
+- `TestRunSetup_UploadsAll14TemplatesAtUserScope` — stub `scion`
+  on PATH recording argvs. Run `runSetup([]string{})`. Assert at
+  least 14 invocations of `scion templates upload <name> --scope
+  user`, one per role in `canonicalRoles`. Ordering not asserted.
+- `TestRunSetup_TemplateUploadIdempotent` — stub `scion templates
+  upload` to exit 0 with body `template already exists` — assert
+  setup still returns nil.
+- `TestRunSetup_TemplateUploadHardError` — stub exits 1 with
+  unrelated error; assert setup returns non-nil.
+
+**Implementation:**
+- After `runBootstrap` completes successfully, iterate
+  `canonicalRoles` (from Task A1). For each, invoke
+  `scionCmd(["templates", "upload", role, "--scope", "user"])`.
+- Treat "already exists" (or scion's idempotent-no-op signal) as
+  success. Treat other non-zero as fail-fast (with the role name
+  in the error).
+
+**Commit:** `cmd/darken/setup: upload all 14 templates to Hub at user scope`
+
+---
+
+## Wave C — Substrate + skills
+
+### Task C1 — `make vendor-skills` pipeline
+
+**Files touched:**
+- new: `internal/substrate/skills.manifest.txt`
+- existing: `Makefile` (or new `vendor-skills.mk` included from it)
+- new: `scripts/test-vendor-skills.sh`
+- existing: `scripts/test-embed-drift.sh` (extend to cover skills tree)
+
+**Failing test (`scripts/test-vendor-skills.sh`):**
+- Setup: create a tmpdir representing a fake `agent-config` with
+  `skills/hipp/SKILL.md` and `skills/ousterhout/SKILL.md`.
+- Set `DARKEN_SKILLS_SOURCE=$tmpdir`.
+- Run `make vendor-skills`.
+- Assert `internal/substrate/data/skills/hipp/SKILL.md` exists and
+  matches the source.
+- Assert: when a manifest entry is missing from the source tree,
+  `make vendor-skills` exits non-zero with the missing skill name.
+- Assert: re-running is idempotent (no diff on second run).
+
+**Implementation:**
+- `internal/substrate/skills.manifest.txt`: list one skill per
+  line, with optional `:in-tree` suffix to mark those sourced from
+  the embedded data directory itself (`superpowers`, `spec-kit`).
+  Default source is `${DARKEN_SKILLS_SOURCE:-$HOME/projects/agent-config/skills}/<name>/`.
+- `make vendor-skills` target: bash loop reads the manifest, copies
+  each non-`:in-tree` skill into `internal/substrate/data/skills/<name>/`
+  via `rsync -a --delete`. Hard-fails on missing source.
+- `make darken` declares `vendor-skills` as a prereq.
+- Extend `scripts/test-embed-drift.sh` to also assert the skills
+  tree under `internal/substrate/data/skills/` matches what would
+  be produced by `make vendor-skills` against the manifest (using
+  the operator's actual canon directory; CI can pin a fixture).
+
+**Commit:**
+1. `internal/substrate: declare skills.manifest.txt with vendored roster`
+2. `Makefile: add vendor-skills target gated on skills.manifest.txt`
+3. `scripts: test-vendor-skills smoke + extended embed-drift coverage`
+
+---
+
+### Task C2 — Author MV `superpowers` + `spec-kit` skill shells
+
+**Files touched:**
+- new: `internal/substrate/data/skills/superpowers/SKILL.md`
+- new: `internal/substrate/data/skills/spec-kit/SKILL.md`
+- (manifest declares both `:in-tree` from C1)
+
+**Failing test:**
+- `TestEmbeddedSkillsHaveSuperpowersAndSpecKit` (Go test in
+  `internal/substrate/embed_test.go` if it exists, else new):
+  asserts `embed.FS.ReadFile("data/skills/superpowers/SKILL.md")`
+  and `…/spec-kit/SKILL.md` both succeed and have non-empty
+  bodies starting with valid SKILL.md frontmatter (`---\nname:`).
+
+**Implementation:**
+- Author minimum-viable `SKILL.md` shells for both. Frontmatter
+  block + a 2-paragraph "what this skill is, what it isn't" body
+  that maps to the planner-t3 / planner-t4 system-prompts'
+  expectations. Full content is an explicit follow-on; the goal
+  here is "manifest references resolve" so planner-t3 / planner-t4
+  no longer reference missing skills.
+
+**Commit:** `internal/substrate: minimum-viable superpowers and spec-kit SKILL shells`
+
+---
+
+### Task C3 — Replace `CANONICAL` hardcode in stage-skills
+
+**Files touched:**
+- existing: `scripts/stage-skills.sh`
+- existing: `internal/substrate/data/scripts/stage-skills.sh`
+- existing: `cmd/darken/script_runner.go` (extend `scriptEnv()`)
+- existing: `cmd/darken/script_runner_test.go`
+- existing: `scripts/test-stage-skills.sh` (extend)
+
+**Failing test:**
+- `TestScriptEnv_InjectsSkillsCanonical` (Go) — asserts
+  `scriptEnv()` includes `DARKEN_SKILLS_CANONICAL=<path>`.
+- `test-stage-skills.sh` extension — set
+  `DARKEN_SKILLS_CANONICAL=$tmpdir/fake-canon`, populate the fake
+  canon, run stage-skills, assert it materialized from the fake
+  canon (not from the operator's `~/projects/agent-config`).
+
+**Implementation:**
+- In `scripts/stage-skills.sh`: replace
+  `CANONICAL="${HOME}/projects/agent-config/skills"` with
+  `CANONICAL="${DARKEN_SKILLS_CANONICAL:-${HOME}/projects/agent-config/skills}"`.
+  Mirror in the embedded copy.
+- In `script_runner.go`'s `scriptEnv()`:
+  - In dev mode (binary run from a working tree): set
+    `DARKEN_SKILLS_CANONICAL=$DARKEN_REPO_ROOT/internal/substrate/data/skills`
+    if that path exists.
+  - In release mode (no working tree): extract the embedded
+    skills tree to a tmp dir per-invocation, set
+    `DARKEN_SKILLS_CANONICAL` to the tmpdir, schedule cleanup.
+  - Operator override (env var pre-set) wins.
+
+**Commit:**
+1. `scripts/stage-skills: read CANONICAL from DARKEN_SKILLS_CANONICAL env`
+2. `cmd/darken/script_runner: inject DARKEN_SKILLS_CANONICAL from substrate`
+
+---
+
+### Task C4 — Bug #11: rewrite orchestrator-mode + subagent-to-subharness
+
+**Files touched:**
+- existing: `.claude/skills/orchestrator-mode/SKILL.md`
+- existing: `internal/substrate/data/skills/orchestrator-mode/SKILL.md`
+- existing: `.claude/skills/subagent-to-subharness/SKILL.md`
+- existing: `internal/substrate/data/skills/subagent-to-subharness/SKILL.md`
+- existing: `cmd/darken/doctor_test.go` (drift check should stay green)
+
+**Failing tests:**
+- `TestOrchestratorSkill_BiasesTowardSubharness` (new Go test in
+  `internal/substrate/skills_content_test.go`):
+  - `embed.FS` read of `data/skills/orchestrator-mode/SKILL.md`
+    contains the literal phrase
+    `dispatch a subharness for any task that fits one of the 14 roles`.
+  - Contains the literal phrase
+    `Agent tool is the fallback`.
+- `TestSubagentToSubharness_ListsAllRoles` — `embed.FS` read of
+  the mapping skill's body contains each of the 14 role names from
+  `canonicalRoles`.
+- `TestSubstrateDriftStaysGreen` — `checkSubstrateDrift()` returns
+  the OK string after the rewrite (project + embedded copies must
+  match byte-for-byte).
+
+**Implementation (per spec §3.3):**
+- Rewrite the decision tree in `subagent-to-subharness/SKILL.md`'s
+  "Decision tree" section so the first branch is "Does the task
+  fit a role? → Yes: spawn. No: stay inline / Agent."
+- Add the four exception clauses (substrate-down, no-role-fit,
+  operator-override, already-spawned) verbatim per spec.
+- Add the role-fit trigger phrase set to the mapping table (one
+  extra column per row showing trigger phrases).
+- In `orchestrator-mode/SKILL.md`'s Step 2 routing classifier:
+  insert the role-fit precheck before the six-axis scoring. If a
+  role matches, skip the axes and dispatch.
+- Mirror identical edits to both project and embedded copies.
+
+**Commit:**
+1. `skills/subagent-to-subharness: bias decision tree toward subharness`
+2. `skills/orchestrator-mode: role-fit precheck before routing axes`
+3. `internal/substrate/data: mirror skill rewrites`
+
+---
+
+### Task C5 — End-to-end smoke
+
+**Files touched:**
+- existing: `scripts/test-end-to-end.sh`
+
+**Failing test (extension):**
+- New phase: after `darken setup` completes on a fixture clean
+  grove, assert each of the following in order:
+  1. `scion server status` reports daemon running.
+  2. `scion broker list` (or equivalent) shows the current grove
+     provided.
+  3. `scion templates list --scope user` includes all 14 roles.
+  4. `darken doctor` exits 0 with no FAIL lines.
+  5. `darken spawn smoke-1 --type researcher "say hi"` exits 0
+     and the agent reaches a non-`Starting` state within
+     `DARKEN_SPAWN_READY_TIMEOUT`.
+- Optionally: run from a *different* grove (fixture clean dir
+  with no templates) and assert step 5 still works (proves the
+  user-scope upload is doing what bug #10 needed).
+
+**Implementation:** sequencing of existing commands; no new
+production code.
+
+**Commit:** `scripts: end-to-end test covers v0.1.16 setup invariants`
+
+---
+
+## Acceptance criteria
+
+The plan is complete when:
+
+1. `make darken && bin/darken doctor` exits 0 on a fresh laptop
+   after `brew install` (no `agent-config` clone).
+2. `bin/darken setup` in a fresh grove succeeds with no manual
+   `/etc/hosts` edits when `DARKEN_HUB_ENDPOINT` is unset and the
+   operator's machine already has `host.docker.internal`
+   resolvable; OR with `DARKEN_HUB_ENDPOINT=…` set, no host edits
+   needed.
+3. `bin/darken spawn …` works from a *different* grove than the
+   one where `darken setup` ran (templates uploaded at user scope
+   per #10).
+4. `scripts/test-stage-creds-push-ordering.sh` proves no
+   "pushed" line escapes when scion is unhealthy.
+5. `bin/darken doctor` reports FAIL when the daemon is down (vs.
+   the v0.1.15 OK lie).
+6. `bin/darken doctor --check=sciontool` correctly identifies the
+   FS+go-git incompatibility pattern.
+7. `planner-t3` / `planner-t4` spawn cleanly with all declared
+   skills resolving from the substrate (no
+   `agent-config/skills/superpowers` not-found errors).
+8. The orchestrator-mode + subagent-to-subharness skills' rewritten
+   decision tree leads with role-fit; an operator reading the
+   skills can name the four exception clauses.
+9. The drift check in `darken doctor` reports OK for both rewritten
+   skills (project + embedded copies match).
+10. The end-to-end script (Task C5) runs green in CI.
+
+## Test discipline reminder
+
+Every task above lists the failing test FIRST. The implementer
+writes the test, watches it fail with the expected error, then
+writes the minimal implementation to make it pass, then commits.
+No skipping the failing-test step. No combining multiple tasks
+into a mega-commit.
+
+## Open questions deferred (NOT blocking implementation)
+
+- **Grove identity for `scion broker provide`** — implementer
+  discovers during B6. If scion needs explicit grove arg, surface
+  via repo-root resolver and document; if implicit, no change
+  beyond the spawn invocation.
+- **Sciontool upstream issue** — operator files outside this plan;
+  the in-repo deliverable is the doctor sniff-test.
+- **`superpowers` / `spec-kit` full content** — C2 ships shells
+  good enough to resolve the manifest references; full skills are
+  follow-on work tracked separately.
+- **Doctor WARN return value** — the current framework returns
+  `error` only (binary OK/FAIL). True WARN support is a follow-on;
+  for now ambiguous-daemon-output is treated as FAIL per Task B3.

--- a/docs/superpowers/specs/2026-04-29-darken-setup-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-29-darken-setup-fixes-design.md
@@ -1,0 +1,439 @@
+# Darken setup fixes — design (v0.1.16)
+
+Status: draft (planner-t2)
+Date: 2026-04-29
+Successor of: v0.1.15 (`docs/superpowers/plans/2026-04-28-darken-setup.md`)
+Related: `2026-04-28-bones-inter-harness-comms-design.md` (out-of-scope here),
+`2026-04-28-roles-bases-template-collapse-design.md` (interacts with §A below)
+
+## 1. Goal
+
+Eliminate the eleven blocking and noise-class failures observed during
+the v0.1.15 fresh-repo `darken setup` debugging session. Make
+`darken setup` succeed end-to-end on a clean machine — no manual
+`/etc/hosts` edits, no cross-grove template gaps, no
+cross-repo-clone dependency on the operator's `agent-config`.
+
+## 2. Architecture summary (3 sentences)
+
+`darken setup` becomes the single source of truth for fresh-repo
+onboarding: it bundles every canonical skill into the binary via
+`go:embed`, registers all 14 templates at user scope on the Hub, and
+provides the grove to the broker — no out-of-band manual steps. The
+per-template hardcoded Hub endpoint is replaced with a runtime knob
+read by a centralized `scion-cmd` helper, removing the brittle
+`/etc/hosts` dependency for the common case while keeping the
+operator's `host.docker.internal` workflow as the documented default.
+The orchestrator-mode skill is rewritten to bias toward subharness
+dispatch when any of the 14 roles fits the task — the Anthropic
+`Agent` tool becomes an explicit fallback rather than the default for
+"light/pure-text" work.
+
+## 3. Three top-line architectural calls
+
+These are the decisions that ripple across the most files. They are
+ratified up front so the per-bug tasks below can reference a single
+choice rather than re-litigating in each task.
+
+### 3.1 Bundling shape — `go:embed` + vendor pipeline (resolves bug #2)
+
+**Choice:** Bundle canonical skills into the substrate via `go:embed`,
+sourced at build time from a configurable canonical directory.
+
+**Rejected alternatives:**
+
+| Option | Why rejected |
+|---|---|
+| Vendor dir checked into repo | Doubles disk footprint, drift between vendored copy and operator's working canon, non-trivial review noise on every skill bump. |
+| Git submodule (`agent-skills` as submodule) | Operator just renamed `agent-skills` → `agent-config`; submodule pinning becomes another moving piece, and submodules + worktrees (which scion uses) have known correctness pitfalls. |
+| Clone-on-bootstrap | Network dependency at setup time; `darken setup` already aspires to be local-only after `brew install darken`; would re-introduce the failure mode v0.1.15 was trying to remove. |
+
+**Justification:**
+
+- The substrate resolver already layers `flag → env → user → project →
+  embedded`. Embedding extends a pattern that already exists in
+  `internal/substrate/data/skills/` (orchestrator-mode and
+  subagent-to-subharness ship today via `go:embed`). No new mechanism.
+- Embedding makes a `darken` binary version self-contained: a fresh
+  laptop with `brew install darken` has every skill it needs without
+  any other clone, secret, or network step.
+- Operator override survives via the existing resolver layers — power
+  users who want a working-tree copy of a skill can drop it in
+  `${DARKEN_SUBSTRATE_OVERRIDE}/data/skills/<name>/` and the resolver
+  picks it up over the embedded copy, exactly as it does today for
+  `orchestrator-mode/SKILL.md` (see `cmd/darken/doctor.go`'s drift
+  check).
+
+**Vendor pipeline (build-time):**
+
+- Add `internal/substrate/skills.manifest.txt` — a newline-separated
+  list of canonical skill names darken bundles. Initial roster:
+  `hipp`, `ousterhout`, `superpowers`, `spec-kit`, plus the existing
+  `orchestrator-mode` and `subagent-to-subharness` (already embedded).
+- Add `make vendor-skills` target. Reads the manifest. For each
+  skill, copies `${DARKEN_SKILLS_SOURCE:-$HOME/projects/agent-config/skills}/<name>/`
+  into `internal/substrate/data/skills/<name>/`. Idempotent.
+- `make darken` declares `vendor-skills` as a prerequisite.
+- CI: `make vendor-skills` + `git diff --exit-code internal/substrate/data/skills`
+  catches drift between the manifest and what's checked into the
+  embedded tree.
+
+**Missing skills (`superpowers`, `spec-kit`):**
+
+- The brief notes these don't exist in agent-config today.
+- `make vendor-skills` will hard-fail on the first missing skill so
+  the gap is visible at build time rather than at runtime in a
+  containerized planner-t3 / planner-t4.
+- Mitigation in this spec: a sub-task in §4 (Bug #2) authors
+  minimum-viable `SKILL.md` shells for `superpowers` and `spec-kit`
+  in the substrate's embedded tree directly (i.e. checked into
+  `internal/substrate/data/skills/superpowers/` and
+  `…/spec-kit/`), rather than waiting on agent-config to grow them.
+  The manifest can declare these two as "in-tree" (sourced from
+  `internal/substrate/data/skills/`) versus the rest as "vendored"
+  (sourced from agent-config). One make target, two source roots.
+
+**Tradeoff accepted:** bumping a skill requires a `darken` rebuild +
+release. This is desirable: deterministic substrate per binary
+version. Drift is now a release-time concern, not a runtime one.
+
+**Stopgap removal:** v0.1.15 inline-patched the `CANONICAL` path in
+`scripts/stage-skills.sh` and `internal/substrate/data/scripts/stage-skills.sh`
+from `~/projects/agent-skills/skills` to `~/projects/agent-config/skills`.
+After this fix, `CANONICAL` resolves from an injected env var
+(`DARKEN_SKILLS_CANONICAL`, set by `script_runner.go`) pointing at
+either the operator's working canon (dev mode) or a tmpdir extracted
+from the embedded tree (release mode). The hardcoded path goes away.
+
+### 3.2 Hub URL strategy — config knob + doctor check, NOT auto-/etc/hosts (resolves bugs #6, #9)
+
+**Choice:** Replace the per-template hardcoded
+`http://host.docker.internal:8080` with a substrate-resolved knob
+applied at spawn time by a centralized `scion-cmd` helper. Pair with
+a `darken doctor` check that flags missing `/etc/hosts` entries and
+prints the exact remediation command — but darken does NOT run sudo.
+
+**Rejected alternative (a):** auto-add `/etc/hosts` entry via sudo
+prompt in `darken setup`. Reasons:
+
+- A sudo prompt in a wrapper script is a UX trap (looks legitimate;
+  trains operators to type sudo passwords into wrapper output).
+- Breaks headless / CI / container-of-containers flows.
+- macOS `host.docker.internal` is already a Docker Desktop
+  convenience name on that platform; on Linux it requires the
+  `--add-host` runtime flag or the explicit hosts entry. The solution
+  shape differs per OS — better to surface the remediation than try
+  to abstract.
+
+**Mechanism (replaces hardcode in 14 templates × 2 trees = 28 files):**
+
+- Templates declare `hub.endpoint: "${DARKEN_HUB_ENDPOINT}"` as a
+  literal placeholder string. The scion-cmd helper, before
+  invoking `scion spawn`, materializes the template through a tiny
+  substitution pass: any `${VAR}` pattern in the materialized
+  manifest is replaced with the env value, defaulting to
+  `http://host.docker.internal:8080` when unset.
+- This does NOT require a YAML library; the existing `scanField`
+  approach in `cmd/darken/doctor.go` already shows the project's
+  taste for hand-rolled scalar reads. Substitution can be a single
+  `os.Expand` call on the materialized manifest text before the
+  spawn shells out.
+- The default value of `DARKEN_HUB_ENDPOINT` preserves the v0.1.15
+  status quo: existing operators with a working `/etc/hosts` entry
+  see no behavior change.
+- Operators on Linux without `host.docker.internal` set
+  `DARKEN_HUB_ENDPOINT=http://172.17.0.1:8080` (the docker0 bridge)
+  and stop editing /etc/hosts.
+- Operators running darken-in-darken or remote-broker setups override
+  to whatever URL their broker advertises.
+
+**Doctor check (#9):**
+
+- New check `host.docker.internal resolvable from container`:
+  - probes resolution from inside the smallest local image (e.g.
+    `docker run --rm local/darkish-claude:latest getent hosts host.docker.internal`).
+  - on FAIL: print exact remediation
+    (`echo "$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}') host.docker.internal" | sudo tee -a /etc/hosts`)
+    AND mention the `DARKEN_HUB_ENDPOINT` knob as the no-sudo
+    alternative.
+- Check is gated by `DARKEN_HUB_ENDPOINT == "" || endpoint contains 'host.docker.internal'`
+  — operators who've moved off the magic name don't get spurious warnings.
+
+**Tradeoff accepted:** operators on a clean Linux machine still need
+one manual decision (edit `/etc/hosts` OR set the env var). We
+surface the choice rather than make it for them. Sudo-in-wrapper is
+worse than one-time documented friction.
+
+### 3.3 Skill bias rule — subharness is the default; `Agent` is the fallback (resolves bug #11)
+
+**Choice:** Rewrite the orchestrator-mode skill's classifier and the
+subagent-to-subharness mapping table so the decision tree leads with
+"does any of the 14 roles fit?" If yes → spawn subharness, even when
+the routing axes say "light/pure-text". The `Agent` tool is reserved
+for: (a) substrate genuinely unavailable (doctor fails), (b) no role
+matches the task shape, (c) explicit operator override.
+
+**Justification:**
+
+- The Darkish Factory's value prop is cross-vendor + isolated-context
+  + auditable dispatch. Using `Agent` for delegate-shaped work
+  bypasses every one of those properties — it runs in-process, same
+  vendor, no audit log entry, no worktree.
+- A "pure-text → inline OR Agent" default trains the orchestrator
+  to keep work in-process. The repo's CLAUDE.md is explicit: the
+  orchestrator should not implement inline. The skill must reflect
+  that, not contradict it.
+- Most "pure-text" tasks have a role fit:
+  - "produce a brief on X" → researcher
+  - "review this diff" → reviewer
+  - "answer this focused question" → sme
+  - "audit / chronicle activity" → admin
+  - "draft a spec" → designer
+  - "plan TDD steps" → planner-t1..t4
+  The natural-language hook lookup is wide; very few tasks land
+  outside the role matrix.
+
+**Rule statement (will appear in both skills verbatim):**
+
+```
+Default: dispatch a subharness for any task that fits one of the 14
+roles, regardless of routing-axis weight.
+
+Exceptions (when to stay inline or use Agent instead):
+  1. Substrate not available (`darken doctor` fails or scion server
+     is down). Inline / Agent is forced.
+  2. No role fit. Examples: "explain how X flows through this repo"
+     (open-ended exploration with no deliverable artifact),
+     "summarize the last three commits" (read-only report-back).
+     Use Agent (Explore) or stay inline.
+  3. Operator explicit override ("just do it", "no spawn", "inline").
+  4. Already-spawned: an agent for this task is live (`darken list`
+     shows it). Don't double-spawn; resume via `scion send`.
+
+Anti-patterns kept from the previous skill version:
+  - Don't spawn yourself (orchestrator role).
+  - Don't spawn for trivial 30-second edits (and even then, only in
+    operator-direct mode, not orchestrator mode).
+```
+
+**Mapping-table changes (subagent-to-subharness skill):**
+
+The "Subagent reflex → Subharness equivalent" table grows two
+columns: a **role-fit** trigger phrase set, and a **fallback** column
+naming when `Agent` is appropriate. Example row:
+
+```
+| "I'll explore the codebase to find X"
+| `darken spawn r1 --type researcher "find X; output to docs/research-brief.md"`
+| Use `Agent (Explore)` only if X is a one-shot lookup with no artifact (< 30s).
+```
+
+The Decision tree's first branch flips from
+`Pure-text host work? → Stay inline` to
+`Does the task fit a role? → Yes: spawn. No: stay inline.`
+
+**Tradeoff accepted:** subharness dispatch is more expensive (cold
+container start, separate hub auth, polling). Some tasks that today
+take 30 seconds inline will become 60-second async dispatches. We're
+paying that cost for the substrate's value prop. Operator can always
+override.
+
+## 4. Per-bug design notes
+
+The plan document at `docs/superpowers/plans/2026-04-29-darken-setup-fixes.md`
+breaks each into TDD tasks. This section captures only design
+decisions and tradeoffs that go beyond "fix the bug as described".
+
+### Bug #1 — `bones init` rerun noise
+
+**Decision:** detect-and-skip pattern, not `bones join` substitution.
+
+`bones join` joins an existing workspace under a different name; it's
+not equivalent to "rerun-as-no-op" semantically. The right response
+to "already initialized" is "do nothing, exit 0, print a one-line
+notice." `runBonesInit` in `cmd/darken/init.go` already soft-fails
+(non-fatal); the change is to treat the specific
+`workspace already initialized` exit pattern as a clean no-op and
+print `bones init: workspace already initialized (skipping)`.
+
+**Detection:** match on the exact stderr substring
+`workspace already initialized` from the bones command's combined
+output. Avoids parsing exit codes (which are noisy across bones
+versions).
+
+### Bug #3 — `stage-creds.sh` print-before-success
+
+**Decision:** straightforward fix; no design surface.
+
+Move the `echo "stage-creds: ${name} pushed …"` lines to AFTER the
+`scion hub secret set` call has succeeded. Bash `set -e` already
+aborts the function on a failed `scion` call, so simply reordering
+the two lines (with a noop guard `local rc=0; scion ... || rc=$?;
+[[ $rc -eq 0 ]] && echo …; return $rc`) is enough. Test asserts the
+"pushed" line is absent when scion is mocked to fail.
+
+### Bug #4 — `darken doctor` daemon liveness
+
+**Decision:** parse `Daemon:` line from `scion server status`, OR
+probe `/healthz` if the scion server exposes one.
+
+Inspecting the brief, the symptom is: `scion server status` exits 0
+but the body says daemon-not-running. So `exec.Command("scion",
+"server", "status").Run()` is the wrong check — the exit code is
+unreliable. Capture stdout, scan for either:
+
+- a literal `Daemon: not running` (or `Daemon: stopped`) line — fail
+- a literal `Daemon: running` line — pass
+- ambiguous output (no Daemon: line at all) — WARN with the raw
+  output included for debugging
+
+**Tradeoff:** parsing CLI output is fragile across scion versions.
+Mitigation: keep the regex narrow (just `Daemon:` line) and add a
+unit test with both string forms. If `/healthz` is exposed in a
+future scion release, switch.
+
+### Bug #5 — centralized `scion-cmd` helper
+
+**Decision:** new file `cmd/darken/scion_cmd.go` (paired with
+`scion_cmd_test.go`). Pure function:
+
+```go
+// signature only — implementation in plan
+type scionCmdOpts struct { … }
+func scionCmd(args []string, opts scionCmdOpts) *exec.Cmd
+```
+
+The helper:
+
+- Sets `SCION_HUB_ENDPOINT=${DARKEN_HUB_ENDPOINT}` (the §3.2 knob).
+- Sets `DARKEN_REPO_ROOT` (already done in `script_runner.go`).
+- Forwards stdout/stderr unless `Captured` is set.
+- Threads `posArgs` correctly — fixing the `--`-vs-positional bug
+  v0.1.15 inline-patched in `runSpawn`.
+
+Existing call sites migrate one at a time: `runDoctor`'s
+`exec.Command("scion", …)` lines, `runBootstrap`'s
+`ensureScionServer`, `runSpawn`'s spawn invocation. Migration is
+mechanical; each migration commit gets a regression test.
+
+**Regression test for spawn posArgs:** the inline v0.1.15 fix needs
+a test that asserts the trailing positional task string is passed
+through verbatim (not swallowed by flag parsing). Done as the first
+task that touches `runSpawn`, before the migration to
+`scion_cmd.go`.
+
+### Bug #7 — prelude pre-clone propagation + sciontool sniff-test
+
+**Decision:** propagate the v0.1.15 claude prelude workaround
+verbatim to the other three preludes (`images/codex/`,
+`images/gemini/`, `images/pi/`). Add a doctor check that performs
+the FS-incompatibility sniff-test using whatever the smallest
+locally-available image is.
+
+The brief mentions "file an upstream issue with scion". I leave that
+as an out-of-band action item for the operator; the doctor check is
+the in-repo deliverable. The sniff-test:
+
+- Skip on host (workaround is image-side; host doctor doesn't
+  reproduce the bug).
+- Run as: `docker run --rm <smallest-image> sciontool init /tmp/test_grove`
+  in a tmpdir. On empty-stderr non-zero exit, FAIL with remediation
+  pointing at the prelude pre-clone workaround comment.
+
+**Tradeoff:** the sniff-test runs a container, which is slow (~2-5s)
+and requires images already built. Gate it behind a
+`--check=sciontool` flag on doctor so the default broad doctor stays
+fast; add it to the per-harness doctor pass instead.
+
+### Bug #8 — `scion broker provide`
+
+**Decision:** add a step to `runBootstrap` between `ensureScionServer`
+and `ensureImages`:
+
+```
+"broker provides current grove" → ensureBrokerProvide
+```
+
+`ensureBrokerProvide`: shells out via the new `scion-cmd` helper to
+`scion broker provide <grove-id>`. Idempotent on the scion side
+(provide-already-provided is a no-op). On error, surface the broker
+output and exit 1 — broker-not-providing is fatal for spawn to work
+in the current grove.
+
+**Open question to operator (deferred to skill rewrite, not blocking
+this plan):** is the grove-id implicit (current dir) or does darken
+need to compute/persist it? Plan task assumes implicit; if scion
+requires explicit, the implementer adds a `darken init`-time grove
+discovery step.
+
+### Bug #10 — upload all 14 templates at user scope
+
+**Decision:** add a step to `runBootstrap` (or `runSetup`,
+post-bootstrap) that iterates the 14 known roles and uploads each
+via `scion templates upload <name> --scope user`. Idempotent on the
+scion side.
+
+Use the canonical roster constant — defined once in a new
+`cmd/darken/roles.go` (or extending `script_runner.go`'s pattern):
+
+```go
+var canonicalRoles = []string{
+  "admin", "base", "darwin", "designer", "orchestrator",
+  "planner-t1", "planner-t2", "planner-t3", "planner-t4",
+  "researcher", "reviewer", "sme", "tdd-implementer", "verifier",
+}
+```
+
+The same constant feeds the §3.3 skill rewrite (the role-fit table)
+once we surface it in the embedded skills. To be explicit: this
+constant is the authoritative source, and the spec/skill rewrites
+reference it by-name.
+
+**Tradeoff:** uploads run every `darken bootstrap`. That's fine —
+the operation is idempotent and cheap. Alternative (only upload
+once, persist a marker) introduces state divergence between the
+binary's view of templates and the Hub's; idempotent re-upload is
+simpler.
+
+### Bug #11 — orchestrator-mode + subagent-to-subharness rewrite
+
+Already covered in §3.3 above. The plan's task is the actual edit
+to both `SKILL.md` files (project copies + embedded copies, since
+they're checked-in twins under `internal/substrate/data/skills/`).
+A doctor-style drift check (`checkSubstrateDrift` in `doctor.go`)
+already detects when project copies diverge from embedded copies; we
+make sure that check fires green after the rewrite by editing both.
+
+## 5. Non-goals (this spec)
+
+- Mode A pivot. Stays out.
+- Inter-harness messaging. See `2026-04-28-bones-inter-harness-comms-design.md`.
+- Template collapse. See `2026-04-28-roles-bases-template-collapse-design.md`
+  — note the §3.1 bundling work creates new embedded skills; if the
+  collapse spec moves templates around, the bundling pipeline needs
+  to follow but doesn't block.
+- New skills authoring beyond `superpowers` + `spec-kit` minimum-
+  viable shells. Full skill content is a follow-on.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| `make vendor-skills` source paths drift between operator machines | Manifest declares each skill's source explicitly (in-tree vs vendored); CI runs `make vendor-skills` + `git diff --exit-code`. |
+| `os.Expand` on a manifest substitutes a `$VAR` we didn't intend | Restrict substitution to `${DARKEN_HUB_ENDPOINT}` and `${DARKEN_*}` prefix only via custom `os.Expand` mapper. |
+| Operator on Linux without docker0 access still hits the URL bug | Doctor check + remediation message now both fire; the default no longer assumes the magic name resolves. |
+| Skill rewrite surprises an operator who explicitly wanted Agent for everything | Operator override clause ("just do it", "no spawn") preserved verbatim. |
+| Bundling breaks the substrate-drift doctor check | `checkSubstrateDrift` only checks `orchestrator-mode/SKILL.md` today; expanding it to all canonical skills is a future improvement, not a blocker. |
+| `scion broker provide` semantics don't match the assumption | Plan task includes a smoke step that runs the command in a clean grove and asserts spawn works after. If the assumption is wrong, the implementer escalates rather than guessing. |
+
+## 7. Out-of-scope deferrals captured here
+
+- A proper IPC channel from a subharness up to the orchestrator (so a
+  planner's clarifying questions can reach the operator). Bug #2's
+  brief flagged this — see referenced design doc for the path.
+- Multi-grove broker discovery. Once #10 ships, every grove sees
+  every template, but cross-grove agent dispatch (e.g. orchestrator
+  in grove A spawns in grove B) is its own design.
+- The `bones join` semantics. We rule it out for #1; if the
+  operator later wants explicit "join existing workspace" support,
+  it's a separate subcommand.


### PR DESCRIPTION
## Summary

- planner-t2 produced this in the orchestrator pipeline. Cherry-picked from `.scion/agents/plan-1/workspace` (branch `plan/darken-setup-fixes-2026-04-29`).
- Two artifacts: TDD plan + design spec. Three top-line architectural calls in spec: bundling = `go:embed` + `make vendor-skills`; Hub URL = `${DARKEN_HUB_ENDPOINT}` placeholder + doctor check (NOT auto-/etc/hosts); skill bias = subharness default, `Agent` is fallback.

## Files

- `docs/superpowers/specs/2026-04-29-darken-setup-fixes-design.md` (21 KB)
- `docs/superpowers/plans/2026-04-29-darken-setup-fixes.md` (26 KB, 18 tasks across 3 waves)

## What's NOT in this plan (queued for v0.1.17)

- **Bug #12** — specs in git, plans in bones (`bones repo ci`); modify `superpowers:writing-plans` to detect bones mode via env
- **Bug #13** — add architecture as 4th deferral axis in §7 escalation gate (alongside taste/ethics/reversibility)
- **Tier roster cleanup** — delete `planner-t1`; planner-t2 keeps clarifying-question capability

## Test plan

- [ ] Merge this PR so impl-1 (tdd-implementer) can clone main and read the plan
- [ ] tdd-implementer dispatch → wave A → wave B → wave C