### PR TITLE
feat(v0.1.18): 9 swarm-built bug fixes

### DIFF
--- a/.claude/skills/orchestrator-mode/SKILL.md
+++ b/.claude/skills/orchestrator-mode/SKILL.md
@@ -240,6 +240,55 @@ The 3-strikes ceiling is deliberate: a worker that hangs three times in a row is
 
 After every redispatch (whether terminal or not), append an audit entry with `type: dispatch`, `outcome: ratified`, payload including `target_role`, `agent_name`, and a note that this was a redispatch (e.g. `payload.redispatch_of: "<previous decision_id>"`). This makes `darken history` show the recovery loop.
 
+## Steering live subharnesses
+
+### Outbound: sending instructions mid-flight
+
+Use `scion message` to reach a running subharness without stopping it.
+
+Single-agent message:
+```bash
+scion message <agent-name> "your updated instruction" --notify
+```
+
+Broadcast to all running agents:
+```bash
+scion message --broadcast "halt; await orchestrator signal before next commit" --notify
+```
+
+Only message when the subharness is between tool calls. Messaging during mid-tool execution is swallowed by the TUI buffer and rarely surfaces cleanly. If `scion look <name>` shows a tool running (file edit, bash, test run), wait for it to complete before sending.
+
+Cadence rule: do not poll or message faster than 2 minutes per agent. Rapid-fire messages produce duplicate handling; the harness has no dedup layer.
+
+### Inbound: receiving messages from subharnesses
+
+Subharnesses route inbound signals two ways:
+
+1. **AskUserQuestion** -- the harness needs operator input. The hook fires, pauses the agent, and surfaces the question to the orchestrator session. You see it as a notification.
+2. **SessionStop** -- the harness hit a terminal condition (success or unrecoverable error). Forward-reference: Bug 17 wires these hooks into the substrate; until Bug 17 lands, monitor via `scion look` heartbeat.
+
+When an AskUserQuestion arrives, run it through the four-axis escalation classifier before answering:
+
+| Axis | Route if unclear |
+|---|---|
+| taste | answer directly; log rationale |
+| architecture | escalate to operator; do not self-ratify |
+| ethics | escalate immediately; do not self-ratify |
+| reversibility | escalate if change is hard to undo; else answer directly |
+
+The classifier fires on every inbound question, not just suspicious ones. Low-confidence answers on architecture or reversibility always escalate.
+
+### Priority decision tree
+
+When a subharness message or AskUserQuestion arrives, triage in this order:
+
+1. **Hard stop** -- ethics violation, credential exposure, destructive op outside worktree -> send `scion message <name> "stop immediately"` and escalate to operator.
+2. **Redirect** -- task is mis-specified or scope has shifted -> send corrected instruction via `scion message`; log the redirect in the audit trail.
+3. **Ack-only** -- harness is reporting progress, no action needed -> append audit entry; no reply required.
+4. **Hands-off** -- harness is operating correctly within spec -> do nothing; monitor via heartbeat.
+
+Default to hands-off unless the classifier fires a higher priority.
+
 ## What this skill is NOT
 
 - Not a substitute for the containerized `.scion/templates/orchestrator/` system-prompt -- that one runs in a container; this one runs in your host session.

--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -8,5 +8,8 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,5 +14,8 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/planner-t3/scion-agent.yaml
+++ b/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,5 +16,8 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,5 +15,8 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/Makefile
+++ b/Makefile
@@ -74,23 +74,40 @@ e2e-smoke:
 
 .PHONY: sync-embed-data
 sync-embed-data:
-	rm -rf $(SUBSTRATE_DATA)
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	while IFS= read -r skill || [ -n "$$skill" ]; do \
+		[ -z "$$skill" ] && continue; \
+		case "$$skill" in \#*) continue ;; esac; \
+		if [ ! -d ".claude/skills/$$skill" ] && [ -d "$(SUBSTRATE_DATA)/skills/$$skill" ]; then \
+			cp -R "$(SUBSTRATE_DATA)/skills/$$skill" "$$tmpdir/" && \
+			echo "sync-embed-data: preserving vendored skill $$skill"; \
+		fi; \
+	done < "$(SKILLS_MANIFEST)"; \
+	rm -rf $(SUBSTRATE_DATA); \
 	mkdir -p $(SUBSTRATE_DATA)/.scion $(SUBSTRATE_DATA)/scripts \
 		$(SUBSTRATE_DATA)/images $(SUBSTRATE_DATA)/skills \
-		$(SUBSTRATE_DATA)/templates
-	cp -R .scion/templates $(SUBSTRATE_DATA)/.scion/
+		$(SUBSTRATE_DATA)/templates; \
+	cp -R .scion/templates $(SUBSTRATE_DATA)/.scion/; \
 	cp scripts/bootstrap.sh scripts/spawn.sh scripts/stage-creds.sh \
-		scripts/stage-skills.sh $(SUBSTRATE_DATA)/scripts/
-	cp images/Makefile images/README.md $(SUBSTRATE_DATA)/images/
+		scripts/stage-skills.sh $(SUBSTRATE_DATA)/scripts/; \
+	cp images/Makefile images/README.md $(SUBSTRATE_DATA)/images/; \
 	for backend in claude codex gemini pi; do \
 		mkdir -p $(SUBSTRATE_DATA)/images/$$backend && \
 		cp images/$$backend/Dockerfile images/$$backend/darkish-prelude.sh \
 			$(SUBSTRATE_DATA)/images/$$backend/; \
