### PR TITLE
fix(tests): unblock v0.1.17 tag — realign 2 stale assertions to post-REVIEW-7 contract

### DIFF
--- a/cmd/darken/skill_filter_test.go
+++ b/cmd/darken/skill_filter_test.go
@@ -227,8 +227,12 @@ esac
 	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
 	t.Setenv("DARKEN_REPO_ROOT", repoRoot)
 
-	if err := runSpawn([]string{"filt-1", "--type", "researcher", "task"}); err != nil {
-		t.Fatalf("spawn: %v", err)
+	// REVIEW-7 consolidated staging into buildSkillsStaging which wipes and
+	// re-stages from manifest. This test verifies the filter step in
+	// isolation by calling filterSkillsForRole directly on the pre-populated
+	// dir; full-spawn integration is exercised by TestSpawnInvokesStageThenScion.
+	if err := filterSkillsForRole(stagingDir, "researcher"); err != nil {
+		t.Fatalf("filter: %v", err)
 	}
 
 	// visible-skill must remain (researcher is listed)

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -45,9 +45,9 @@ func TestSpawnInvokesStageThenScion(t *testing.T) {
 	if !strings.Contains(string(body), "stage-creds.sh") {
 		t.Fatalf("stage-creds.sh not invoked: %s", body)
 	}
-	if !strings.Contains(string(body), "stage-skills.sh") {
-		t.Fatalf("stage-skills.sh not invoked: %s", body)
-	}
+	// REVIEW-7 consolidated skill staging into the Go-side
+	// buildSkillsStaging; spawn no longer invokes a stage-skills.sh
+	// shell script, so the prior bash-stub assertion has been removed.
 	if !strings.Contains(string(body), "start smoke-1") {
 		t.Fatalf("scion start not invoked: %s", body)
 	}


### PR DESCRIPTION
## Summary

v0.1.17 PR #29 merged but the goreleaser pre-hook (\`go test ./...\`) catches 2 stale test assertions that were authored against pre-REVIEW-7 code paths. Without this fix the v0.1.17 tag fails CI.

## Root cause

REVIEW-7 consolidated skill staging into Go (\`buildSkillsStaging\`) which wipes and re-stages from manifest. Two tests were authored against the pre-REVIEW-7 contract where staging was a separate shell-script step on a pre-populated dir.

## Fix

1. **TestSpawn_FiltersSkillsByRole** — call \`filterSkillsForRole\` directly on the pre-populated dir instead of \`runSpawn\` (which wipes the dir). Filter logic is what this test verifies; spawn integration is covered separately.

2. **TestSpawnInvokesStageThenScion** — drop the stale \`stage-skills.sh\` shell-script assertion (the script is no longer invoked; staging is pure Go). \`stage-creds.sh\` and \`scion start\` assertions remain.

## Verification

- \`go test ./...\` — all 3 packages pass
- \`bash scripts/test-vendor-skills-drift.sh\` — PASS
- \`bash scripts/test-skill-shells.sh\` — PASS
- \`bash scripts/test-stage-skills-canonical.sh\` — PASS
- \`bash scripts/test-prelude-token-safety.sh\` — PASS
- \`bash scripts/test-embed-drift.sh\` — PASS

## Note

A red herring along the way: a stale \`~/.config/darken/overrides/\` from prior development was shadowing project + embedded researcher manifest with old content. Cleaned locally; not relevant to the fix.

After merge → tag v0.1.17.