### PR TITLE
fix: revert haiku [1m] suffix in admin template (no 1M variant exists)

### DIFF
--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-haiku-4-5-20251001[1m]
+model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true

--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -4,7 +4,7 @@ agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude
 image: local/darkish-claude:latest
-model: claude-haiku-4-5-20251001[1m]
+model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true


### PR DESCRIPTION
## Summary

In v0.1.19 I uniformly bumped long-running Claude templates to add the `[1m]` suffix without verifying per-model 1M support. Anthropic's Models overview confirms Haiku 4.5 has 200K context only — no 1M variant. Reverting just the admin template (which uses haiku-4-5).

## Untouched (verified valid)

- Opus 4.7 templates (orchestrator, planner-t2, planner-t3, designer): `[1m]` valid ✓
- Sonnet 4.6 template (tdd-implementer): `[1m]` valid ✓ (no longer requires beta header as of 2026)

## Test plan

- [x] `go test ./...` green
- [x] `bash scripts/test-embed-drift.sh` PASS