-	done
-	cp -R .claude/skills/orchestrator-mode $(SUBSTRATE_DATA)/skills/
-	cp -R .claude/skills/subagent-to-subharness $(SUBSTRATE_DATA)/skills/
-	cp -R .claude/skills/writing-plans $(SUBSTRATE_DATA)/skills/
-	cp -R .claude/skills/superpowers $(SUBSTRATE_DATA)/skills/
-	cp -R .claude/skills/spec-kit $(SUBSTRATE_DATA)/skills/
-	cp templates/CLAUDE.md.tmpl $(SUBSTRATE_DATA)/templates/
-	@echo "synced $(SUBSTRATE_DATA) from canonical sources"
+	done; \
+	cp -R .claude/skills/orchestrator-mode $(SUBSTRATE_DATA)/skills/; \
+	cp -R .claude/skills/subagent-to-subharness $(SUBSTRATE_DATA)/skills/; \
+	cp -R .claude/skills/writing-plans $(SUBSTRATE_DATA)/skills/; \
+	cp -R .claude/skills/superpowers $(SUBSTRATE_DATA)/skills/; \
+	cp -R .claude/skills/spec-kit $(SUBSTRATE_DATA)/skills/; \
+	cp templates/CLAUDE.md.tmpl $(SUBSTRATE_DATA)/templates/; \
+	for d in "$$tmpdir"/*/; do \
+		[ -d "$$d" ] || continue; \
+		skill=$$(basename "$$d"); \
+		cp -R "$$d" "$(SUBSTRATE_DATA)/skills/$$skill"; \
+		echo "sync-embed-data: restored vendored skill $$skill"; \
+	done; \
+	rm -rf "$$tmpdir"; \
+	echo "synced $(SUBSTRATE_DATA) from canonical sources"

--- a/cmd/darken/harness_manifest.go
+++ b/cmd/darken/harness_manifest.go
@@ -21,6 +21,9 @@ type HarnessManifest struct {
 	Backend string
 	// Skills is the ordered list of skill refs declared in the manifest.
 	Skills []string
+	// CommandArgs is the ordered list of extra CLI arguments appended to the
+	// harness invocation. Used to pass --betas flags for extended context.
+	CommandArgs []string
 }
 
 // loadHarnessManifest parses a scion-agent.yaml body into a typed HarnessManifest.
@@ -43,7 +46,8 @@ func loadHarnessManifest(body []byte) (HarnessManifest, error) {
 	if skills == nil {
 		skills = []string{}
 	}
-	return HarnessManifest{Backend: backend, Skills: skills}, nil
+	cmdArgs := scanList(s, "command_args:")
+	return HarnessManifest{Backend: backend, Skills: skills, CommandArgs: cmdArgs}, nil
 }
 
 // harnessSecretFor returns the hub secret name required by a given backend.

--- a/cmd/darken/harness_manifest_test.go
+++ b/cmd/darken/harness_manifest_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/danmestas/darken/internal/substrate"
 )
 
 func TestLoadHarnessManifest_ParsesBackendAndSkills(t *testing.T) {
@@ -78,6 +81,70 @@ func TestLoadHarnessManifest_SkillsAsInlineList(t *testing.T) {
 	}
 	if len(m.Skills) != 3 {
 		t.Fatalf("want 3 skills, got %d: %v", len(m.Skills), m.Skills)
+	}
+}
+
+// TestLoadHarnessManifest_ParsesCommandArgs verifies that loadHarnessManifest
+// reads the command_args block sequence from a manifest body.
+func TestLoadHarnessManifest_ParsesCommandArgs(t *testing.T) {
+	body := []byte("default_harness_config: claude\ncommand_args:\n  - --betas\n  - context-1m-2025-08-07\n")
+	m, err := loadHarnessManifest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.CommandArgs) != 2 {
+		t.Fatalf("CommandArgs: want 2 entries, got %d: %v", len(m.CommandArgs), m.CommandArgs)
+	}
+	if m.CommandArgs[0] != "--betas" {
+		t.Errorf("CommandArgs[0]: want --betas, got %q", m.CommandArgs[0])
+	}
+	if m.CommandArgs[1] != "context-1m-2025-08-07" {
+		t.Errorf("CommandArgs[1]: want context-1m-2025-08-07, got %q", m.CommandArgs[1])
+	}
+}
+
+// TestLoadHarnessManifest_EmptyCommandArgs verifies that a manifest without
+// command_args returns a nil or empty slice with no error.
+func TestLoadHarnessManifest_EmptyCommandArgs(t *testing.T) {
+	body := []byte("default_harness_config: codex\n")
+	m, err := loadHarnessManifest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.CommandArgs) != 0 {
+		t.Errorf("CommandArgs: want empty, got %v", m.CommandArgs)
+	}
+}
+
+// TestTddImplementerManifest_HasBetasFlag asserts the embedded tdd-implementer
+// manifest declares command_args with the 1M-context betas flag. This is the
+// regression anchor for Bug 24.
+func TestTddImplementerManifest_HasBetasFlag(t *testing.T) {
+	efs := substrate.EmbeddedFS()
+	path := "data/.scion/templates/tdd-implementer/scion-agent.yaml"
+	body, err := fs.ReadFile(efs, path)
+	if err != nil {
+		t.Fatalf("cannot read embedded tdd-implementer manifest: %v", err)
+	}
+	m, err := loadHarnessManifest(body)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	hasBetas := false
+	hasContext := false
+	for _, arg := range m.CommandArgs {
+		if arg == "--betas" {
+			hasBetas = true
+		}
+		if strings.Contains(arg, "context-1m") {
+			hasContext = true
+		}
+	}
+	if !hasBetas {
+		t.Errorf("tdd-implementer CommandArgs missing --betas flag; got: %v", m.CommandArgs)
+	}
+	if !hasContext {
+		t.Errorf("tdd-implementer CommandArgs missing context-1m beta; got: %v", m.CommandArgs)
 	}
 }
 

--- a/cmd/darken/look.go
+++ b/cmd/darken/look.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+)
+
+// ansiEscape matches ANSI/VT100 escape sequences of the form ESC[...m
+// as well as cursor-control sequences (ESC[<n>J, ESC[H, etc.).
+// The pattern covers the common CSI (Control Sequence Introducer)
+// family used by terminal TUI toolkits.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+// stripANSI removes ANSI escape sequences from b and returns the
+// cleaned bytes. The original slice is not modified.
+func stripANSI(b []byte) []byte {
+	return ansiEscape.ReplaceAll(b, nil)
+}
+
+// runLook is the entry point registered in main.go. It delegates to
+// runLookInto with os.Stdout so tests can capture output.
+func runLook(args []string) error {
+	return runLookInto(args, os.Stdout)
+}
+
+// runLookInto runs `scion --no-hub look <agent>`, strips ANSI escape
+// sequences from the output, and writes clean text to w.
+func runLookInto(args []string, w io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: darken look <agent>")
+	}
+	agentName := args[0]
+	cmdArgs := append([]string{"--no-hub", "look", agentName}, args[1:]...)
+	cmd := exec.Command("scion", cmdArgs...)
+	raw, err := cmd.Output()
+	if err != nil {
+		// Surface stderr if available.
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			return fmt.Errorf("scion look %s: %w\n%s", agentName, err, ee.Stderr)
+		}
+		return fmt.Errorf("scion look %s: %w", agentName, err)
+	}
+	clean := stripANSI(raw)
+	_, werr := w.Write(clean)
+	return werr
+}
+
+// init registers the look subcommand so it appears in `darken --help`.
+// This is called from the package init chain; the subcommands slice is
+// defined in main.go and is safe to append during init.
+func init() {
+	subcommands = append(subcommands, subcommand{
+		name: "look",
+		desc: "inspect an agent terminal, ANSI-stripped (wraps scion look)",
+		run:  runLook,
+	})
+}

--- a/cmd/darken/look_test.go
+++ b/cmd/darken/look_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStripANSI asserts that stripANSI removes ANSI escape sequences
+// from input while leaving plain text untouched.
+func TestStripANSI(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no escapes",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "color reset",
+			input: "\x1b[0mhello\x1b[0m",
+			want:  "hello",
+		},
+		{
+			name:  "bold green text",
+			input: "\x1b[1;32mrunning\x1b[0m",
+			want:  "running",
+		},
+		{
+			name:  "cursor movement",
+			input: "\x1b[2J\x1b[Hsome output",
+			want:  "some output",
+		},
+		{
+			name:  "mixed content",
+			input: "phase: \x1b[32mrunning\x1b[0m (pid 42)",
+			want:  "phase: running (pid 42)",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripANSI([]byte(tc.input))
+			if string(got) != tc.want {
+				t.Errorf("stripANSI(%q) = %q; want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunLook_StripsANSIFromScionOutput asserts that runLook pipes scion
+// look output through stripANSI so the caller sees clean text.
+func TestRunLook_StripsANSIFromScionOutput(t *testing.T) {
+	// Stub scion to emit ANSI-decorated output on `look` subcommand.
+	stubDir := t.TempDir()
+	rawOutput := "\x1b[1;32mworker-1\x1b[0m phase: \x1b[33mrunning\x1b[0m\nsome log line\n"
+	script := "#!/bin/sh\nprintf '" + rawOutput + "'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	var buf bytes.Buffer
+	if err := runLookInto([]string{"worker-1"}, &buf); err != nil {
+		t.Fatalf("runLookInto returned error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("output still contains ANSI escapes: %q", out)
+	}
+	if !strings.Contains(out, "worker-1") {
+		t.Errorf("expected agent name in output, got: %q", out)
+	}
+	if !strings.Contains(out, "running") {
+		t.Errorf("expected phase in output, got: %q", out)
+	}
+}
+
+// TestRunLook_RequiresAgentArg asserts that runLook errors when no
+// agent name is supplied.
+func TestRunLook_RequiresAgentArg(t *testing.T) {
+	var buf bytes.Buffer
+	err := runLookInto([]string{}, &buf)
+	if err == nil {
+		t.Fatal("expected error when no agent name provided")
+	}
+	if !strings.Contains(err.Error(), "agent") {
+		t.Errorf("error should mention agent argument, got: %v", err)
+	}
+}

--- a/cmd/darken/prelude_test.go
+++ b/cmd/darken/prelude_test.go
@@ -8,6 +8,34 @@ import (
 	"github.com/danmestas/darken/internal/substrate"
 )
 
+// TestPrelude_SkillsDirPermissions verifies that every claude-backend prelude
+// writes a ~/.claude/settings.json that grants auto-allow for .claude/skills
+// writes. Without this, spawned agents block on a TUI dialog when editing
+// skill files even when --dangerously-skip-permissions is set.
+func TestPrelude_SkillsDirPermissions(t *testing.T) {
+	// All four backends use the claude harness image; only claude is covered
+	// here because codex/pi/gemini use non-claude CLI and have no settings.json
+	// concept. The marker must appear in the embedded prelude for "claude".
+	markers := []string{
+		".claude/skills",
+		"settings.json",
+		"permissions",
+	}
+
+	efs := substrate.EmbeddedFS()
+	path := "data/images/claude/darkish-prelude.sh"
+	body, err := fs.ReadFile(efs, path)
+	if err != nil {
+		t.Fatalf("cannot read embedded claude prelude at %s: %v", path, err)
+	}
+	text := string(body)
+	for _, m := range markers {
+		if !strings.Contains(text, m) {
+			t.Errorf("claude prelude missing skills-permission marker %q", m)
+		}
+	}
+}
+
 // TestPreludePreCloneBlockPropagated verifies that the three non-claude
 // prelude scripts contain the pre-clone workaround block that is
 // authoritative in images/claude/darkish-prelude.sh. Each prelude must

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -32,6 +32,11 @@ type ScionClient interface {
 
 	// PushTemplate uploads a role template to the hub at user (global) scope.
 	PushTemplate(role string) error
+
+	// GroveInit registers the current directory as a project-scoped scion grove.
+	// Idempotent at the caller level: callers check for .scion/grove-id before
+	// invoking this method.
+	GroveInit() error
 }
 
 // execScionClient is the production ScionClient that delegates to the scion binary.
@@ -72,6 +77,13 @@ func (c *execScionClient) BrokerProvide() error {
 
 func (c *execScionClient) PushTemplate(role string) error {
 	cmd := scionCmdWithEnv([]string{"--global", "templates", "push", role})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (c *execScionClient) GroveInit() error {
+	cmd := scionCmdWithEnv([]string{"grove", "init"})
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -16,9 +16,11 @@ type mockScionClient struct {
 	startAgentErr    error
 	brokerProvideErr error
 	pushTemplateErr  error
+	groveInitErr     error
 
 	startAgentCalls   [][]string
 	pushTemplateCalls []string
+	groveInitCalls    int
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -37,6 +39,10 @@ func (m *mockScionClient) BrokerProvide() error {
 func (m *mockScionClient) PushTemplate(role string) error {
 	m.pushTemplateCalls = append(m.pushTemplateCalls, role)
 	return m.pushTemplateErr
+}
+func (m *mockScionClient) GroveInit() error {
+	m.groveInitCalls++
+	return m.groveInitErr
 }
 
 // setDefaultClient replaces defaultScionClient for the duration of the test.

--- a/cmd/darken/setup.go
+++ b/cmd/darken/setup.go
@@ -8,16 +8,39 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 )
 
 func runSetup(args []string) error {
 	if err := runInit(args); err != nil {
 		return err
 	}
+	if err := ensureGroveInit(); err != nil {
+		return err
+	}
 	if err := runBootstrap(nil); err != nil {
 		return err
 	}
 	return uploadAllTemplatesToHub()
+}
+
+// ensureGroveInit registers the current directory as a project-scoped scion
+// grove by running scion grove init. It is idempotent: if .scion/grove-id
+// already exists the call is skipped entirely, avoiding a redundant round-trip
+// to the hub and preventing grove_id from being replaced.
+func ensureGroveInit() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("ensureGroveInit: getwd: %w", err)
+	}
+	groveIDPath := filepath.Join(cwd, ".scion", "grove-id")
+	if info, err := os.Stat(groveIDPath); err == nil && !info.IsDir() {
+		// Grove already initialised for this project; skip.
+		return nil
+	}
+	fmt.Println("initialising project grove ...")
+	return defaultScionClient.GroveInit()
 }
 
 // uploadAllTemplatesToHub pushes all 14 canonical templates to the Hub at

--- a/cmd/darken/setup_test.go
+++ b/cmd/darken/setup_test.go
@@ -203,6 +203,76 @@ func TestSetup_UploadsAllTemplatesToHub(t *testing.T) {
 	}
 }
 
+// TestSetup_GroveInit_InvokedOnce confirms runSetup calls GroveInit exactly
+// once when no .scion/grove-id file is present (fresh project).
+func TestSetup_GroveInit_InvokedOnce(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	stubAllBinariesForSetup(t)
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		serverStatusOut: "Status: ok\n",
+		secretListOut:   "claude_auth\ncodex_auth\n",
+	}
+	setDefaultClient(t, mc)
+
+	if err := runSetup(nil); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if mc.groveInitCalls != 1 {
+		t.Errorf("GroveInit called %d times; want 1 (fresh project, no grove-id)", mc.groveInitCalls)
+	}
+}
+
+// TestSetup_GroveInit_SkippedOnReSetup confirms runSetup does NOT call
+// GroveInit when .scion/grove-id already exists (idempotent guard).
+func TestSetup_GroveInit_SkippedOnReSetup(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	stubAllBinariesForSetup(t)
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-plant a grove-id file to simulate an already-initialised project.
+	scionDir := filepath.Join(root, ".scion")
+	if err := os.MkdirAll(scionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scionDir, "grove-id"),
+		[]byte("existing-grove-uuid\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		serverStatusOut: "Status: ok\n",
+		secretListOut:   "claude_auth\ncodex_auth\n",
+	}
+	setDefaultClient(t, mc)
+
+	if err := runSetup(nil); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if mc.groveInitCalls != 0 {
+		t.Errorf("GroveInit called %d times; want 0 (grove-id already present)", mc.groveInitCalls)
+	}
+}
+
 // TestSetup_TemplateUploadFailureAbortsSetup confirms that a PushTemplate error
 // propagates and aborts setup.
 func TestSetup_TemplateUploadFailureAbortsSetup(t *testing.T) {

--- a/cmd/darken/skill_staging.go
+++ b/cmd/darken/skill_staging.go
@@ -114,6 +114,31 @@ func copyDir(src, dst string) error {
 	})
 }
 
+// loadManifestForRole resolves and parses the scion-agent.yaml for the given
+// harnessType. Uses resolveTemplatesDir (project-local or embedded) so it works
+// in any environment where staging works. Returns an error when the manifest
+// cannot be read or parsed.
+func loadManifestForRole(harnessType string) (HarnessManifest, error) {
+	// Allow test overrides via DARKEN_TEMPLATES_DIR.
+	if dir := os.Getenv("DARKEN_TEMPLATES_DIR"); dir != "" {
+		body, err := os.ReadFile(filepath.Join(dir, harnessType, "scion-agent.yaml"))
+		if err != nil {
+			return HarnessManifest{}, fmt.Errorf("loadManifestForRole: %w", err)
+		}
+		return loadHarnessManifest(body)
+	}
+	templatesDir, cleanup, err := resolveTemplatesDir()
+	if err != nil {
+		return HarnessManifest{}, fmt.Errorf("loadManifestForRole: resolve templates: %w", err)
+	}
+	defer cleanup()
+	body, err := os.ReadFile(filepath.Join(templatesDir, harnessType, "scion-agent.yaml"))
+	if err != nil {
+		return HarnessManifest{}, fmt.Errorf("loadManifestForRole: read manifest: %w", err)
+	}
+	return loadHarnessManifest(body)
+}
+
 // stageSkillsForRole is the single entry point for skill staging called by
 // spawn. It resolves the templates directory (project-local or embedded),
 // the canonical skills source, and the output staging directory, then

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -38,10 +38,20 @@ func runSpawn(args []string) error {
 		}
 	}
 
+	// Load command_args from the manifest (non-fatal: missing or unreadable
+	// manifests degrade gracefully — operator still gets the agent started).
+	var extraArgs []string
+	if m, err := loadManifestForRole(*harnessType); err == nil {
+		extraArgs = m.CommandArgs
+	}
+
 	startArgs := []string{"--type", *harnessType}
 	if *backend != "" {
 		image := fmt.Sprintf("local/darkish-%s:latest", *backend)
 		startArgs = append(startArgs, "--harness", *backend, "--image", image)
+	}
+	if len(extraArgs) > 0 {
+		startArgs = append(startArgs, extraArgs...)
 	}
 	if len(posArgs) > 0 {
 		startArgs = append(startArgs, posArgs...)

--- a/cmd/darken/spawn_poller.go
+++ b/cmd/darken/spawn_poller.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -64,14 +65,37 @@ func pollUntilReady(agentName string, timeout, interval time.Duration, onPhaseCh
 
 // scionListAgents shells out to `scion list --format json` and parses
 // the result into agentInfo slices.
+//
+// scion sometimes prepends non-JSON diagnostic lines (e.g. a dev-auth
+// WARNING) before the JSON array. jsonStart strips those lines so the
+// unmarshal does not fail on the prefix.
 func scionListAgents() ([]agentInfo, error) {
 	out, err := exec.Command("scion", "list", "--format", "json").Output()
 	if err != nil {
 		return nil, err
 	}
+	jsonBytes := jsonStart(out)
 	var agents []agentInfo
-	if err := json.Unmarshal(out, &agents); err != nil {
+	if err := json.Unmarshal(jsonBytes, &agents); err != nil {
 		return nil, fmt.Errorf("parse scion list output: %w", err)
 	}
 	return agents, nil
+}
+
+// jsonStart returns the first line of b that starts with '[' or '{',
+// plus all subsequent bytes. Lines before that are silently discarded.
+// If no such line exists, the original slice is returned unchanged so
+// that the caller surfaces a descriptive json.Unmarshal error.
+func jsonStart(b []byte) []byte {
+	for len(b) > 0 {
+		if b[0] == '[' || b[0] == '{' {
+			return b
+		}
+		nl := bytes.IndexByte(b, '\n')
+		if nl < 0 {
+			return b
+		}
+		b = b[nl+1:]
+	}
+	return b
 }

--- a/cmd/darken/spawn_poller_test.go
+++ b/cmd/darken/spawn_poller_test.go
@@ -27,6 +27,31 @@ func stubScionList(t *testing.T, jsonBody string) {
 	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
 }
 
+// TestScionListAgents_StripsWarningPrefix asserts Bug 19: scion sometimes
+// prepends a dev-auth WARNING line before the JSON array. scionListAgents
+// must strip any non-JSON prefix lines so json.Unmarshal succeeds.
+func TestScionListAgents_StripsWarningPrefix(t *testing.T) {
+	stubDir := t.TempDir()
+	// Stub output: WARNING line then valid JSON array.
+	stubOutput := "WARNING: dev-auth mode; hub token unset\n" +
+		`[{"name":"worker-1","phase":"running","template":"researcher"}]`
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '" + stubOutput + "'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	agents, err := scionListAgents()
+	if err != nil {
+		t.Fatalf("expected success stripping WARNING prefix, got: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Name != "worker-1" {
+		t.Fatalf("expected [{worker-1 running researcher}], got %+v", agents)
+	}
+}
+
 func TestPollUntilReady_ReturnsWhenRunning(t *testing.T) {
 	stubScionList(t, `[{"name":"researcher-1","phase":"running"}]`)
 

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -168,3 +168,52 @@ func TestRunSpawn_FailsWithoutType(t *testing.T) {
 		t.Fatal("expected error when --type is missing, got nil")
 	}
 }
+
+// TestSpawn_ForwardsCommandArgsFromManifest verifies that runSpawn reads
+// command_args from the manifest and forwards them to StartAgent. Uses a
+// mock client to capture what StartAgent receives.
+func TestSpawn_ForwardsCommandArgsFromManifest(t *testing.T) {
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	// Create a temporary templates dir with a custom manifest that has
+	// command_args. No canonical skills dir needed because we use --no-stage.
+	tmpDir := t.TempDir()
+	harnessDir := filepath.Join(tmpDir, "custom-role")
+	if err := os.MkdirAll(harnessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "default_harness_config: claude\ncommand_args:\n  - --betas\n  - context-1m-2025-08-07\n"
+	if err := os.WriteFile(filepath.Join(harnessDir, "scion-agent.yaml"),
+		[]byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DARKEN_TEMPLATES_DIR", tmpDir)
+
+	// Scion stub for the readiness poller only (start is handled by mock).
+	stubDir := t.TempDir()
+	scionStub := `#!/bin/sh
+case "$1" in
+  list) echo '[{"name":"cmd-agent","phase":"running"}]'; exit 0 ;;
+  *)    exit 0 ;;
+esac
+`
+	os.WriteFile(filepath.Join(stubDir, "scion"), []byte(scionStub), 0o755)
+	os.WriteFile(filepath.Join(stubDir, "bash"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	if err := runSpawn([]string{"cmd-agent", "--type", "custom-role", "--no-stage", "task"}); err != nil {
+		t.Fatalf("runSpawn: %v", err)
+	}
+
+	if len(mc.startAgentCalls) == 0 {
+		t.Fatal("StartAgent was not called")
+	}
+	args := strings.Join(mc.startAgentCalls[0], " ")
+	if !strings.Contains(args, "--betas") {
+		t.Errorf("--betas not forwarded to StartAgent; args: %s", args)
+	}
+	if !strings.Contains(args, "context-1m-2025-08-07") {
+		t.Errorf("context-1m-2025-08-07 not forwarded to StartAgent; args: %s", args)
+	}
+}

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -100,7 +100,35 @@ if [[ -n "${SCION_GIT_CLONE_URL:-}" && -n "${GITHUB_TOKEN:-}" && ! -d /workspace
   fi
 fi
 
-# --- 4. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---
+# --- 4. Pre-allow .claude/skills writes in Claude Code settings.json ----------
+#
+# claude --dangerously-skip-permissions does NOT suppress the interactive TUI
+# dialog that fires when Claude Code writes to .claude/skills. Skill-editing
+# agents block on that dialog until a human presses Y. Fix: write a project-
+# level settings.json that adds an explicit allow entry for .claude/skills
+# before the session starts. This is idempotent: if the file already contains
+# the entry we leave it untouched; if it is absent or empty we write it.
+
+CLAUDE_SETTINGS="${HOME}/.claude/settings.json"
+mkdir -p "${HOME}/.claude"
+
+if [[ ! -f "${CLAUDE_SETTINGS}" ]] || ! grep -q '\.claude/skills' "${CLAUDE_SETTINGS}" 2>/dev/null; then
+  cat > "${CLAUDE_SETTINGS}" <<'SETTINGS_EOF'
+{
+  "permissions": {
+    "allow": [
+      "Write(**/.claude/skills/**)",
+      "Edit(**/.claude/skills/**)",
+      "Bash(mkdir -p **/.claude/skills/**)"
+    ],
+    "deny": []
+  }
+}
+SETTINGS_EOF
+  echo "darkish-prelude: wrote .claude/skills permissions to ${CLAUDE_SETTINGS}" >&2
+fi
+
+# --- 5. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---
 #
 # Scion's broker injects SCION_HUB_URL=http://localhost:8080 into the
 # container based on its bind address, ignoring per-template hub.endpoint.
@@ -116,7 +144,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Operator notification hooks ------------------------------------------
+# --- 6. Operator notification hooks ------------------------------------------
 #
 # Write a Claude Code Stop hook so SessionStop events route to the
 # operator via scion message.  The recipient is read from
@@ -173,7 +201,7 @@ else
   echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
 fi
 
-# --- 6. Hand off to scion ----------------------------------------------------
+# --- 7. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -116,7 +116,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 5. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 6. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/codex/darkish-prelude.sh
+++ b/images/codex/darkish-prelude.sh
@@ -104,7 +104,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 5. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 6. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/gemini/darkish-prelude.sh
+++ b/images/gemini/darkish-prelude.sh
@@ -61,7 +61,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Hand off to scion ----------------------------------------------------
+# --- 4. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/pi/darkish-prelude.sh
+++ b/images/pi/darkish-prelude.sh
@@ -61,7 +61,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Hand off to scion ----------------------------------------------------
+# --- 4. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -8,5 +8,8 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,5 +14,8 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,5 +16,8 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,5 +15,8 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
+command_args:
+  - --betas
+  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -100,7 +100,35 @@ if [[ -n "${SCION_GIT_CLONE_URL:-}" && -n "${GITHUB_TOKEN:-}" && ! -d /workspace
   fi
 fi
 
-# --- 4. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---
+# --- 4. Pre-allow .claude/skills writes in Claude Code settings.json ----------
+#
+# claude --dangerously-skip-permissions does NOT suppress the interactive TUI
+# dialog that fires when Claude Code writes to .claude/skills. Skill-editing
+# agents block on that dialog until a human presses Y. Fix: write a project-
+# level settings.json that adds an explicit allow entry for .claude/skills
+# before the session starts. This is idempotent: if the file already contains
+# the entry we leave it untouched; if it is absent or empty we write it.
+
+CLAUDE_SETTINGS="${HOME}/.claude/settings.json"
+mkdir -p "${HOME}/.claude"
+
+if [[ ! -f "${CLAUDE_SETTINGS}" ]] || ! grep -q '\.claude/skills' "${CLAUDE_SETTINGS}" 2>/dev/null; then
+  cat > "${CLAUDE_SETTINGS}" <<'SETTINGS_EOF'
+{
+  "permissions": {
+    "allow": [
+      "Write(**/.claude/skills/**)",
+      "Edit(**/.claude/skills/**)",
+      "Bash(mkdir -p **/.claude/skills/**)"
+    ],
+    "deny": []
+  }
+}
+SETTINGS_EOF
+  echo "darkish-prelude: wrote .claude/skills permissions to ${CLAUDE_SETTINGS}" >&2
+fi
+
+# --- 5. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---
 #
 # Scion's broker injects SCION_HUB_URL=http://localhost:8080 into the
 # container based on its bind address, ignoring per-template hub.endpoint.
@@ -116,7 +144,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Operator notification hooks ------------------------------------------
+# --- 6. Operator notification hooks ------------------------------------------
 #
 # Write a Claude Code Stop hook so SessionStop events route to the
 # operator via scion message.  The recipient is read from
@@ -173,7 +201,7 @@ else
   echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
 fi
 
-# --- 6. Hand off to scion ----------------------------------------------------
+# --- 7. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -116,7 +116,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 5. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 6. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/codex/darkish-prelude.sh
+++ b/internal/substrate/data/images/codex/darkish-prelude.sh
@@ -104,7 +104,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 5. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 6. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/gemini/darkish-prelude.sh
+++ b/internal/substrate/data/images/gemini/darkish-prelude.sh
@@ -61,7 +61,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Hand off to scion ----------------------------------------------------
+# --- 4. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/pi/darkish-prelude.sh
+++ b/internal/substrate/data/images/pi/darkish-prelude.sh
@@ -61,7 +61,64 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Hand off to scion ----------------------------------------------------
+# --- 4. Operator notification hooks ------------------------------------------
+#
+# Write a Claude Code Stop hook so SessionStop events route to the
+# operator via scion message.  The recipient is read from
+# DARKEN_HOOK_RECIPIENT (default: user:Development User).
+#
+# The hook also fires on PreToolUse:AskFollowupQuestion so question
+# events are forwarded before the session fully stops.
+#
+# Implementation: write a self-contained hook script, then merge the
+# hook declarations into ~/.claude/settings.json using jq.
+
+DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
+DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
+DARKEN_SETTINGS="${HOME}/.claude/settings.json"
+
+mkdir -p "${DARKEN_HOOKS_DIR}"
+
+cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
+#!/usr/bin/env bash
+# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
+set -uo pipefail
+RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
+AGENT="${SCION_AGENT_NAME:-unknown}"
+EVENT="${DARKISH_HOOK_EVENT:-Stop}"
+scion message --to "${RECIPIENT}" \
+  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
+HOOKEOF
+chmod +x "${DARKEN_HOOK_SCRIPT}"
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${DARKEN_SETTINGS}" ]]; then
+    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
+  else
+    EXISTING_SETTINGS='{}'
+  fi
+  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
+    .hooks = (.hooks // {}) |
+    .hooks.Stop = (
+      (.hooks.Stop // []) + [{
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
+      }]
+    ) |
+    .hooks.PreToolUse = (
+      (.hooks.PreToolUse // []) + [{
+        "matcher": "AskFollowupQuestion",
+        "hooks": [{"type": "command", "command": $cmd,
+                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
+      }]
+    )
+  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
+  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
+fi
+
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -115,12 +115,17 @@ PYEOF
 }
 
 do_rebuild() {
-  rm -rf "${STAGE_DIR}"
-  mkdir -p "${STAGE_DIR}"
+  # Use a per-process temp dir so parallel invocations never share a
+  # destination during cp.  The final rename is the only shared
+  # operation; the last writer wins and both processes exit 0.
+  local stage_tmp="${STAGE_DIR}.tmp.$$"
+  rm -rf "${stage_tmp}"
+  mkdir -p "${stage_tmp}"
   local refs
   refs="$(read_skills_from_manifest || true)"
   if [[ -z "${refs}" ]]; then
     echo "stage-skills: no role skills declared for ${HARNESS}" >&2
+    rm -rf "${stage_tmp}"
     return 0
   fi
   while IFS= read -r ref; do
@@ -128,14 +133,17 @@ do_rebuild() {
     local src dest name
     src="$(resolve_ref "${ref}")"
     name="${ref##*/}"
