### PR TITLE
docs: drop --yes from down examples (don't train users to skip the safety prompt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ The `caveman` skill (mounted in every container; available globally on host) gov
 # Bring up a new project (chains bones up by default; pass --no-bones to skip)
 darken up
 
-# Tear it down
-darken down --yes
+# Tear it down (prompts; add --yes to skip in scripts)
+darken down
 
 # After `brew upgrade darken`
 darken upgrade-init

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ That's it — scaffolds CLAUDE.md, stages skills, ensures Docker/scion/images/se
 **Tear it back down:**
 
 ```bash
-darken down --yes
+darken down
 ```
 
-Stops project agents, deletes the project grove, removes scaffolds, runs `bones down`. Add `--purge` to also stop the scion server and clean user-scope hub templates.
+Stops project agents, deletes the project grove, removes scaffolds, runs `bones down`. Prompts before acting; pass `--yes` to skip the prompt in scripts. Add `--purge` to also stop the scion server and clean user-scope hub templates.
 
 **Existing project, post-`brew upgrade darken`:**
 


### PR DESCRIPTION
Follow-up to PR #37 — operator pointed out that showing `darken down --yes` in the README/CLAUDE.md trains users to bypass the safety prompt by reflex. Plain `darken down` is the discoverable default; `--yes` exists for scripts and is mentioned parenthetically.