### PR TITLE
feat(doctor): surface bones CLI version + footer points at darken up

### DIFF
--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -26,11 +26,12 @@ const (
 // Using a registry of DoctorCheck values replaces the old stringly-typed
 // remediationFor dispatch.
 type DoctorCheck struct {
-	ID          string       // machine-readable identifier (stable across versions)
-	Label       string       // human-readable label printed in the report
-	Severity    string       // SeverityFail or SeverityWarn
-	Run         func() error // returns nil on success, non-nil on failure
-	Remediation string       // inline remediation hint; used when Run() returns non-nil
+	ID          string        // machine-readable identifier (stable across versions)
+	Label       string        // human-readable label printed in the report
+	Severity    string        // SeverityFail or SeverityWarn
+	Run         func() error  // returns nil on success, non-nil on failure
+	Detail      func() string // optional: short detail appended to the OK line (e.g. version string)
+	Remediation string        // inline remediation hint; used when Run() returns non-nil
 }
 
 func runDoctor(args []string) error {
@@ -174,6 +175,14 @@ func doctorBroadChecks() []DoctorCheck {
 			Run:         checkHostsDockerInternal,
 			Remediation: `echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts`,
 		},
+		{
+			ID:          "bones-cli",
+			Label:       "bones CLI present",
+			Severity:    SeverityWarn,
+			Run:         checkBones,
+			Detail:      bonesVersion,
+			Remediation: "brew install bones (or run `darken up --no-bones` to skip the bones chain)",
+		},
 	}
 }
 
@@ -185,6 +194,12 @@ func doctorBroad() (string, error) {
 		err := dc.Run()
 		switch {
 		case err == nil:
+			if dc.Detail != nil {
+				if d := dc.Detail(); d != "" {
+					fmt.Fprintf(&sb, "OK    %s (%s)\n", dc.Label, d)
+					continue
+				}
+			}
 			fmt.Fprintf(&sb, "OK    %s\n", dc.Label)
 		case dc.Severity == SeverityWarn:
 			fmt.Fprintf(&sb, "WARN  %s — %v\n", dc.Label, err)
@@ -217,6 +232,34 @@ func checkScion() error {
 		return fmt.Errorf("scion not found on PATH: %w", err)
 	}
 	return nil
+}
+
+// checkBones reports whether the bones CLI is on PATH. Severity is Warn
+// because `darken up --no-bones` is a supported path; we just want the
+// operator to see when bones is missing or stale.
+func checkBones() error {
+	_, err := exec.LookPath("bones")
+	if err != nil {
+		return fmt.Errorf("bones not found on PATH (run `brew install bones`, or use --no-bones to skip the chain)")
+	}
+	return nil
+}
+
+// bonesVersion captures `bones --version` for the Detail line of the
+// bones-cli check. Returns empty on any error so the renderer falls back
+// to plain "OK". Trims whitespace and keeps the first non-empty line.
+func bonesVersion() string {
+	out, err := exec.Command("bones", "--version").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func checkScionServer() error {

--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -212,7 +212,7 @@ func doctorBroad() (string, error) {
 	}
 
 	if len(failed) > 0 {
-		sb.WriteString("\n→ for a fresh project, run `darken setup` to bring everything online\n")
+		sb.WriteString("\n→ for a fresh project, run `darken up` to bring everything online\n")
 		return sb.String(), fmt.Errorf("%d checks failed: %s", len(failed), strings.Join(failed, ", "))
 	}
 	return sb.String(), nil

--- a/cmd/darken/doctor_bones_test.go
+++ b/cmd/darken/doctor_bones_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckBones_PresentSurfacesVersion plants a fake `bones` that prints
+// a version line, then asserts doctorBroad's OK line for the bones-cli
+// check includes the version in parentheses.
+func TestCheckBones_PresentSurfacesVersion(t *testing.T) {
+	dir := t.TempDir()
+	bones := filepath.Join(dir, "bones")
+	body := `#!/bin/sh
+case "$1" in
+  --version) echo "bones 1.4.0 (commit deadbeef)" ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(bones, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+
+	if err := checkBones(); err != nil {
+		t.Fatalf("checkBones should succeed when bones is on PATH: %v", err)
+	}
+
+	got := bonesVersion()
+	if !strings.Contains(got, "1.4.0") {
+		t.Errorf("bonesVersion should surface version string, got %q", got)
+	}
+}
+
+// TestCheckBones_MissingReturnsError verifies the warn-severity check
+// fires when bones is absent.
+func TestCheckBones_MissingReturnsError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty PATH — no bones
+
+	err := checkBones()
+	if err == nil {
+		t.Fatal("checkBones should error when bones is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "bones") {
+		t.Errorf("error should mention bones, got: %v", err)
+	}
+}
+
+// TestBonesVersion_FailureReturnsEmpty asserts that when bones is missing
+// (or fails), bonesVersion returns "" so the renderer falls back to plain
+// "OK label" instead of "OK label ()".
+func TestBonesVersion_FailureReturnsEmpty(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	if got := bonesVersion(); got != "" {
+		t.Errorf("bonesVersion with no bones on PATH should be empty, got %q", got)
+	}
+}

--- a/cmd/darken/doctor_test.go
+++ b/cmd/darken/doctor_test.go
@@ -295,7 +295,7 @@ func TestCheckScion_CLIPresentDaemonDown(t *testing.T) {
 	}
 }
 
-func TestDoctorBroad_FooterMentionsSetupOnFailure(t *testing.T) {
+func TestDoctorBroad_FooterMentionsUpOnFailure(t *testing.T) {
 	// Stub scion to exit non-zero so checkScion fails.
 	stubDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(stubDir, "scion"),
@@ -314,8 +314,8 @@ func TestDoctorBroad_FooterMentionsSetupOnFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected doctor to fail when scion is broken")
 	}
-	if !strings.Contains(report, "darken setup") {
-		t.Fatalf("failure report should mention `darken setup`:\n%s", report)
+	if !strings.Contains(report, "darken up") {
+		t.Fatalf("failure report should mention `darken up`:\n%s", report)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related cleanups in `darken doctor`.

**1. Bones CLI check + version surface.** New warn-severity check `bones-cli` runs `bones --version` and includes the version string on the OK line. Helps the operator notice when bones is months behind without forcing version coupling at the `darken up` boundary.

```
OK    bones CLI present (bones 1.4.0)
WARN  bones CLI present — bones not found on PATH ...
      remediation: brew install bones (or run `darken up --no-bones` to skip the bones chain)
```

Mechanism: extends `DoctorCheck` with an optional `Detail func() string`; the renderer appends `(detail)` to the OK line when present. Other checks unaffected.

**2. Footer points at `darken up`.** The doctor's failure footer used to suggest `darken setup` — now deprecated alias. Updated to `darken up`. Existing assertion test updated/renamed accordingly.

## Test plan

- [x] `go test ./...` green (new: TestCheckBones_PresentSurfacesVersion, TestCheckBones_MissingReturnsError, TestBonesVersion_FailureReturnsEmpty)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `bash scripts/test-embed-drift.sh` PASS