-    dest="${STAGE_DIR}/${name}"
+    dest="${stage_tmp}/${name}"
     if [[ ! -d "${src}" ]]; then
       echo "stage-skills: source skill missing at ${src}" >&2
+      rm -rf "${stage_tmp}"
       return 1
     fi
     cp -R "${src}" "${dest}"
-    echo "stage-skills: copied ${name} → ${dest}"
+    echo "stage-skills: copied ${name} → ${STAGE_DIR}/${name}"
   done <<< "${refs}"
+  rm -rf "${STAGE_DIR}"
+  mv "${stage_tmp}" "${STAGE_DIR}"
 }
 
 do_diff() {

--- a/internal/substrate/data/skills/orchestrator-mode/SKILL.md
+++ b/internal/substrate/data/skills/orchestrator-mode/SKILL.md
@@ -240,6 +240,55 @@ The 3-strikes ceiling is deliberate: a worker that hangs three times in a row is
 
 After every redispatch (whether terminal or not), append an audit entry with `type: dispatch`, `outcome: ratified`, payload including `target_role`, `agent_name`, and a note that this was a redispatch (e.g. `payload.redispatch_of: "<previous decision_id>"`). This makes `darken history` show the recovery loop.
 
+## Steering live subharnesses
+
+### Outbound: sending instructions mid-flight
+
+Use `scion message` to reach a running subharness without stopping it.
+
+Single-agent message:
+```bash
+scion message <agent-name> "your updated instruction" --notify
+```
+
+Broadcast to all running agents:
+```bash
+scion message --broadcast "halt; await orchestrator signal before next commit" --notify
+```
+
+Only message when the subharness is between tool calls. Messaging during mid-tool execution is swallowed by the TUI buffer and rarely surfaces cleanly. If `scion look <name>` shows a tool running (file edit, bash, test run), wait for it to complete before sending.
+
+Cadence rule: do not poll or message faster than 2 minutes per agent. Rapid-fire messages produce duplicate handling; the harness has no dedup layer.
+
+### Inbound: receiving messages from subharnesses
+
+Subharnesses route inbound signals two ways:
+
+1. **AskUserQuestion** -- the harness needs operator input. The hook fires, pauses the agent, and surfaces the question to the orchestrator session. You see it as a notification.
+2. **SessionStop** -- the harness hit a terminal condition (success or unrecoverable error). Forward-reference: Bug 17 wires these hooks into the substrate; until Bug 17 lands, monitor via `scion look` heartbeat.
+
+When an AskUserQuestion arrives, run it through the four-axis escalation classifier before answering:
+
+| Axis | Route if unclear |
+|---|---|
+| taste | answer directly; log rationale |
+| architecture | escalate to operator; do not self-ratify |
+| ethics | escalate immediately; do not self-ratify |
+| reversibility | escalate if change is hard to undo; else answer directly |
+
+The classifier fires on every inbound question, not just suspicious ones. Low-confidence answers on architecture or reversibility always escalate.
+
+### Priority decision tree
+
+When a subharness message or AskUserQuestion arrives, triage in this order:
+
+1. **Hard stop** -- ethics violation, credential exposure, destructive op outside worktree -> send `scion message <name> "stop immediately"` and escalate to operator.
+2. **Redirect** -- task is mis-specified or scope has shifted -> send corrected instruction via `scion message`; log the redirect in the audit trail.
+3. **Ack-only** -- harness is reporting progress, no action needed -> append audit entry; no reply required.
+4. **Hands-off** -- harness is operating correctly within spec -> do nothing; monitor via heartbeat.
+
+Default to hands-off unless the classifier fires a higher priority.
+
 ## What this skill is NOT
 
 - Not a substitute for the containerized `.scion/templates/orchestrator/` system-prompt -- that one runs in a container; this one runs in your host session.

--- a/internal/substrate/skill_rules_test.go
+++ b/internal/substrate/skill_rules_test.go
@@ -68,6 +68,50 @@ func TestWritingPlansSkill_ExistsAndHasBonesRepo(t *testing.T) {
 	}
 }
 
