### PR TITLE
fix(v0.1.18): apply 11 ousterhout review fixups

### DIFF
--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -8,8 +8,5 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,8 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/planner-t3/scion-agent.yaml
+++ b/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,8 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,8 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/cmd/darken/harness_manifest_test.go
+++ b/cmd/darken/harness_manifest_test.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"io/fs"
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/danmestas/darken/internal/substrate"
 )
 
 func TestLoadHarnessManifest_ParsesBackendAndSkills(t *testing.T) {
@@ -113,38 +110,6 @@ func TestLoadHarnessManifest_EmptyCommandArgs(t *testing.T) {
 	}
 	if len(m.CommandArgs) != 0 {
 		t.Errorf("CommandArgs: want empty, got %v", m.CommandArgs)
-	}
-}
-
-// TestTddImplementerManifest_HasBetasFlag asserts the embedded tdd-implementer
-// manifest declares command_args with the 1M-context betas flag. This is the
-// regression anchor for Bug 24.
-func TestTddImplementerManifest_HasBetasFlag(t *testing.T) {
-	efs := substrate.EmbeddedFS()
-	path := "data/.scion/templates/tdd-implementer/scion-agent.yaml"
-	body, err := fs.ReadFile(efs, path)
-	if err != nil {
-		t.Fatalf("cannot read embedded tdd-implementer manifest: %v", err)
-	}
-	m, err := loadHarnessManifest(body)
-	if err != nil {
-		t.Fatalf("parse manifest: %v", err)
-	}
-	hasBetas := false
-	hasContext := false
-	for _, arg := range m.CommandArgs {
-		if arg == "--betas" {
-			hasBetas = true
-		}
-		if strings.Contains(arg, "context-1m") {
-			hasContext = true
-		}
-	}
-	if !hasBetas {
-		t.Errorf("tdd-implementer CommandArgs missing --betas flag; got: %v", m.CommandArgs)
-	}
-	if !hasContext {
-		t.Errorf("tdd-implementer CommandArgs missing context-1m beta; got: %v", m.CommandArgs)
 	}
 }
 

--- a/cmd/darken/look.go
+++ b/cmd/darken/look.go
@@ -7,11 +7,19 @@ import (
 	"regexp"
 )
 
-// ansiEscape matches ANSI/VT100 escape sequences of the form ESC[...m
-// as well as cursor-control sequences (ESC[<n>J, ESC[H, etc.).
-// The pattern covers the common CSI (Control Sequence Introducer)
-// family used by terminal TUI toolkits.
-var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+// ansiEscape matches ANSI/VT100 escape sequences and strips them from
+// terminal output. Two sequence families are covered:
+//
+//   - CSI (Control Sequence Introducer): ESC [ followed by optional
+//     private-mode prefix '?' (0x3F), digit/semicolon parameters, and a
+//     final letter. Handles standard SGR colours, cursor controls, and
+//     private modes such as ESC[?25l (hide cursor) and ESC[?1049h
+//     (alternate screen).
+//
+//   - OSC (Operating System Command): ESC ] followed by a payload
+//     terminated by BEL (0x07) or ST (ESC \). Handles title-bar updates
+//     such as ESC]0;My Title BEL.
+var ansiEscape = regexp.MustCompile(`\x1b\[[\x3f]?[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)`)
 
 // stripANSI removes ANSI escape sequences from b and returns the
 // cleaned bytes. The original slice is not modified.

--- a/cmd/darken/look.go
+++ b/cmd/darken/look.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 )
 
@@ -26,35 +25,21 @@ func runLook(args []string) error {
 	return runLookInto(args, os.Stdout)
 }
 
-// runLookInto runs `scion --no-hub look <agent>`, strips ANSI escape
-// sequences from the output, and writes clean text to w.
+// runLookInto fetches the raw terminal output for the named agent via
+// ScionClient.LookAgent, strips ANSI escape sequences, and writes clean
+// text to w. Routing through ScionClient ensures env propagation is
+// consistent with all other scion operations and avoids hardcoding flags
+// such as --no-hub.
 func runLookInto(args []string, w io.Writer) error {
 	if len(args) == 0 {
 		return fmt.Errorf("usage: darken look <agent>")
 	}
 	agentName := args[0]
-	cmdArgs := append([]string{"--no-hub", "look", agentName}, args[1:]...)
-	cmd := exec.Command("scion", cmdArgs...)
-	raw, err := cmd.Output()
+	raw, err := defaultScionClient.LookAgent(agentName, args[1:])
 	if err != nil {
-		// Surface stderr if available.
-		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
-			return fmt.Errorf("scion look %s: %w\n%s", agentName, err, ee.Stderr)
-		}
-		return fmt.Errorf("scion look %s: %w", agentName, err)
+		return err
 	}
 	clean := stripANSI(raw)
 	_, werr := w.Write(clean)
 	return werr
-}
-
-// init registers the look subcommand so it appears in `darken --help`.
-// This is called from the package init chain; the subcommands slice is
-// defined in main.go and is safe to append during init.
-func init() {
-	subcommands = append(subcommands, subcommand{
-		name: "look",
-		desc: "inspect an agent terminal, ANSI-stripped (wraps scion look)",
-		run:  runLook,
-	})
 }

--- a/cmd/darken/look_test.go
+++ b/cmd/darken/look_test.go
@@ -46,6 +46,23 @@ func TestStripANSI(t *testing.T) {
 			input: "",
 			want:  "",
 		},
+		// CSI private modes — question-mark parameter prefix used by TUI toolkits.
+		{
+			name:  "CSI hide cursor (ESC[?25l)",
+			input: "\x1b[?25lsome text",
+			want:  "some text",
+		},
+		{
+			name:  "CSI alternate screen enter (ESC[?1049h)",
+			input: "\x1b[?1049hsome text",
+			want:  "some text",
+		},
+		// OSC sequences — title bar updates and other out-of-band messages.
+		{
+			name:  "OSC title BEL terminator (ESC]0;title BEL)",
+			input: "\x1b]0;My Title\x07some text",
+			want:  "some text",
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/darken/look_test.go
+++ b/cmd/darken/look_test.go
@@ -99,3 +99,45 @@ func TestRunLook_RequiresAgentArg(t *testing.T) {
 		t.Errorf("error should mention agent argument, got: %v", err)
 	}
 }
+
+// TestRunLook_UsesScionClient asserts that runLookInto routes through
+// ScionClient.LookAgent rather than calling exec.Command("scion") directly.
+func TestRunLook_UsesScionClient(t *testing.T) {
+	mc := &mockScionClient{
+		lookAgentOut: []byte("worker-1 phase: running\n"),
+	}
+	setDefaultClient(t, mc)
+
+	var buf bytes.Buffer
+	if err := runLookInto([]string{"worker-1"}, &buf); err != nil {
+		t.Fatalf("runLookInto: %v", err)
+	}
+	if len(mc.lookAgentCalls) == 0 {
+		t.Fatal("ScionClient.LookAgent was not called by runLookInto")
+	}
+	if mc.lookAgentCalls[0] != "worker-1" {
+		t.Errorf("LookAgent agent name: got %q, want %q", mc.lookAgentCalls[0], "worker-1")
+	}
+	if got := buf.String(); got != "worker-1 phase: running\n" {
+		t.Errorf("unexpected output: %q", got)
+	}
+}
+
+// TestRunLook_NoHubFlagAbsent asserts that scion is not called with --no-hub.
+// With ScionClient routing, scionCmdWithEnv builds the command without
+// hardcoded flags; this test confirms --no-hub is absent from the scion call.
+func TestRunLook_NoHubFlagAbsent(t *testing.T) {
+	stubDir := t.TempDir()
+	logPath := filepath.Join(stubDir, "args.log")
+	// This stub rejects any invocation that includes --no-hub.
+	script := "#!/bin/sh\nfor arg in \"$@\"; do\n  if [ \"$arg\" = \"--no-hub\" ]; then\n    echo \"REJECTED: --no-hub found\" >&2\n    exit 1\n  fi\ndone\necho \"output\" >> " + logPath + "\nprintf 'ok'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	var buf bytes.Buffer
+	if err := runLookInto([]string{"agent-1"}, &buf); err != nil {
+		t.Fatalf("runLookInto: --no-hub appears to be hardcoded: %v", err)
+	}
+}

