### PR TITLE
docs: update README + CLAUDE.md for darken up/down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,11 @@ The `caveman` skill (mounted in every container; available globally on host) gov
 ## Operator-side quick reference
 
 ```bash
-# One-time setup (new project)
-darken setup
+# Bring up a new project (chains bones up by default; pass --no-bones to skip)
+darken up
+
+# Tear it down
+darken down --yes
 
 # After `brew upgrade darken`
 darken upgrade-init

--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ The `darken` binary is self-contained — templates, scripts, Dockerfiles, and t
 **Fresh project:**
 
 ```bash
-darken setup
+darken up
 ```
 
-That's it — scaffolds CLAUDE.md, stages skills, ensures Docker/scion/images/secrets, and runs `bones init`.
+That's it — scaffolds CLAUDE.md, stages skills, ensures Docker/scion/images/secrets, and chains `bones up`. Pass `--no-bones` to skip the bones chain.
+
+**Tear it back down:**
+
+```bash
+darken down --yes
+```
+
+Stops project agents, deletes the project grove, removes scaffolds, runs `bones down`. Add `--purge` to also stop the scion server and clean user-scope hub templates.
 
 **Existing project, post-`brew upgrade darken`:**
 


### PR DESCRIPTION
## Summary

Follow-up to PR #36 (v0.1.21). The CLI doc was updated but README.md and CLAUDE.md still referenced the deprecated `darken setup`. This PR aligns them:

- README quick-start now shows `darken up` and `darken down --yes`
- CLAUDE.md operator quick-reference now shows `darken up` / `darken down --yes` / `darken upgrade-init`

No code changes.