+// TestOrchestratorModeSkill_SteeringLiveSubharnesses asserts Bug 21: the
+// orchestrator-mode skill contains a "Steering live subharnesses" section
+// covering scion message outbound, AskUserQuestion + SessionStop inbound,
+// cadence rules, priority decision tree, and four-axis routing of
+// AskUserQuestion through the escalation classifier.
+func TestOrchestratorModeSkill_SteeringLiveSubharnesses(t *testing.T) {
+	phrases := []string{
+		"Steering live subharnesses",
+		"broadcast",
+		"scion message",
+		"AskUserQuestion",
+		"SessionStop",
+		"2 minutes",
+		"taste",
+		"architecture",
+		"ethics",
+		"reversibility",
+	}
+
+	// Embedded copy.
+	body, err := fs.ReadFile(EmbeddedFS(), "data/skills/orchestrator-mode/SKILL.md")
+	if err != nil {
+		t.Fatalf("orchestrator-mode embedded skill missing: %v", err)
+	}
+	s := string(body)
+	for _, phrase := range phrases {
+		if !strings.Contains(s, phrase) {
+			t.Errorf("embedded orchestrator-mode skill missing required phrase: %q", phrase)
+		}
+	}
+
+	// Canonical source copy.
+	canon, err := os.ReadFile("../../.claude/skills/orchestrator-mode/SKILL.md")
+	if err != nil {
+		t.Fatalf("canonical .claude/skills/orchestrator-mode/SKILL.md missing: %v", err)
+	}
+	cs := string(canon)
+	for _, phrase := range phrases {
+		if !strings.Contains(cs, phrase) {
+			t.Errorf("canonical orchestrator-mode skill missing required phrase: %q", phrase)
+		}
+	}
+}
+
 // TestOrchestratorModeSkill_ArchitectureAxis asserts Bug 13: architecture
 // is the 4th deferral axis in the escalation gate alongside taste, ethics,
 // and reversibility. Both the orchestrator-mode and subagent-to-subharness

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -115,12 +115,17 @@ PYEOF
 }
 
 do_rebuild() {
-  rm -rf "${STAGE_DIR}"
-  mkdir -p "${STAGE_DIR}"
+  # Use a per-process temp dir so parallel invocations never share a
+  # destination during cp.  The final rename is the only shared
+  # operation; the last writer wins and both processes exit 0.
+  local stage_tmp="${STAGE_DIR}.tmp.$$"
+  rm -rf "${stage_tmp}"
+  mkdir -p "${stage_tmp}"
   local refs
   refs="$(read_skills_from_manifest || true)"
   if [[ -z "${refs}" ]]; then
     echo "stage-skills: no role skills declared for ${HARNESS}" >&2
+    rm -rf "${stage_tmp}"
     return 0
   fi
   while IFS= read -r ref; do
@@ -128,14 +133,17 @@ do_rebuild() {
     local src dest name
     src="$(resolve_ref "${ref}")"
     name="${ref##*/}"
-    dest="${STAGE_DIR}/${name}"
+    dest="${stage_tmp}/${name}"
     if [[ ! -d "${src}" ]]; then
       echo "stage-skills: source skill missing at ${src}" >&2
+      rm -rf "${stage_tmp}"
       return 1
     fi
     cp -R "${src}" "${dest}"
-    echo "stage-skills: copied ${name} → ${dest}"
+    echo "stage-skills: copied ${name} → ${STAGE_DIR}/${name}"
   done <<< "${refs}"
+  rm -rf "${STAGE_DIR}"
+  mv "${stage_tmp}" "${STAGE_DIR}"
 }
 
 do_diff() {

--- a/scripts/test-stage-skills-concurrency.sh
+++ b/scripts/test-stage-skills-concurrency.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression test for Bug 18: two parallel stage-skills.sh invocations
+# must both succeed without cp errors (dest-exists race).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_WORK}"' EXIT
+
+# Build a fake canonical source with two skills.
+FAKE_CANONICAL="${TMPDIR_WORK}/skills"
+for skill in alpha-skill beta-skill; do
+  mkdir -p "${FAKE_CANONICAL}/${skill}"
+  echo "# ${skill}" > "${FAKE_CANONICAL}/${skill}/SKILL.md"
+done
+
+# Fake harness template that declares both skills.
+FAKE_HARNESS="concurrency-test-harness"
+FAKE_TEMPLATES="${TMPDIR_WORK}/templates/${FAKE_HARNESS}"
+mkdir -p "${FAKE_TEMPLATES}"
+cat > "${FAKE_TEMPLATES}/scion-agent.yaml" <<YAML
+skills:
+  - alpha-skill
+  - beta-skill
+YAML
+
+STAGE_DIR="${ROOT}/.scion/skills-staging/${FAKE_HARNESS}"
+rm -rf "${STAGE_DIR}"
+
+# Launch two parallel invocations and collect exit codes.
+DARKEN_SKILLS_CANONICAL="${FAKE_CANONICAL}" \
+DARKEN_TEMPLATES_DIR="${TMPDIR_WORK}/templates" \
+  bash "${ROOT}/scripts/stage-skills.sh" "${FAKE_HARNESS}" \
+  > "${TMPDIR_WORK}/out1.txt" 2>&1 &
+PID1=$!
+
+DARKEN_SKILLS_CANONICAL="${FAKE_CANONICAL}" \
+DARKEN_TEMPLATES_DIR="${TMPDIR_WORK}/templates" \
+  bash "${ROOT}/scripts/stage-skills.sh" "${FAKE_HARNESS}" \
+  > "${TMPDIR_WORK}/out2.txt" 2>&1 &
+PID2=$!
+
+RC1=0; RC2=0
+wait "${PID1}" || RC1=$?
+wait "${PID2}" || RC2=$?
+
+if [[ "${RC1}" -ne 0 ]]; then
+  echo "FAIL: first invocation exited ${RC1}" >&2
+  cat "${TMPDIR_WORK}/out1.txt" >&2
+  rm -rf "${STAGE_DIR}"
+  exit 1
+fi
+if [[ "${RC2}" -ne 0 ]]; then
+  echo "FAIL: second invocation exited ${RC2}" >&2
+  cat "${TMPDIR_WORK}/out2.txt" >&2
+  rm -rf "${STAGE_DIR}"
+  exit 1
+fi
+
+# Verify the staging dir has the expected skills after parallel runs.
+for skill in alpha-skill beta-skill; do
+  if [[ ! -f "${STAGE_DIR}/${skill}/SKILL.md" ]]; then
+    echo "FAIL: ${skill} missing from staging dir after parallel runs" >&2
+    rm -rf "${STAGE_DIR}"
+    exit 1
+  fi
+done
+
+rm -rf "${STAGE_DIR}"
+echo "PASS: parallel stage-skills.sh invocations both succeeded without cp errors"

--- a/scripts/test-subharness-stop-hook.sh
+++ b/scripts/test-subharness-stop-hook.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Regression test for Bug 17: darkish-prelude.sh must write a Claude Code
+# Stop hook so SessionStop events route to the operator via scion message.
+#
+# Tests:
+#   1. Static: prelude references settings.json hook wiring.
+#   2. Functional: running the prelude (with sciontool stubbed out) writes
+#      ~/.claude/settings.json with a Stop hook whose command calls scion.
+#   3. Functional: executing the hook script fires scion message --to.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PRELUDE="${ROOT}/images/claude/darkish-prelude.sh"
+
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Test 1: static analysis
+# ---------------------------------------------------------------------------
+if ! grep -q "settings.json\|hooks" "${PRELUDE}"; then
+  echo "FAIL T1: darkish-prelude.sh does not reference settings.json or hooks" >&2
+  FAIL=1
+else
+  echo "ok T1: prelude references hook configuration"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: prelude writes settings.json with Stop hook when executed
+# ---------------------------------------------------------------------------
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_WORK}"' EXIT
+
+FAKE_HOME="${TMPDIR_WORK}/home"
+FAKE_BIN="${TMPDIR_WORK}/bin"
+SCION_LOG="${TMPDIR_WORK}/scion-calls.log"
+
+mkdir -p "${FAKE_HOME}/.claude" "${FAKE_BIN}"
+
+# sciontool stub: exit immediately instead of initialising a workspace.
+cat > "${FAKE_BIN}/sciontool" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "${FAKE_BIN}/sciontool"
+
+# scion stub: record call arguments.
+cat > "${FAKE_BIN}/scion" << STUB
+#!/usr/bin/env bash
+echo "\$@" >> "${SCION_LOG}"
+exit 0
+STUB
+chmod +x "${FAKE_BIN}/scion"
+
+RC=0
+HOME="${FAKE_HOME}" \
+  PATH="${FAKE_BIN}:${PATH}" \
+  SCION_AGENT_NAME="test-harness-17" \
+  DARKEN_HOOK_RECIPIENT="user:test-operator" \
+  SCION_HUB_URL="" \
+  SCION_HUB_ENDPOINT="" \
+  DARKEN_HUB_ENDPOINT="" \
+  SCION_GIT_CLONE_URL="" \
+  bash "${PRELUDE}" 2>/dev/null || RC=$?
+
+SETTINGS="${FAKE_HOME}/.claude/settings.json"
+
+if [[ ! -f "${SETTINGS}" ]]; then
+  echo "FAIL T2a: settings.json not written by prelude (exit ${RC})" >&2
+  FAIL=1
+else
+  echo "ok T2a: settings.json written"
+  if ! jq -e '.hooks.Stop | length > 0' "${SETTINGS}" >/dev/null 2>&1; then
+    echo "FAIL T2b: Stop hook not present in settings.json" >&2
+    cat "${SETTINGS}" >&2
+    FAIL=1
+  else
+    echo "ok T2b: Stop hook present in settings.json"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: hook script calls scion message --to when executed
+# ---------------------------------------------------------------------------
+if [[ -f "${SETTINGS}" ]]; then
+  HOOK_CMD="$(jq -r '.hooks.Stop[0].hooks[0].command // empty' "${SETTINGS}" 2>/dev/null || true)"
+  if [[ -z "${HOOK_CMD}" ]]; then
+    echo "FAIL T3: cannot extract hook command from settings.json" >&2
+    FAIL=1
+  elif [[ ! -x "${HOOK_CMD}" ]]; then
+    echo "FAIL T3: hook command ${HOOK_CMD} is not executable" >&2
+    FAIL=1
+  else
+    HOME="${FAKE_HOME}" \
+      PATH="${FAKE_BIN}:${PATH}" \
+      SCION_AGENT_NAME="test-harness-17" \
+      DARKEN_HOOK_RECIPIENT="user:test-operator" \
+      bash "${HOOK_CMD}" < /dev/null 2>/dev/null || true
+
+    if [[ ! -f "${SCION_LOG}" ]]; then
+      echo "FAIL T3: scion was not called by the hook script" >&2
+      FAIL=1
+    elif ! grep -q "test-operator" "${SCION_LOG}"; then
+      echo "FAIL T3: scion call did not reference the configured recipient" >&2
+      cat "${SCION_LOG}" >&2
+      FAIL=1
+    else
+      echo "ok T3: hook script called scion message with correct recipient"
+    fi
+  fi
+fi
+
+[[ "${FAIL}" -eq 0 ]] && echo "PASS" || exit 1

--- a/scripts/test-sync-embed-data-preserves-vendored.sh
+++ b/scripts/test-sync-embed-data-preserves-vendored.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Regression test for Bug 27: make sync-embed-data must not wipe skills
+# that are listed in internal/substrate/skills.manifest.txt but are NOT
+# present in .claude/skills/ (i.e., vendored skills like hipp, ousterhout).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${ROOT}/internal/substrate/skills.manifest.txt"
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_WORK}"' EXIT
+
+# Create a fake SUBSTRATE_DATA pre-seeded with vendored skills.
+FAKE_DATA="${TMPDIR_WORK}/data"
+mkdir -p "${FAKE_DATA}/skills/hipp" "${FAKE_DATA}/skills/ousterhout"
+echo "# hipp stub" > "${FAKE_DATA}/skills/hipp/SKILL.md"
+echo "# ousterhout stub" > "${FAKE_DATA}/skills/ousterhout/SKILL.md"
+
+# Run sync-embed-data against the fake data dir.
+make -C "${ROOT}" sync-embed-data SUBSTRATE_DATA="${FAKE_DATA}" -s 2>&1
+
+# Assert vendored skills survived.
+FAILED=0
+while IFS= read -r skill || [[ -n "${skill}" ]]; do
+  [[ -z "${skill}" ]] && continue
+  case "${skill}" in \#*) continue ;; esac
+  # Skip skills that come from .claude/skills/ (they are not vendored).
+  if [[ -d "${ROOT}/.claude/skills/${skill}" ]]; then
+    continue
+  fi
+  # This skill is vendored; it must still be present after sync-embed-data.
+  if [[ ! -d "${FAKE_DATA}/skills/${skill}" ]]; then
+    echo "FAIL: vendored skill ${skill} was wiped by sync-embed-data" >&2
+    FAILED=1
+  fi
+done < "${MANIFEST}"
+
+if [[ "${FAILED}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "PASS: sync-embed-data preserved all vendored skills"


### PR DESCRIPTION
## Summary

v0.1.18 ships 9 bug fixes from a 3-implementer parallel swarm. Branch is rebased into 9 clean linear commits (one per bug, no merge noise), all local CI gates green.

**Operator UX:**
- bug-17: subharness hooks route SessionStop to operator via scion message
- bug-22: auto-allow .claude/skills writes in image-level settings.json (kills the TUI prompt that stalled skill-editing impls)
- bug-26: `darken look` subcommand with ANSI escape stripping (cleaner scrollback for orchestrator)

**Substrate robustness:**
- bug-18: stage-skills concurrency safety via per-process tmp dir
- bug-19: strip non-JSON prefix lines from `scion list` before unmarshal
- bug-20: `darken setup` runs `scion grove init` for project-scoped grove
- bug-27: `sync-embed-data` preserves vendored skills listed in manifest

**Per-template config:**
- bug-24: per-template `command_args` for 1M context on long-running claude roles

**Orchestrator skill:**
- bug-21: Steering live subharnesses section in orchestrator-mode skill

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `go test ./...` green (3 packages, 18.9s)
- [x] `bash scripts/test-embed-drift.sh` PASS
- [ ] CI green on PR
- [ ] rev-final block-or-ship verdict (codex cross-vendor reviewer)