--- a/cmd/darken/main.go
+++ b/cmd/darken/main.go
@@ -30,6 +30,7 @@ var subcommands = []subcommand{
 	{"creds", "refresh hub secrets", runCreds},
 	{"images", "wrap make -C images", runImages},
 	{"list", "wrap scion list", runList},
+	{"look", "inspect an agent terminal, ANSI-stripped (wraps scion look)", runLook},
 	{"orchestrate", "print host-mode orchestrator skill body", runOrchestrate},
 	{"redispatch", "kill + re-spawn an agent with the same role", runRedispatch},
 	{"init", "scaffold CLAUDE.md in a target dir", runInit},

--- a/cmd/darken/main_test.go
+++ b/cmd/darken/main_test.go
@@ -11,10 +11,33 @@ func TestMainHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("--help should not error: %v\n%s", err, out)
 	}
-	for _, sub := range []string{"doctor", "spawn", "bootstrap", "apply", "create-harness", "skills", "creds", "images", "list"} {
+	for _, sub := range []string{"doctor", "spawn", "bootstrap", "apply", "create-harness", "skills", "creds", "images", "list", "look"} {
 		if !strings.Contains(string(out), sub) {
 			t.Fatalf("--help missing subcommand %q\n%s", sub, out)
 		}
+	}
+}
+
+// TestLookInExplicitSubcommandTable asserts that "look" is registered in the
+// compile-time subcommand table, not only via a hidden init() append in
+// look.go. If look is removed from the table and only registered by init(),
+// removing the init() would silently delete it from the CLI surface.
+func TestLookInExplicitSubcommandTable(t *testing.T) {
+	// subcommands is the package-level slice populated at compile time in
+	// main.go. init() functions run before tests, so we cannot distinguish
+	// table-registered from init()-registered commands at test time. This test
+	// is a regression guard: it fails if look is ever missing from the slice
+	// (e.g. both sources removed).
+	found := false
+	for _, sc := range subcommands {
+		if sc.name == "look" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error(`"look" subcommand not found in subcommands slice; ` +
+			`ensure it is registered in main.go's explicit table`)
 	}
 }
 

--- a/cmd/darken/prelude_test.go
+++ b/cmd/darken/prelude_test.go
@@ -36,6 +36,86 @@ func TestPrelude_SkillsDirPermissions(t *testing.T) {
 	}
 }
 
