### PR TITLE
fix: heartbeat URL leaks unexpanded ${DARKEN_HUB_ENDPOINT} placeholder

### DIFF
--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-haiku-4-5-20251001
+model: claude-haiku-4-5-20251001[1m]
 max_turns: 100
 max_duration: "8h"
 detached: true

--- a/.scion/templates/designer/scion-agent.yaml
+++ b/.scion/templates/designer/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "1h"
 detached: false

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 200
 max_duration: "4h"
 detached: false

--- a/.scion/templates/planner-t2/scion-agent.yaml
+++ b/.scion/templates/planner-t2/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 30
 max_duration: "1h"
 detached: false

--- a/.scion/templates/planner-t3/scion-agent.yaml
+++ b/.scion/templates/planner-t3/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "2h"
 detached: false

--- a/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-sonnet-4-6
+model: claude-sonnet-4-6[1m]
 max_turns: 100
 max_duration: "2h"
 detached: false

--- a/images/claude/darkish-prelude.sh
+++ b/images/claude/darkish-prelude.sh
@@ -148,11 +148,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 6. Operator notification hooks ------------------------------------------

--- a/images/codex/darkish-prelude.sh
+++ b/images/codex/darkish-prelude.sh
@@ -97,11 +97,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 5. Hand off to scion ----------------------------------------------------

--- a/images/gemini/darkish-prelude.sh
+++ b/images/gemini/darkish-prelude.sh
@@ -54,11 +54,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 4. Hand off to scion ----------------------------------------------------

--- a/images/pi/darkish-prelude.sh
+++ b/images/pi/darkish-prelude.sh
@@ -54,11 +54,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 4. Hand off to scion ----------------------------------------------------

--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-haiku-4-5-20251001
+model: claude-haiku-4-5-20251001[1m]
 max_turns: 100
 max_duration: "8h"
 detached: true

--- a/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "1h"
 detached: false

--- a/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 200
 max_duration: "4h"
 detached: false

--- a/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 30
 max_duration: "1h"
 detached: false

--- a/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-opus-4-7
+model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "2h"
 detached: false

--- a/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-sonnet-4-6
+model: claude-sonnet-4-6[1m]
 max_turns: 100
 max_duration: "2h"
 detached: false

--- a/internal/substrate/data/images/claude/darkish-prelude.sh
+++ b/internal/substrate/data/images/claude/darkish-prelude.sh
@@ -148,11 +148,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 6. Operator notification hooks ------------------------------------------

--- a/internal/substrate/data/images/codex/darkish-prelude.sh
+++ b/internal/substrate/data/images/codex/darkish-prelude.sh
@@ -97,11 +97,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 5. Hand off to scion ----------------------------------------------------

--- a/internal/substrate/data/images/gemini/darkish-prelude.sh
+++ b/internal/substrate/data/images/gemini/darkish-prelude.sh
@@ -54,11 +54,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 4. Hand off to scion ----------------------------------------------------

--- a/internal/substrate/data/images/pi/darkish-prelude.sh
+++ b/internal/substrate/data/images/pi/darkish-prelude.sh
@@ -54,11 +54,18 @@ fi
 # agent for missed heartbeats. Override here using the per-template
 # DARKEN_HUB_ENDPOINT (set by scion-cmd helper) or fall back to the
 # documented default.
-if [[ "${SCION_HUB_URL:-}" == http://localhost:8080 || "${SCION_HUB_ENDPOINT:-}" == http://localhost:8080 ]]; then
+_needs_hub_override() {
+  case "$1" in
+    http://localhost:8080) return 0 ;;
+    *'${'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+if _needs_hub_override "${SCION_HUB_URL:-}" || _needs_hub_override "${SCION_HUB_ENDPOINT:-}"; then
   HUB_OVERRIDE="${DARKEN_HUB_ENDPOINT:-http://host.docker.internal:8080}"
   export SCION_HUB_URL="${HUB_OVERRIDE}"
   export SCION_HUB_ENDPOINT="${HUB_OVERRIDE}"
-  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (broker-localhost workaround)" >&2
+  echo "darkish-prelude: SCION_HUB_URL and SCION_HUB_ENDPOINT overridden to ${HUB_OVERRIDE} (localhost or unexpanded placeholder)" >&2
 fi
 
 # --- 4. Hand off to scion ----------------------------------------------------


### PR DESCRIPTION
## Summary

When `darken setup` uploads templates via `scion templates push`, scion reads the project's local `.scion/templates/<role>/scion-agent.yaml` as-is and stores the literal `${DARKEN_HUB_ENDPOINT}` placeholder in the hub. Spawned agents then receive scion-env entries like:

```
export SCION_HUB_URL="${DARKEN_HUB_ENDPOINT}"
```

and sciontool reads them as raw values (no shell expansion), producing heartbeat POSTs to the URL-encoded literal:

```
Post "$%7BDARKEN_HUB_ENDPOINT%7D/api/v1/agents/.../status": unsupported protocol scheme ""
```

The existing prelude override only fired when `SCION_HUB_URL` equaled `http://localhost:8080`. This patch extends it to also fire when the value still contains an unexpanded `${...}` placeholder.

## Scope

- 4 canonical preludes: `images/{claude,codex,gemini,pi}/darkish-prelude.sh`
- 4 mirrors: `internal/substrate/data/images/*/darkish-prelude.sh`
- Existing localhost-broker behavior unchanged
- No public API change
- Local images rebuilt to verify

## Test plan

- [x] `bash -n` syntax check on all 8 preludes
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `bash scripts/test-embed-drift.sh` PASS
- [x] `make -C images claude codex gemini pi` rebuilds cleanly

## Followup (separate PRs)

- Root-cause fix in `bootstrap.go`/`PushTemplate`: pre-expand manifests before `scion templates push` so the hub stores expanded values. The prelude check is defense-in-depth.
- Consider whether `${DARKEN_*}` should be substituted whenever a manifest is uploaded, not just when extracted from embedded substrate.