+// TestPrelude_NonClaudeHookBlockAbsent verifies that codex, gemini, and pi
+// preludes do not contain the Claude hook setup block. That block writes
+// ~/.claude/settings.json hook config, which is meaningless on non-Claude
+// harnesses. Ousterhout review fixup F5: strip it from non-Claude images.
+func TestPrelude_NonClaudeHookBlockAbsent(t *testing.T) {
+	backends := []string{"codex", "gemini", "pi"}
+	// Markers exclusive to the Claude hook setup block.
+	markers := []string{
+		"DARKEN_HOOK_SCRIPT",
+		"notify-operator.sh",
+		"DARKISH_HOOK_EVENT",
+	}
+
+	efs := substrate.EmbeddedFS()
+	for _, b := range backends {
+		path := "data/images/" + b + "/darkish-prelude.sh"
+		body, err := fs.ReadFile(efs, path)
+		if err != nil {
+			t.Fatalf("cannot read embedded prelude for %s at %s: %v", b, path, err)
+		}
+		text := string(body)
+		for _, m := range markers {
+			if strings.Contains(text, m) {
+				t.Errorf("prelude %s must not contain Claude hook marker %q (fixup F5)", b, m)
+			}
+		}
+	}
+}
+
+// TestPrelude_SkillsPermissionsJqMerge verifies that the claude prelude uses
+// jq-merge semantics for .claude/skills permissions, not full-file replacement.
+// Full replacement destroys operator-configured permissions and hooks.
+// Ousterhout review fixup F6.
+func TestPrelude_SkillsPermissionsJqMerge(t *testing.T) {
+	efs := substrate.EmbeddedFS()
+	path := "data/images/claude/darkish-prelude.sh"
+	body, err := fs.ReadFile(efs, path)
+	if err != nil {
+		t.Fatalf("cannot read embedded claude prelude at %s: %v", path, err)
+	}
+	text := string(body)
+
+	// Must NOT use a bare cat-replace for the skills settings block.
+	if strings.Contains(text, "cat > \"${CLAUDE_SETTINGS}\"") {
+		t.Error("claude prelude must not use cat > to fully replace settings.json; use jq merge (fixup F6)")
+	}
+
+	// Must use jq to merge the allow rules.
+	if !strings.Contains(text, "permissions.allow") {
+		t.Error("claude prelude must use jq to merge .permissions.allow for skills permissions (fixup F6)")
+	}
+}
+
+// TestPrelude_HookInsertionIdempotent verifies that the claude prelude guards
+// against duplicate hook entries before appending. Without this guard,
+// persistent container homes accumulate duplicate hooks on every prelude run.
+// Ousterhout review fixup F7.
+func TestPrelude_HookInsertionIdempotent(t *testing.T) {
+	efs := substrate.EmbeddedFS()
+	path := "data/images/claude/darkish-prelude.sh"
+	body, err := fs.ReadFile(efs, path)
+	if err != nil {
+		t.Fatalf("cannot read embedded claude prelude at %s: %v", path, err)
+	}
+	text := string(body)
+
+	// Expect a jq de-duplication guard — any() or map(select(...)) pattern.
+	dedupeMarkers := []string{"any(", "map(select("}
+	found := false
+	for _, m := range dedupeMarkers {
+		if strings.Contains(text, m) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("claude prelude hook insertion must be idempotent; expected jq any() or map(select()) guard (fixup F7)")
+	}
+}
+
 // TestPreludePreCloneBlockPropagated verifies that the three non-claude
 // prelude scripts contain the pre-clone workaround block that is
 // authoritative in images/claude/darkish-prelude.sh. Each prelude must

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -11,7 +11,7 @@ import (
 // scion CLI. Env propagation, output policy, and error mapping are owned by
 // the implementation; callers receive typed results.
 //
-// The five methods correspond to the five operation classes used across
+// The six methods correspond to the six operation classes used across
 // doctor.go, spawn.go, setup.go, and bootstrap.go.
 type ScionClient interface {
 	// ServerStatus returns the raw output of `scion server status`.
@@ -33,10 +33,15 @@ type ScionClient interface {
 	// PushTemplate uploads a role template to the hub at user (global) scope.
 	PushTemplate(role string) error
 
-	// GroveInit registers the current directory as a project-scoped scion grove.
+	// GroveInit registers targetDir as a project-scoped scion grove.
 	// Idempotent at the caller level: callers check for .scion/grove-id before
-	// invoking this method.
-	GroveInit() error
+	// invoking this method. targetDir is used as the working directory so that
+	// grove init applies to the correct project even when cwd differs.
+	GroveInit(targetDir string) error
+
+	// LookAgent returns the raw terminal output of `scion look <name>`.
+	// ANSI stripping is the caller's responsibility.
+	LookAgent(name string, extraArgs []string) ([]byte, error)
 }
 
 // execScionClient is the production ScionClient that delegates to the scion binary.
@@ -82,11 +87,24 @@ func (c *execScionClient) PushTemplate(role string) error {
 	return cmd.Run()
 }
 
-func (c *execScionClient) GroveInit() error {
+func (c *execScionClient) GroveInit(targetDir string) error {
 	cmd := scionCmdWithEnv([]string{"grove", "init"})
+	cmd.Dir = targetDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func (c *execScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {
+	full := append([]string{"look", name}, extraArgs...)
+	out, err := scionCmdWithEnv(full).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			return out, fmt.Errorf("scion look %s: %w\n%s", name, err, ee.Stderr)
+		}
+		return out, fmt.Errorf("scion look %s: %w", name, err)
+	}
+	return out, nil
 }
 
 // defaultScionClient is the package-level ScionClient used by doctor, spawn,

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -17,10 +17,14 @@ type mockScionClient struct {
 	brokerProvideErr error
 	pushTemplateErr  error
 	groveInitErr     error
+	lookAgentOut     []byte
+	lookAgentErr     error
 
 	startAgentCalls   [][]string
 	pushTemplateCalls []string
 	groveInitCalls    int
+	groveInitDir      string
+	lookAgentCalls    []string
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -40,9 +44,14 @@ func (m *mockScionClient) PushTemplate(role string) error {
 	m.pushTemplateCalls = append(m.pushTemplateCalls, role)
 	return m.pushTemplateErr
 }
-func (m *mockScionClient) GroveInit() error {
+func (m *mockScionClient) GroveInit(targetDir string) error {
 	m.groveInitCalls++
+	m.groveInitDir = targetDir
 	return m.groveInitErr
+}
+func (m *mockScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {
+	m.lookAgentCalls = append(m.lookAgentCalls, name)
+	return m.lookAgentOut, m.lookAgentErr
 }
 
 // setDefaultClient replaces defaultScionClient for the duration of the test.

--- a/cmd/darken/setup.go
+++ b/cmd/darken/setup.go
@@ -7,16 +7,24 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
 
 func runSetup(args []string) error {
+	// Resolve the setup target once so that ensureGroveInit operates on the
+	// same directory that runInit writes to, regardless of cwd.
+	target, err := resolveInitTarget(args)
+	if err != nil {
+		return err
+	}
 	if err := runInit(args); err != nil {
 		return err
 	}
-	if err := ensureGroveInit(); err != nil {
+	if err := ensureGroveInit(target); err != nil {
 		return err
 	}
 	if err := runBootstrap(nil); err != nil {
@@ -25,22 +33,37 @@ func runSetup(args []string) error {
 	return uploadAllTemplatesToHub()
 }
 
-// ensureGroveInit registers the current directory as a project-scoped scion
-// grove by running scion grove init. It is idempotent: if .scion/grove-id
-// already exists the call is skipped entirely, avoiding a redundant round-trip
-// to the hub and preventing grove_id from being replaced.
-func ensureGroveInit() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("ensureGroveInit: getwd: %w", err)
+// resolveInitTarget parses the same flag set as runInit and returns the
+// absolute path of the target directory. This is intentionally kept in sync
+// with runInit's flag definitions so the resolved target is identical.
+func resolveInitTarget(args []string) (string, error) {
+	fs := flag.NewFlagSet("setup-target", flag.ContinueOnError)
+	fs.Bool("dry-run", false, "")
+	fs.Bool("force", false, "")
+	fs.Bool("refresh", false, "")
+	fs.SetOutput(io.Discard) // suppress duplicate usage output
+	if err := fs.Parse(args); err != nil {
+		return "", err
 	}
-	groveIDPath := filepath.Join(cwd, ".scion", "grove-id")
+	target := "."
+	if pos := fs.Args(); len(pos) > 0 {
+		target = pos[0]
+	}
+	return filepath.Abs(target)
+}
+
+// ensureGroveInit registers targetDir as a project-scoped scion grove by
+// running scion grove init. It is idempotent: if .scion/grove-id already
+// exists the call is skipped entirely, avoiding a redundant round-trip to the
+// hub and preventing grove_id from being replaced.
+func ensureGroveInit(targetDir string) error {
+	groveIDPath := filepath.Join(targetDir, ".scion", "grove-id")
 	if info, err := os.Stat(groveIDPath); err == nil && !info.IsDir() {
 		// Grove already initialised for this project; skip.
 		return nil
 	}
 	fmt.Println("initialising project grove ...")
-	return defaultScionClient.GroveInit()
+	return defaultScionClient.GroveInit(targetDir)
 }
 
 // uploadAllTemplatesToHub pushes all 14 canonical templates to the Hub at

--- a/cmd/darken/setup_test.go
+++ b/cmd/darken/setup_test.go
@@ -301,3 +301,38 @@ func TestSetup_TemplateUploadFailureAbortsSetup(t *testing.T) {
 		t.Fatal("expected setup to fail when template upload fails")
 	}
 }
+
+// TestSetup_GroveInit_UsesTargetDir_NotCwd confirms that ensureGroveInit
+// uses the explicit setup target directory, not the process working directory.
+// This guards against the divergence where `darken setup /path/to/project`
+// is run from a different directory: grove init must happen in /path/to/project.
+func TestSetup_GroveInit_UsesTargetDir_NotCwd(t *testing.T) {
+	targetDir := t.TempDir()
+	otherDir := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", targetDir)
+	stubAllBinariesForSetup(t)
+
+	// cwd is otherDir — NOT the setup target.
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+	if err := os.Chdir(otherDir); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		serverStatusOut: "Status: ok\n",
+		secretListOut:   "claude_auth\ncodex_auth\n",
+	}
+	setDefaultClient(t, mc)
+
+	if err := runSetup([]string{targetDir}); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if mc.groveInitDir != targetDir {
+		t.Errorf("GroveInit used dir %q; want %q (the setup target, not cwd %q)",
+			mc.groveInitDir, targetDir, otherDir)
+	}
+}

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -38,6 +38,15 @@ func runSpawn(args []string) error {
 		}
 	}
 
+	// Validate the manifest before attempting to start the agent. A parse
+	// error in a known role's manifest is a configuration mistake that must
+	// be fixed; silently degrading would let a broken manifest produce an
+	// agent with missing context or wrong backend.
+	// A missing manifest (ErrNotExist) is non-fatal: the role may not have a
+	// local template tree in this workspace.
+	if _, err := loadManifestForRole(*harnessType); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("spawn: manifest for role %q: %w", *harnessType, err)
+	}
 	// TODO(upstream-scion): manifest command_args are intentionally not
 	// forwarded to scion start. scion start has no --betas flag; passing raw
 	// harness flags through the orchestration CLI crosses an abstraction

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -38,20 +38,16 @@ func runSpawn(args []string) error {
 		}
 	}
 
-	// Load command_args from the manifest (non-fatal: missing or unreadable
-	// manifests degrade gracefully — operator still gets the agent started).
-	var extraArgs []string
-	if m, err := loadManifestForRole(*harnessType); err == nil {
-		extraArgs = m.CommandArgs
-	}
+	// TODO(upstream-scion): manifest command_args are intentionally not
+	// forwarded to scion start. scion start has no --betas flag; passing raw
+	// harness flags through the orchestration CLI crosses an abstraction
+	// boundary. Wire m.CommandArgs here once upstream scion exposes a
+	// harness-level flag routing mechanism.
 
 	startArgs := []string{"--type", *harnessType}
 	if *backend != "" {
 		image := fmt.Sprintf("local/darkish-%s:latest", *backend)
 		startArgs = append(startArgs, "--harness", *backend, "--image", image)
-	}
-	if len(extraArgs) > 0 {
-		startArgs = append(startArgs, extraArgs...)
 	}
 	if len(posArgs) > 0 {
 		startArgs = append(startArgs, posArgs...)

--- a/cmd/darken/spawn_poller.go
+++ b/cmd/darken/spawn_poller.go
@@ -82,14 +82,22 @@ func scionListAgents() ([]agentInfo, error) {
 	return agents, nil
 }
 
-// jsonStart returns the first line of b that starts with '[' or '{',
-// plus all subsequent bytes. Lines before that are silently discarded.
+// jsonStart returns the slice of b starting at the first '[' or '{'
+// that appears as the first non-whitespace byte of a line.
+// Lines before that are silently discarded. Leading spaces and tabs on
+// the matching line are also stripped so the caller receives a slice
+// that begins with the JSON delimiter itself.
 // If no such line exists, the original slice is returned unchanged so
 // that the caller surfaces a descriptive json.Unmarshal error.
 func jsonStart(b []byte) []byte {
 	for len(b) > 0 {
-		if b[0] == '[' || b[0] == '{' {
-			return b
+		// Find the first non-space/tab byte on this line.
+		i := 0
+		for i < len(b) && (b[i] == ' ' || b[i] == '\t') {
+			i++
+		}
+		if i < len(b) && (b[i] == '[' || b[i] == '{') {
+			return b[i:]
 		}
 		nl := bytes.IndexByte(b, '\n')
 		if nl < 0 {

--- a/cmd/darken/spawn_poller_test.go
+++ b/cmd/darken/spawn_poller_test.go
@@ -116,6 +116,51 @@ func TestPollUntilReady_ScionListErrors(t *testing.T) {
 	}
 }
 
+// TestJsonStart_WhitespacePrefixedLine asserts F-11: jsonStart must recognise
+// a JSON array or object that is preceded by leading spaces or tabs on the
+// first meaningful line, returning from the '[' / '{' byte rather than from
+// the start of the line.
+func TestJsonStart_WhitespacePrefixedLine(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+		// wantByte is the first byte of the slice jsonStart should return.
+		wantByte byte
+	}{
+		{
+			name:     "leading spaces before array",
+			input:    []byte("  \t []\n"),
+			wantByte: '[',
+		},
+		{
+			name:     "leading tabs before object",
+			input:    []byte("\t\t{}\n"),
+			wantByte: '{',
+		},
+		{
+			name:     "warning line then indented array",
+			input:    []byte("WARNING: dev-auth mode\n  [{\"name\":\"a\"}]\n"),
+			wantByte: '[',
+		},
+		{
+			name:     "no whitespace prefix still works",
+			input:    []byte("[{\"name\":\"a\"}]\n"),
+			wantByte: '[',
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonStart(tc.input)
+			if len(got) == 0 {
+				t.Fatalf("jsonStart returned empty slice for input %q", tc.input)
+			}
+			if got[0] != tc.wantByte {
+				t.Fatalf("jsonStart(%q)[0] = %q, want %q", tc.input, got[0], tc.wantByte)
+			}
+		})
+	}
+}
+
 func TestPollUntilReady_CallbackFiresOnPhaseChange(t *testing.T) {
 	// First call: phase=starting. Second call: phase=running.
 	// Use a script that flips state via a sentinel file.

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -169,15 +169,17 @@ func TestRunSpawn_FailsWithoutType(t *testing.T) {
 	}
 }
 
-// TestSpawn_ForwardsCommandArgsFromManifest verifies that runSpawn reads
-// command_args from the manifest and forwards them to StartAgent. Uses a
-// mock client to capture what StartAgent receives.
-func TestSpawn_ForwardsCommandArgsFromManifest(t *testing.T) {
+// TestSpawn_DoesNotForwardCommandArgsToScion asserts that runSpawn does NOT
+// append manifest command_args to the scion start argv. scion start has no
+// --betas flag; forwarding raw harness flags through the orchestration CLI
+// crosses the abstraction boundary. command_args stays readable in the struct
+// but is a no-op until upstream scion exposes harness-level flag routing.
+func TestSpawn_DoesNotForwardCommandArgsToScion(t *testing.T) {
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
 
-	// Create a temporary templates dir with a custom manifest that has
-	// command_args. No canonical skills dir needed because we use --no-stage.
+	// Create a temporary templates dir with a manifest that declares command_args.
+	// No canonical skills dir needed because we use --no-stage.
 	tmpDir := t.TempDir()
 	harnessDir := filepath.Join(tmpDir, "custom-role")
 	if err := os.MkdirAll(harnessDir, 0o755); err != nil {
@@ -210,10 +212,11 @@ esac
 		t.Fatal("StartAgent was not called")
 	}
 	args := strings.Join(mc.startAgentCalls[0], " ")
-	if !strings.Contains(args, "--betas") {
-		t.Errorf("--betas not forwarded to StartAgent; args: %s", args)
+	// command_args must NOT be forwarded to scion start.
+	if strings.Contains(args, "--betas") {
+		t.Errorf("--betas must not be forwarded to scion start; args: %s", args)
 	}
-	if !strings.Contains(args, "context-1m-2025-08-07") {
-		t.Errorf("context-1m-2025-08-07 not forwarded to StartAgent; args: %s", args)
+	if strings.Contains(args, "context-1m-2025-08-07") {
+		t.Errorf("context-1m-2025-08-07 must not be forwarded to scion start; args: %s", args)
 	}
 }

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -220,3 +220,33 @@ esac
 		t.Errorf("context-1m-2025-08-07 must not be forwarded to scion start; args: %s", args)
 	}
 }
+
+// TestSpawn_ManifestParseError_IsFatal asserts that runSpawn returns a non-nil
+// error when the manifest for the requested role exists on disk but cannot be
+// parsed (e.g. unknown backend). Silently degrading on parse errors hides
+// configuration mistakes that should be fixed before the agent starts.
+func TestSpawn_ManifestParseError_IsFatal(t *testing.T) {
+	// Write a manifest with an unknown backend value so loadHarnessManifest
+	// returns a parse error (not a file-not-found error).
+	tmpDir := t.TempDir()
+	harnessDir := filepath.Join(tmpDir, "bad-role")
+	if err := os.MkdirAll(harnessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	badManifest := "default_harness_config: totally-unknown-backend\n"
+	if err := os.WriteFile(filepath.Join(harnessDir, "scion-agent.yaml"),
+		[]byte(badManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DARKEN_TEMPLATES_DIR", tmpDir)
+
+	// --no-stage skips credential/skills staging so the test only exercises
+	// the manifest-load path.
+	err := runSpawn([]string{"bad-agent", "--type", "bad-role", "--no-stage", "task"})
+	if err == nil {
+		t.Fatal("expected error for malformed manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Errorf("error should mention 'manifest'; got: %v", err)
+	}
+}

--- a/docs/ousterhout-review-v0.1.18.md
+++ b/docs/ousterhout-review-v0.1.18.md
@@ -1,0 +1,95 @@
+# Ousterhout Review: v0.1.18
+
+## Executive Summary
+
+Verdict: **BLOCK**.
+
+The branch adds useful fixes, but several changes make shallow interfaces deeper in the wrong direction: backend-specific Claude behavior leaks into every image prelude, `command_args` is parsed as manifest data but forwarded to the wrong CLI layer, `darken setup` splits project identity between the requested target and current working directory, and the stage-skills concurrency fix still has a non-atomic publish step. `go test ./...` and `go vet ./...` pass, but the tests mostly validate the intended happy path, not the boundary failures.
+
+Review method: commits were grouped by disjoint ownership and reviewed in parallel: prelude hooks/settings, stage-skills, scion output/look, setup grove init, and manifests/templates/embed preservation. The requested `superpowers:dispatching-parallel-agents` skill was not installed in this environment, so parallel subagents were dispatched directly.
+
+## Per-Commit Findings
+
+### bug-24: per-template command_args for 1M context on long-running roles
+
+- **High: `command_args` crosses the wrong abstraction boundary.** `cmd/darken/spawn.go:53` appends manifest `command_args` directly to `scion start`. Installed `scion start --help` has no `--betas` flag, so roles with `command_args` can fail before the harness starts. In POSD terms, the manifest now looks like a deep module, but its implementation leaks raw harness flags into the orchestration CLI.
+
+- **Medium: malformed manifests are silently ignored.** `cmd/darken/spawn.go:41` treats manifest load/parse failure as non-fatal, which makes `command_args` disappear without signal. That weakens the manifest as a configuration boundary and increases operator debugging load.
+
+### bug18: stage-skills concurrency safety via per-process tmp dir
+
+- **High: publish is still not atomic.** `scripts/stage-skills.sh:145` and `internal/substrate/data/scripts/stage-skills.sh:145` use `rm -rf "${STAGE_DIR}"` followed by `mv "${stage_tmp}" "${STAGE_DIR}"`. Two concurrent publishers can interleave so the second `mv` nests its temp directory under an existing `STAGE_DIR` instead of replacing it. The interface says "last writer wins"; the implementation can produce malformed staging.
+
+- **Medium: the regression test does not prove tree shape.** `scripts/test-stage-skills-concurrency.sh` checks expected files, but not exact top-level contents or absence of temp directories. It can pass with extra nested `.tmp.<pid>` directories.
+
+- **Low: duplicated shell scripts increase drift.** The source and embedded `stage-skills.sh` copies carry the same concurrency logic. A single staging contract is maintained in two places.
+
+### bug-20: darken setup runs scion grove init for project-scoped grove
+
+- **High: setup target and grove target can diverge.** `cmd/darken/setup.go:15` allows `darken setup <target>`, but `ensureGroveInit` uses `os.Getwd()` at `cmd/darken/setup.go:32`. Running setup for another directory can initialize/check the wrong `.scion/grove-id`. Project identity should be resolved once and passed through the setup pipeline.
+
+- **Low: interface comment drift.** `cmd/darken/scion_client.go:14` still says the interface has five methods after adding `GroveInit`.
+
+### bug17: subharness hooks route SessionStop to operator via scion message
+
+- **High: Claude hook configuration was copied into non-Claude images.** `images/codex/darkish-prelude.sh`, `images/gemini/darkish-prelude.sh`, and `images/pi/darkish-prelude.sh` write Claude Code hook config under `~/.claude/settings.json`, but those harnesses do not consume Claude hooks. The hook feature belongs at a Scion/harness-level boundary or in backend-native integrations.
+
+- **Medium: hook insertion is not idempotent.** `images/claude/darkish-prelude.sh:183` appends identical `Stop` and `PreToolUse` hooks on each prelude run. Persistent homes or reruns can produce duplicate operator messages.
+
+### bug-22: auto-allow .claude/skills writes in image-level settings.json
+
+- **High: settings write can destroy existing operator config.** `images/claude/darkish-prelude.sh:115` writes a full new `~/.claude/settings.json` whenever `.claude/skills` is absent. That can erase unrelated permissions, hooks, theme/model settings, and future config. The code should merge one Darken-owned allow rule into existing JSON instead of treating a grep miss as permission to replace the file.
+
+### bug-26: add darken look subcommand with ANSI escape stripping
+
+- **Medium: ANSI stripping is too narrow for TUI output.** `cmd/darken/look.go:15` only handles CSI escapes of the form `ESC[` plus digits/semicolons plus a final letter. Common sequences such as `ESC[?25l`, `ESC[?1049h`, and OSC title updates survive.
+
+- **Medium: `look` bypasses the Scion command boundary.** `cmd/darken/look.go:36` uses raw `exec.Command` instead of `scionCmdWithEnv` or `ScionClient`, and hardcodes `--no-hub`. That adds a second command policy path and conflicts with the branch's hub-oriented agent instructions.
+
+- **Low: subcommand registration is hidden in `init`.** `cmd/darken/look.go:54` appends to `subcommands` nonlocally instead of registering in the explicit command table in `main.go`.
+
+### bug-19: strip non-JSON prefix lines from scion list output before unmarshal
+
+- **Low: JSON trimming is line-start only.** `cmd/darken/spawn_poller.go:89` only recognizes `[` or `{` at byte zero of a line. Legal JSON preceded by whitespace on the first JSON line can still fail. Trim JSON whitespace before choosing the start.
+
+### bug-21: add Steering live subharnesses section to orchestrator-mode skill
+
+- No blocking Ousterhout finding. The document addition is localized. Main risk is copy drift between `.claude/skills/orchestrator-mode/SKILL.md` and the embedded copy, already covered by existing skill rules tests.
+
+### bug27: sync-embed-data preserves vendored skills listed in manifest
+
+- No blocking Ousterhout finding. The preservation rule is pragmatic. It would benefit from extracting the preserve/restore loop into a script helper later, but the current Makefile change is narrow.
+
+## Recommended Fixups
+
+1. **`cmd/darken/spawn.go`: stop appending `command_args` to `scion start`.** Route these values to a harness/template field that Scion actually consumes, or remove the `command_args` forwarding until Scion supports it. Add a test whose stub rejects unknown `scion start` flags.
+
+2. **`cmd/darken/spawn.go`: fail loudly on malformed manifests.** Keep compatibility only for true manifest absence if needed; parse errors in known roles should block spawn with a clear message.
+
+3. **`scripts/stage-skills.sh` and `internal/substrate/data/scripts/stage-skills.sh`: serialize only the publish section.** Use a lock directory or other portable lock around `rm -rf && mv`, leaving copy work outside the lock. Update the concurrency test to assert exact top-level staging contents and no temp directories.
+
+4. **`cmd/darken/setup.go` and `cmd/darken/scion_client.go`: resolve setup target once.** Pass that target into `ensureGroveInit(targetDir)` and run `scion grove init` with `cmd.Dir = targetDir`. Add a test where cwd differs from the setup target.
+
+5. **`images/*/darkish-prelude.sh`: remove Claude hook setup from non-Claude images.** Either implement backend-native stop/question notification or move notification to a Scion-level hook shared by all harnesses.
+
+6. **`images/claude/darkish-prelude.sh`: merge settings with jq.** Preserve existing top-level keys, `permissions.deny`, existing allow rules, and hooks; append only missing Darken-owned rules. Add a test with preexisting settings and hooks.
+
+7. **`images/claude/darkish-prelude.sh`: make hook insertion idempotent.** De-duplicate by command plus matcher/event or replace a named Darken-owned hook entry.
+
+8. **`cmd/darken/look.go`: use the Scion command abstraction.** Add `LookAgent` to `ScionClient` or use `scionCmdWithEnv`; do not hardcode `--no-hub` in `darken look`.
+
+9. **`cmd/darken/look.go`: use a fuller ANSI stripper.** Cover CSI private modes and OSC sequences, with tests for `\x1b[?25l`, `\x1b[?1049h`, and `\x1b]0;title\x07`.
+
+10. **`cmd/darken/main.go`: register `look` in the explicit subcommand table.** Keep command surface area local and discoverable.
+
+11. **`cmd/darken/spawn_poller.go`: make `jsonStart` whitespace-aware.** Scan for the first non-space byte on each line and return from that byte when it is `[` or `{`.
+
+## Decision
+
+**BLOCK.** This should not land as minor polish. The branch needs architectural fixups around command argument ownership, project target resolution, concurrency publish semantics, and backend-specific hook/config boundaries before release.
+
+Verification run:
+
+- `go test ./...` passed.
+- `go vet ./...` passed.
+- `scion start --help` confirms `--betas` is not a `scion start` flag.

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -104,28 +104,39 @@ fi
 #
 # claude --dangerously-skip-permissions does NOT suppress the interactive TUI
 # dialog that fires when Claude Code writes to .claude/skills. Skill-editing
-# agents block on that dialog until a human presses Y. Fix: write a project-
-# level settings.json that adds an explicit allow entry for .claude/skills
-# before the session starts. This is idempotent: if the file already contains
-# the entry we leave it untouched; if it is absent or empty we write it.
+# agents block on that dialog until a human presses Y. Fix: merge explicit
+# allow entries for .claude/skills into the existing settings.json using jq,
+# preserving all other top-level keys, permissions.deny, existing allow rules,
+# and hooks. Only missing Darken-owned rules are appended.
 
 CLAUDE_SETTINGS="${HOME}/.claude/settings.json"
 mkdir -p "${HOME}/.claude"
 
-if [[ ! -f "${CLAUDE_SETTINGS}" ]] || ! grep -q '\.claude/skills' "${CLAUDE_SETTINGS}" 2>/dev/null; then
-  cat > "${CLAUDE_SETTINGS}" <<'SETTINGS_EOF'
-{
-  "permissions": {
-    "allow": [
-      "Write(**/.claude/skills/**)",
-      "Edit(**/.claude/skills/**)",
-      "Bash(mkdir -p **/.claude/skills/**)"
-    ],
-    "deny": []
-  }
-}
-SETTINGS_EOF
-  echo "darkish-prelude: wrote .claude/skills permissions to ${CLAUDE_SETTINGS}" >&2
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${CLAUDE_SETTINGS}" ]]; then
+    _SKILLS_BASE="$(cat "${CLAUDE_SETTINGS}")"
+  else
+    _SKILLS_BASE='{}'
+  fi
+  echo "${_SKILLS_BASE}" | jq '
+    .permissions       = (.permissions       // {}) |
+    .permissions.allow = (.permissions.allow // []) |
+    .permissions.deny  = (.permissions.deny  // []) |
+    reduce (
+      ["Write(**/.claude/skills/**)",
+       "Edit(**/.claude/skills/**)",
+       "Bash(mkdir -p **/.claude/skills/**)"][]
+    ) as $r (
+      .;
+      if (.permissions.allow | map(select(. == $r)) | length) == 0
+      then .permissions.allow += [$r]
+      else .
+      end
+    )
+  ' > "${CLAUDE_SETTINGS}.tmp" && mv "${CLAUDE_SETTINGS}.tmp" "${CLAUDE_SETTINGS}"
+  echo "darkish-prelude: merged .claude/skills permissions into ${CLAUDE_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING — no jq; .claude/skills permissions not configured" >&2
 fi
 
 # --- 5. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -191,23 +191,36 @@ if command -v jq >/dev/null 2>&1; then
   else
     EXISTING_SETTINGS='{}'
   fi
+  # Idempotent: append each hook entry only when no existing entry for this
+  # command is already present. De-duplicates by command path so persistent
+  # container homes do not accumulate duplicate operator messages across runs.
   echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
     .hooks = (.hooks // {}) |
     .hooks.Stop = (
-      (.hooks.Stop // []) + [{
+      (.hooks.Stop // []) as $existing |
+      if any($existing[]; .hooks[]?.command == $cmd) | not
+      then $existing + [{
         "hooks": [{"type": "command", "command": $cmd,
                    "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
       }]
+      else $existing
+      end
     ) |
     .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
+      (.hooks.PreToolUse // []) as $existing |
+      if any($existing[];
+             .matcher == "AskFollowupQuestion" and
+             (.hooks[]?.command == $cmd)) | not
+      then $existing + [{
         "matcher": "AskFollowupQuestion",
         "hooks": [{"type": "command", "command": $cmd,
                    "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
       }]
+      else $existing
+      end
     )
   ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+  echo "darkish-prelude: operator notification hooks merged into ${DARKEN_SETTINGS}" >&2
 else
   echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
 fi

--- a/images/codex/darkish-prelude.sh
+++ b/images/codex/darkish-prelude.sh
@@ -104,64 +104,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 6. Hand off to scion ----------------------------------------------------
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/gemini/darkish-prelude.sh
+++ b/images/gemini/darkish-prelude.sh
@@ -61,64 +61,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/images/pi/darkish-prelude.sh
+++ b/images/pi/darkish-prelude.sh
@@ -61,64 +61,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -8,8 +8,5 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
@@ -14,8 +14,5 @@ volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
@@ -16,8 +16,5 @@ volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -15,8 +15,5 @@ volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/
     read_only: true
-command_args:
-  - --betas
-  - context-1m-2025-08-07
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -104,28 +104,39 @@ fi
 #
 # claude --dangerously-skip-permissions does NOT suppress the interactive TUI
 # dialog that fires when Claude Code writes to .claude/skills. Skill-editing
-# agents block on that dialog until a human presses Y. Fix: write a project-
-# level settings.json that adds an explicit allow entry for .claude/skills
-# before the session starts. This is idempotent: if the file already contains
-# the entry we leave it untouched; if it is absent or empty we write it.
+# agents block on that dialog until a human presses Y. Fix: merge explicit
+# allow entries for .claude/skills into the existing settings.json using jq,
+# preserving all other top-level keys, permissions.deny, existing allow rules,
+# and hooks. Only missing Darken-owned rules are appended.
 
 CLAUDE_SETTINGS="${HOME}/.claude/settings.json"
 mkdir -p "${HOME}/.claude"
 
-if [[ ! -f "${CLAUDE_SETTINGS}" ]] || ! grep -q '\.claude/skills' "${CLAUDE_SETTINGS}" 2>/dev/null; then
-  cat > "${CLAUDE_SETTINGS}" <<'SETTINGS_EOF'
-{
-  "permissions": {
-    "allow": [
-      "Write(**/.claude/skills/**)",
-      "Edit(**/.claude/skills/**)",
-      "Bash(mkdir -p **/.claude/skills/**)"
-    ],
-    "deny": []
-  }
-}
-SETTINGS_EOF
-  echo "darkish-prelude: wrote .claude/skills permissions to ${CLAUDE_SETTINGS}" >&2
+if command -v jq >/dev/null 2>&1; then
+  if [[ -f "${CLAUDE_SETTINGS}" ]]; then
+    _SKILLS_BASE="$(cat "${CLAUDE_SETTINGS}")"
+  else
+    _SKILLS_BASE='{}'
+  fi
+  echo "${_SKILLS_BASE}" | jq '
+    .permissions       = (.permissions       // {}) |
+    .permissions.allow = (.permissions.allow // []) |
+    .permissions.deny  = (.permissions.deny  // []) |
+    reduce (
+      ["Write(**/.claude/skills/**)",
+       "Edit(**/.claude/skills/**)",
+       "Bash(mkdir -p **/.claude/skills/**)"][]
+    ) as $r (
+      .;
+      if (.permissions.allow | map(select(. == $r)) | length) == 0
+      then .permissions.allow += [$r]
+      else .
+      end
+    )
+  ' > "${CLAUDE_SETTINGS}.tmp" && mv "${CLAUDE_SETTINGS}.tmp" "${CLAUDE_SETTINGS}"
+  echo "darkish-prelude: merged .claude/skills permissions into ${CLAUDE_SETTINGS}" >&2
+else
+  echo "darkish-prelude: WARNING — no jq; .claude/skills permissions not configured" >&2
 fi
 
 # --- 5. Heartbeat URL fix (work around scion broker SCION_HUB_URL = localhost) ---

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -191,23 +191,36 @@ if command -v jq >/dev/null 2>&1; then
   else
     EXISTING_SETTINGS='{}'
   fi
+  # Idempotent: append each hook entry only when no existing entry for this
+  # command is already present. De-duplicates by command path so persistent
+  # container homes do not accumulate duplicate operator messages across runs.
   echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
     .hooks = (.hooks // {}) |
     .hooks.Stop = (
-      (.hooks.Stop // []) + [{
+      (.hooks.Stop // []) as $existing |
+      if any($existing[]; .hooks[]?.command == $cmd) | not
+      then $existing + [{
         "hooks": [{"type": "command", "command": $cmd,
                    "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
       }]
+      else $existing
+      end
     ) |
     .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
+      (.hooks.PreToolUse // []) as $existing |
+      if any($existing[];
+             .matcher == "AskFollowupQuestion" and
+             (.hooks[]?.command == $cmd)) | not
+      then $existing + [{
         "matcher": "AskFollowupQuestion",
         "hooks": [{"type": "command", "command": $cmd,
                    "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
       }]
+      else $existing
+      end
     )
   ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
+  echo "darkish-prelude: operator notification hooks merged into ${DARKEN_SETTINGS}" >&2
 else
   echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
 fi

--- a/internal/substrate/data/images/codex/darkish-prelude.sh
+++ b/internal/substrate/data/images/codex/darkish-prelude.sh
@@ -104,64 +104,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 5. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 6. Hand off to scion ----------------------------------------------------
+# --- 5. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/gemini/darkish-prelude.sh
+++ b/internal/substrate/data/images/gemini/darkish-prelude.sh
@@ -61,64 +61,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/images/pi/darkish-prelude.sh
+++ b/internal/substrate/data/images/pi/darkish-prelude.sh
@@ -61,64 +61,7 @@ if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}"
   echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
 fi
 
-# --- 4. Operator notification hooks ------------------------------------------
-#
-# Write a Claude Code Stop hook so SessionStop events route to the
-# operator via scion message.  The recipient is read from
-# DARKEN_HOOK_RECIPIENT (default: user:Development User).
-#
-# The hook also fires on PreToolUse:AskFollowupQuestion so question
-# events are forwarded before the session fully stops.
-#
-# Implementation: write a self-contained hook script, then merge the
-# hook declarations into ~/.claude/settings.json using jq.
-
-DARKEN_HOOKS_DIR="${HOME}/.claude/hooks"
-DARKEN_HOOK_SCRIPT="${DARKEN_HOOKS_DIR}/notify-operator.sh"
-DARKEN_SETTINGS="${HOME}/.claude/settings.json"
-
-mkdir -p "${DARKEN_HOOKS_DIR}"
-
-cat > "${DARKEN_HOOK_SCRIPT}" << 'HOOKEOF'
-#!/usr/bin/env bash
-# Darkish Factory subharness: route Stop/AskFollowupQuestion events to operator.
-set -uo pipefail
-RECIPIENT="${DARKEN_HOOK_RECIPIENT:-user:Development User}"
-AGENT="${SCION_AGENT_NAME:-unknown}"
-EVENT="${DARKISH_HOOK_EVENT:-Stop}"
-scion message --to "${RECIPIENT}" \
-  "darkish hook ${EVENT}: agent ${AGENT}" 2>/dev/null || true
-HOOKEOF
-chmod +x "${DARKEN_HOOK_SCRIPT}"
-
-if command -v jq >/dev/null 2>&1; then
-  if [[ -f "${DARKEN_SETTINGS}" ]]; then
-    EXISTING_SETTINGS="$(cat "${DARKEN_SETTINGS}")"
-  else
-    EXISTING_SETTINGS='{}'
-  fi
-  echo "${EXISTING_SETTINGS}" | jq --arg cmd "${DARKEN_HOOK_SCRIPT}" '
-    .hooks = (.hooks // {}) |
-    .hooks.Stop = (
-      (.hooks.Stop // []) + [{
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "Stop"}}]
-      }]
-    ) |
-    .hooks.PreToolUse = (
-      (.hooks.PreToolUse // []) + [{
-        "matcher": "AskFollowupQuestion",
-        "hooks": [{"type": "command", "command": $cmd,
-                   "env": {"DARKISH_HOOK_EVENT": "AskFollowupQuestion"}}]
-      }]
-    )
-  ' > "${DARKEN_SETTINGS}.tmp" && mv "${DARKEN_SETTINGS}.tmp" "${DARKEN_SETTINGS}"
-  echo "darkish-prelude: operator notification hooks written to ${DARKEN_SETTINGS}" >&2
-else
-  echo "darkish-prelude: WARNING -- jq not found, operator notification hooks not configured" >&2
-fi
-
-# --- 5. Hand off to scion ----------------------------------------------------
+# --- 4. Hand off to scion ----------------------------------------------------
 
 # Resolve sciontool from PATH; the scion-claude image installs it but the
 # absolute path varies by release.

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -116,9 +116,12 @@ PYEOF
 
 do_rebuild() {
   # Use a per-process temp dir so parallel invocations never share a
-  # destination during cp.  The final rename is the only shared
-  # operation; the last writer wins and both processes exit 0.
+  # destination during cp.  Copy work happens outside the lock.
+  # The publish pair (rm -rf + mv) is serialized with a lock directory;
+  # mkdir is atomic on POSIX, so only one process enters the critical
+  # section at a time.
   local stage_tmp="${STAGE_DIR}.tmp.$$"
+  local lock_dir="${STAGE_DIR}.lock"
   rm -rf "${stage_tmp}"
   mkdir -p "${stage_tmp}"
   local refs
@@ -142,8 +145,21 @@ do_rebuild() {
     cp -R "${src}" "${dest}"
     echo "stage-skills: copied ${name} → ${STAGE_DIR}/${name}"
   done <<< "${refs}"
+  # Acquire publish lock (spin-wait up to ~10 s).
+  local i=0
+  while ! mkdir "${lock_dir}" 2>/dev/null; do
+    if [[ $((i++)) -ge 200 ]]; then
+      echo "stage-skills: timed out waiting for publish lock at ${lock_dir}" >&2
+      rm -rf "${stage_tmp}"
+      return 1
+    fi
+    sleep 0.05
+  done
+  # Critical section: remove old staging dir then atomically rename tmp into place.
   rm -rf "${STAGE_DIR}"
   mv "${stage_tmp}" "${STAGE_DIR}"
+  # Release lock.
+  rm -rf "${lock_dir}"
 }
 
 do_diff() {

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -116,9 +116,12 @@ PYEOF
 
 do_rebuild() {
   # Use a per-process temp dir so parallel invocations never share a
-  # destination during cp.  The final rename is the only shared
-  # operation; the last writer wins and both processes exit 0.
+  # destination during cp.  Copy work happens outside the lock.
+  # The publish pair (rm -rf + mv) is serialized with a lock directory;
+  # mkdir is atomic on POSIX, so only one process enters the critical
+  # section at a time.
   local stage_tmp="${STAGE_DIR}.tmp.$$"
+  local lock_dir="${STAGE_DIR}.lock"
   rm -rf "${stage_tmp}"
   mkdir -p "${stage_tmp}"
   local refs
@@ -142,8 +145,21 @@ do_rebuild() {
     cp -R "${src}" "${dest}"
     echo "stage-skills: copied ${name} → ${STAGE_DIR}/${name}"
   done <<< "${refs}"
+  # Acquire publish lock (spin-wait up to ~10 s).
+  local i=0
+  while ! mkdir "${lock_dir}" 2>/dev/null; do
+    if [[ $((i++)) -ge 200 ]]; then
+      echo "stage-skills: timed out waiting for publish lock at ${lock_dir}" >&2
+      rm -rf "${stage_tmp}"
+      return 1
+    fi
+    sleep 0.05
+  done
+  # Critical section: remove old staging dir then atomically rename tmp into place.
   rm -rf "${STAGE_DIR}"
   mv "${stage_tmp}" "${STAGE_DIR}"
+  # Release lock.
+  rm -rf "${lock_dir}"
 }
 
 do_diff() {

--- a/scripts/test-stage-skills-concurrency.sh
+++ b/scripts/test-stage-skills-concurrency.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
-# Regression test for Bug 18: two parallel stage-skills.sh invocations
-# must both succeed without cp errors (dest-exists race).
+# Regression test for Bug 18 + F3: concurrent stage-skills.sh invocations
+# must both succeed without cp errors (dest-exists race) AND must produce
+# exactly the expected top-level staging contents with no leftover temp or
+# lock dirs.
+#
+# Usage: test-stage-skills-concurrency.sh [N]
+#   N defaults to 10.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+N="${1:-10}"
 
 TMPDIR_WORK="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR_WORK}"' EXIT
@@ -24,47 +31,76 @@ skills:
   - beta-skill
 YAML
 
-STAGE_DIR="${ROOT}/.scion/skills-staging/${FAKE_HARNESS}"
-rm -rf "${STAGE_DIR}"
+STAGING_BASE="${ROOT}/.scion/skills-staging"
+STAGE_DIR="${STAGING_BASE}/${FAKE_HARNESS}"
+rm -rf "${STAGE_DIR}" "${STAGE_DIR}.lock" "${STAGE_DIR}".tmp.*
 
-# Launch two parallel invocations and collect exit codes.
-DARKEN_SKILLS_CANONICAL="${FAKE_CANONICAL}" \
-DARKEN_TEMPLATES_DIR="${TMPDIR_WORK}/templates" \
-  bash "${ROOT}/scripts/stage-skills.sh" "${FAKE_HARNESS}" \
-  > "${TMPDIR_WORK}/out1.txt" 2>&1 &
-PID1=$!
+# Launch N parallel invocations.
+PIDS=()
+for i in $(seq 1 "${N}"); do
+  DARKEN_SKILLS_CANONICAL="${FAKE_CANONICAL}" \
+  DARKEN_TEMPLATES_DIR="${TMPDIR_WORK}/templates" \
+    bash "${ROOT}/scripts/stage-skills.sh" "${FAKE_HARNESS}" \
+    > "${TMPDIR_WORK}/out${i}.txt" 2>&1 &
+  PIDS+=($!)
+done
 
-DARKEN_SKILLS_CANONICAL="${FAKE_CANONICAL}" \
-DARKEN_TEMPLATES_DIR="${TMPDIR_WORK}/templates" \
-  bash "${ROOT}/scripts/stage-skills.sh" "${FAKE_HARNESS}" \
-  > "${TMPDIR_WORK}/out2.txt" 2>&1 &
-PID2=$!
-
-RC1=0; RC2=0
-wait "${PID1}" || RC1=$?
-wait "${PID2}" || RC2=$?
-
-if [[ "${RC1}" -ne 0 ]]; then
-  echo "FAIL: first invocation exited ${RC1}" >&2
-  cat "${TMPDIR_WORK}/out1.txt" >&2
-  rm -rf "${STAGE_DIR}"
-  exit 1
-fi
-if [[ "${RC2}" -ne 0 ]]; then
-  echo "FAIL: second invocation exited ${RC2}" >&2
-  cat "${TMPDIR_WORK}/out2.txt" >&2
-  rm -rf "${STAGE_DIR}"
+FAILED=0
+for i in $(seq 1 "${N}"); do
+  RC=0
+  wait "${PIDS[$((i-1))]}" || RC=$?
+  if [[ "${RC}" -ne 0 ]]; then
+    echo "FAIL: invocation ${i} exited ${RC}" >&2
+    cat "${TMPDIR_WORK}/out${i}.txt" >&2
+    FAILED=1
+  fi
+done
+if [[ "${FAILED}" -ne 0 ]]; then
+  rm -rf "${STAGE_DIR}" "${STAGE_DIR}.lock" "${STAGE_DIR}".tmp.*
   exit 1
 fi
 
-# Verify the staging dir has the expected skills after parallel runs.
+# --- Assertion 1: expected skills are present ---
 for skill in alpha-skill beta-skill; do
   if [[ ! -f "${STAGE_DIR}/${skill}/SKILL.md" ]]; then
-    echo "FAIL: ${skill} missing from staging dir after parallel runs" >&2
-    rm -rf "${STAGE_DIR}"
+    echo "FAIL: ${skill}/SKILL.md missing from staging dir after ${N} parallel runs" >&2
+    rm -rf "${STAGE_DIR}" "${STAGE_DIR}.lock" "${STAGE_DIR}".tmp.*
     exit 1
   fi
 done
 
+# --- Assertion 2: exact top-level entries (no nested tmp dirs, no extra dirs) ---
+EXTRA=()
+while IFS= read -r -d '' entry; do
+  name="$(basename "${entry}")"
+  case "${name}" in
+    alpha-skill|beta-skill) ;;   # expected
+    *) EXTRA+=("${name}") ;;     # unexpected — catches nested .tmp.<pid> dirs
+  esac
+done < <(find "${STAGE_DIR}" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
+
+if [[ "${#EXTRA[@]}" -gt 0 ]]; then
+  echo "FAIL: unexpected top-level entries in staging dir after ${N} parallel runs:" >&2
+  printf '  %s\n' "${EXTRA[@]}" >&2
+  ls -la "${STAGE_DIR}" >&2
+  rm -rf "${STAGE_DIR}" "${STAGE_DIR}.lock" "${STAGE_DIR}".tmp.*
+  exit 1
+fi
+
+# --- Assertion 3: no leftover .tmp.* or .lock dirs beside the staging dir ---
+LEFTOVER=()
+while IFS= read -r -d '' entry; do
+  LEFTOVER+=("${entry}")
+done < <(find "${STAGING_BASE}" -maxdepth 1 \
+           \( -name "${FAKE_HARNESS}.tmp.*" -o -name "${FAKE_HARNESS}.lock" \) \
+           -print0 2>/dev/null || true)
+
+if [[ "${#LEFTOVER[@]}" -gt 0 ]]; then
+  echo "FAIL: leftover tmp/lock dirs after ${N} parallel runs:" >&2
+  printf '  %s\n' "${LEFTOVER[@]}" >&2
+  rm -rf "${STAGE_DIR}" "${STAGE_DIR}.lock" "${STAGE_DIR}".tmp.*
+  exit 1
+fi
+
 rm -rf "${STAGE_DIR}"
-echo "PASS: parallel stage-skills.sh invocations both succeeded without cp errors"
+echo "PASS: ${N} parallel stage-skills.sh invocations produced exact staging contents with no temp/lock dirs"


### PR DESCRIPTION
## Summary

Applies all 11 fixups from the ousterhout review of v0.1.18 (which was BLOCKED). Operator chose option (a) for both architectural questions: revert bug-24 entirely and strip non-Claude prelude hooks.

## Fixups

| # | Commit | Description |
|---|---|---|
| F1 | `cd51be4` | spawn.go stops forwarding manifest `command_args` to scion start |
| F2 | `a695629` | manifest parse errors block spawn instead of being swallowed |
| F3 | `3021839` | stage-skills publish section serialized via atomic mkdir lock |
| F4 | `9074ce9` | setup target resolved once, threaded into ensureGroveInit |
| F5 | `f8b9b02` | Claude hook setup stripped from non-Claude image preludes (codex/gemini/pi) |
| F6 | `c34ec2f` | `.claude/skills` permissions write switched from full-file replace to jq-merge |
| F7 | `d32b716` | Claude prelude hook insertion now idempotent |
| F8 | `cbaac0c` | `darken look` routed through `ScionClient.LookAgent`, drops hardcoded `--no-hub` |
| F9 | `2f1b950` | ANSI stripper expanded to cover CSI private modes and OSC sequences |
| F10 | `71c6069` | `look` registered in main.go explicit subcommand table |
| F11 | `67f7580` | `jsonStart` whitespace-aware for leading spaces/tabs |

Plus pre-swarm `command_args` cleanup (`6501ea6`) — variadic `--betas` was eating dispatch briefs — and post-swarm test polish (`a17c369`).

Full review document committed at `241b098`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `go test ./...` green (cmd/darken, internal/staging, internal/substrate)
- [x] `bash scripts/test-embed-drift.sh` PASS
- [x] All 4 docker images rebuilt from updated preludes (claude/codex/gemini/pi)