### PR TITLE
fix(darken-up): import templates into scion before Hub push

### DIFF
--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -87,7 +87,7 @@ func ensureAllSkillsStaged() error {
 	}
 	defer cleanup()
 
-	return withTemplatesDirEnv(templatesDir, func() error {
+	if err := withTemplatesDirEnv(templatesDir, func() error {
 		dirs, err := os.ReadDir(templatesDir)
 		if err != nil {
 			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
@@ -101,7 +101,18 @@ func ensureAllSkillsStaged() error {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Register every canonical role with scion's local template store so
+	// uploadAllTemplatesToHub can push them. The deferred cleanup above
+	// removes the source dir; scion's import copies bodies into its own
+	// store, so post-cleanup push works.
+	if err := defaultScionClient.ImportAllTemplates(templatesDir); err != nil {
+		return fmt.Errorf("import templates: %w", err)
+	}
+	return nil
 }
 
 // withTemplatesDirEnv runs fn with DARKEN_TEMPLATES_DIR set to dir,

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -82,3 +82,51 @@ func TestBootstrap_BrokerProvideStep(t *testing.T) {
 		t.Fatalf("broker provide must run after scion server check, log:\n%s", got)
 	}
 }
+
+// TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore asserts that
+// ensureAllSkillsStaged calls ImportAllTemplates with the resolved
+// templatesDir. This is the regression guard for the darken-up
+// template-upload bug: without the import, scion's local store is empty
+// when uploadAllTemplatesToHub later calls templates push.
+func TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore(t *testing.T) {
+	// Prepare a fake project root with .scion/templates/ so resolveTemplatesDir
+	// returns a known, no-cleanup path. resolveTemplatesDir's first preference
+	// is repoRoot()/.scion/templates/.
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	templatesDir := filepath.Join(root, ".scion", "templates")
+	for _, role := range []string{"admin", "researcher"} {
+		dir := filepath.Join(templatesDir, role)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Plant a minimal manifest so stage-skills doesn't barf on missing yaml.
+		manifest := filepath.Join(dir, "scion-agent.yaml")
+		if err := os.WriteFile(manifest, []byte("schema_version: \"1\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Stub bash on PATH so runSubstrateScript no-ops.
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "bash"),
+		[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := ensureAllSkillsStaged(); err != nil {
+		t.Fatalf("ensureAllSkillsStaged: %v", err)
+	}
+
+	if got := len(mc.importAllTemplatesCalls); got != 1 {
+		t.Fatalf("expected exactly 1 ImportAllTemplates call; got %d: %v",
+			got, mc.importAllTemplatesCalls)
+	}
+	if got := mc.importAllTemplatesCalls[0]; got != templatesDir {
+		t.Errorf("ImportAllTemplates called with %q; want %q", got, templatesDir)
+	}
+}

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -33,6 +33,13 @@ type ScionClient interface {
 	// PushTemplate uploads a role template to the hub at user (global) scope.
 	PushTemplate(role string) error
 
+	// ImportAllTemplates copies every template subdirectory under dir into
+	// scion's local store at user (global) scope. Idempotent: re-importing
+	// the same template overwrites the prior copy. Bodies survive deletion
+	// of the source dir, so the caller can clean up an extracted tmpdir
+	// immediately after this returns.
+	ImportAllTemplates(dir string) error
+
 	// GroveInit registers targetDir as a project-scoped scion grove.
 	// Idempotent at the caller level: callers check for .scion/grove-id before
 	// invoking this method. targetDir is used as the working directory so that
@@ -82,6 +89,13 @@ func (c *execScionClient) BrokerProvide() error {
 
 func (c *execScionClient) PushTemplate(role string) error {
 	cmd := scionCmdWithEnv([]string{"--global", "templates", "push", role})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (c *execScionClient) ImportAllTemplates(dir string) error {
+	cmd := scionCmdWithEnv([]string{"--global", "templates", "import", "--all", dir})
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -20,6 +20,9 @@ type mockScionClient struct {
 	lookAgentOut     []byte
 	lookAgentErr     error
 
+	importAllTemplatesErr   error
+	importAllTemplatesCalls []string
+
 	startAgentCalls   [][]string
 	pushTemplateCalls []string
 	groveInitCalls    int
@@ -43,6 +46,10 @@ func (m *mockScionClient) BrokerProvide() error {
 func (m *mockScionClient) PushTemplate(role string) error {
 	m.pushTemplateCalls = append(m.pushTemplateCalls, role)
 	return m.pushTemplateErr
+}
+func (m *mockScionClient) ImportAllTemplates(dir string) error {
+	m.importAllTemplatesCalls = append(m.importAllTemplatesCalls, dir)
+	return m.importAllTemplatesErr
 }
 func (m *mockScionClient) GroveInit(targetDir string) error {
 	m.groveInitCalls++

--- a/cmd/darken/setup.go
+++ b/cmd/darken/setup.go
@@ -46,7 +46,12 @@ func ensureGroveInit(targetDir string) error {
 
 // uploadAllTemplatesToHub pushes all 14 canonical templates to the Hub at
 // user (global) scope via ScionClient.PushTemplate.
-// Runs after bootstrap so the scion server is guaranteed to be running.
+//
+// Precondition: scion's local template store contains every canonical
+// role. ensureAllSkillsStaged satisfies this by calling
+// ImportAllTemplates during bootstrap. Without that import, push fails
+// with "template not found locally" because scion looks up templates by
+// name in its own store and refuses to push what it has never seen.
 func uploadAllTemplatesToHub() error {
 	for _, role := range canonicalRoles {
 		fmt.Printf("uploading template %s to Hub (user scope) ...\n", role)

--- a/cmd/darken/setup_test.go
+++ b/cmd/darken/setup_test.go
@@ -26,6 +26,13 @@ exit 0
 `
 	scionStub := `#!/bin/sh
 echo "scion $@" >> ` + logPath + `
+# Path of the import-state file. Each role registered via 'templates import'
+# adds a line; 'templates push' then requires the role be present.
+state="` + filepath.Join(stubDir, "scion-import-state") + `"
+
+# Strip global flags to find the subcommand.
+while [ "$1" = "--global" ] || [ "$1" = "--no-hub" ]; do shift; done
+
 case "$1" in
   list)
     case "$2" in
@@ -39,6 +46,46 @@ case "$1" in
       echo "codex_auth"
       echo "gemini_auth"
     fi
+    ;;
+  templates)
+    sub="$2"
+    case "$sub" in
+      import)
+        if [ "$3" = "--all" ]; then
+          dir="$4"
+          if [ ! -d "$dir" ]; then
+            echo "Error: import --all: directory not found: $dir" >&2
+            exit 1
+          fi
+          for d in "$dir"/*/; do
+            [ -d "$d" ] || continue
+            role=$(basename "$d")
+            echo "$role" >> "$state"
+          done
+        else
+          if [ -z "$3" ]; then
+            echo "Error: import: path required" >&2
+            exit 1
+          fi
+          role=$(basename "$3")
+          echo "$role" >> "$state"
+        fi
+        ;;
+      push)
+        role="$3"
+        if [ -z "$role" ]; then
+          echo "Error: push: role required" >&2
+          exit 1
+        fi
+        if [ ! -f "$state" ] || ! grep -qx "$role" "$state"; then
+          echo "Error: template '$role' not found locally" >&2
+          exit 1
+        fi
+        ;;
+      list)
+        if [ -f "$state" ]; then cat "$state"; fi
+        ;;
+    esac
     ;;
 esac
 exit 0

--- a/docs/superpowers/plans/2026-05-01-darken-up-template-upload-fix.md
+++ b/docs/superpowers/plans/2026-05-01-darken-up-template-upload-fix.md
@@ -1,0 +1,462 @@
+# `darken up` template-upload fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `darken up` succeed in any project (not just darkish-factory) by registering the 14 canonical templates with scion's local store during bootstrap, before the Hub-push step runs.
+
+**Architecture:** Branch A from `docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md`. Verification confirmed `scion --global templates import --all <dir>` copies template bodies into scion's permanent store at `~/.scion/templates/<role>`. Wire one new call into `ensureAllSkillsStaged` so scion has the templates before `uploadAllTemplatesToHub` later calls `scion templates push <role>`.
+
+**Tech Stack:** Go (standard library + scion CLI). Tests use the existing PATH-stub harness in `cmd/darken/setup_test.go`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `cmd/darken/scion_client.go` | Production scion CLI wrapper | Add `ImportAllTemplates(dir string) error` to the `ScionClient` interface and to `execScionClient` |
+| `cmd/darken/scion_client_test.go` | Mock scion client | Extend `mockScionClient` with `importAllTemplatesCalls []string` plus the interface method |
+| `cmd/darken/bootstrap.go` | Bootstrap step orchestration | Call `defaultScionClient.ImportAllTemplates(templatesDir)` inside `ensureAllSkillsStaged` after stage-skills loop, before deferred cleanup runs |
+| `cmd/darken/setup_test.go` | PATH-stub integration test | Tighten the scion stub to model "import-before-push" semantics so the existing `TestSetup_UploadsAllTemplatesToHub` catches the bug |
+| `cmd/darken/bootstrap_test.go` (new file) | Unit test for the new wiring | Assert `ensureAllSkillsStaged` calls `ImportAllTemplates` with the resolved templatesDir |
+
+Files NOT changed: `cmd/darken/up.go`, `cmd/darken/setup.go`, `cmd/darken/roles.go`. Branch A's whole point is that runUp and uploadAllTemplatesToHub are untouched.
+
+---
+
+## Task 1: Tighten scion PATH-stub to model import-before-push (RED)
+
+The current stub at `cmd/darken/setup_test.go:27-45` always exits 0 on `templates push`. That's why `TestSetup_UploadsAllTemplatesToHub` passes on `main` even though `darken up` fails in the real world. Make the stub model scion's actual behavior: `templates push <role>` requires that `<role>` was previously imported. This test is RED until Task 3 is complete.
+
+**Files:**
+- Modify: `cmd/darken/setup_test.go:18-80` (the `stubAllBinariesForSetup` function — specifically the `scionStub` heredoc at lines 27-45)
+
+- [ ] **Step 1: Read the current stub**
+
+```bash
+sed -n '11,80p' cmd/darken/setup_test.go
+```
+
+Confirm the scion stub exits 0 unconditionally and only special-cases `list` and `hub`.
+
+- [ ] **Step 2: Replace `scionStub` heredoc with import-aware version**
+
+Replace lines 27-45 of `cmd/darken/setup_test.go` (the `scionStub` heredoc) with:
+
+```go
+	scionStub := `#!/bin/sh
+echo "scion $@" >> ` + logPath + `
+# Path of the import-state file. Each role registered via 'templates import'
+# adds a line to this file; 'templates push' then requires the role be present.
+state="` + filepath.Join(stubDir, "scion-import-state") + `"
+
+# Strip global flags to find the subcommand.
+while [ "$1" = "--global" ] || [ "$1" = "--no-hub" ]; do shift; done
+
+case "$1" in
+  list)
+    case "$2" in
+      "--format") echo "[]" ;;
+      *) echo "" ;;
+    esac
+    ;;
+  hub)
+    if [ "$3" = "list" ]; then
+      echo "claude_auth"
+      echo "codex_auth"
+      echo "gemini_auth"
+    fi
+    ;;
+  templates)
+    sub="$2"
+    case "$sub" in
+      import)
+        # 'import --all <dir>' or 'import <path>'
+        if [ "$3" = "--all" ]; then
+          dir="$4"
+          for d in "$dir"/*/; do
+            role=$(basename "$d")
+            echo "$role" >> "$state"
+          done
+        else
+          role=$(basename "$3")
+          echo "$role" >> "$state"
+        fi
+        ;;
+      push)
+        role="$3"
+        if [ ! -f "$state" ] || ! grep -qx "$role" "$state"; then
+          echo "Error: template '$role' not found locally: template '$role' not found" >&2
+          exit 1
+        fi
+        ;;
+      list)
+        if [ -f "$state" ]; then cat "$state"; fi
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`
+```
+
+Note the use of `filepath.Join(stubDir, "scion-import-state")` — Go string interpolation, not shell. The heredoc must be assembled in Go code; the import-state file path is a Go expression.
+
+- [ ] **Step 3: Run the existing test to confirm it now fails**
+
+Run: `go test ./cmd/darken/ -run TestSetup_UploadsAllTemplatesToHub -v`
+
+Expected: FAIL with output like `expected scion "--global templates push admin" to be called` — actually the push IS called but exits non-zero because no import preceded it. Look for the runSetup return error: `bootstrap returned error: upload template admin: ...`. The exact failure message depends on how runSetup propagates the push error; the key observation is the test no longer passes.
+
+If the test still passes, the stub change wasn't applied — re-check Step 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/darken/setup_test.go
+git commit -m "test: model scion import-before-push semantics in PATH stub
+
+The existing scion stub exited 0 unconditionally, which is why
+TestSetup_UploadsAllTemplatesToHub passed despite darken up
+failing in real usage. Now the stub tracks imported roles in a
+state file and requires push targets to have been imported first.
+Test is RED until ImportAllTemplates is wired into bootstrap."
+```
+
+---
+
+## Task 2: Add `ImportAllTemplates` to the `ScionClient` interface and implementations
+
+**Files:**
+- Modify: `cmd/darken/scion_client.go:16-45` (interface declaration); `cmd/darken/scion_client.go:50-108` (execScionClient methods)
+- Modify: `cmd/darken/scion_client_test.go:10-55` (mockScionClient struct + methods)
+
+- [ ] **Step 1: Add interface method to `ScionClient`**
+
+In `cmd/darken/scion_client.go`, inside the `ScionClient` interface block (lines 16-45), add this method between `PushTemplate` and `GroveInit`:
+
+```go
+	// ImportAllTemplates copies every template subdirectory under dir into
+	// scion's local store at user (global) scope. Idempotent: re-importing
+	// the same template overwrites the prior copy. Bodies survive deletion
+	// of the source dir, so the caller can clean up an extracted tmpdir
+	// immediately after this returns.
+	ImportAllTemplates(dir string) error
+```
+
+- [ ] **Step 2: Implement `ImportAllTemplates` on `execScionClient`**
+
+After `PushTemplate` in `cmd/darken/scion_client.go` (insert after line 88), add:
+
+```go
+func (c *execScionClient) ImportAllTemplates(dir string) error {
+	cmd := scionCmdWithEnv([]string{"--global", "templates", "import", "--all", dir})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+```
+
+- [ ] **Step 3: Add mock method**
+
+In `cmd/darken/scion_client_test.go`, extend the `mockScionClient` struct (lines 11-28) by adding two fields:
+
+```go
+	importAllTemplatesErr   error
+	importAllTemplatesCalls []string
+```
+
+Insert them next to the other call-tracking fields (around line 24, near `pushTemplateCalls`).
+
+Then add the method after `PushTemplate` (line 46):
+
+```go
+func (m *mockScionClient) ImportAllTemplates(dir string) error {
+	m.importAllTemplatesCalls = append(m.importAllTemplatesCalls, dir)
+	return m.importAllTemplatesErr
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `go build ./cmd/darken/`
+
+Expected: success (no output). Confirms the interface and both implementations satisfy the contract.
+
+- [ ] **Step 5: Run all existing cmd/darken tests**
+
+Run: `go test ./cmd/darken/ -count=1`
+
+Expected: `TestSetup_UploadsAllTemplatesToHub` still FAILs (Task 1's RED state). All other tests should still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/darken/scion_client.go cmd/darken/scion_client_test.go
+git commit -m "feat(scion-client): add ImportAllTemplates method
+
+Wraps 'scion --global templates import --all <dir>'. Copies all
+template subdirectories under dir into scion's permanent local
+store. Used by bootstrap to register canonical roles before the
+Hub-push step. Mock and execScionClient both implement the new
+interface method; not yet called from bootstrap."
+```
+
+---
+
+## Task 3: Call `ImportAllTemplates` from `ensureAllSkillsStaged` (GREEN)
+
+**Files:**
+- Modify: `cmd/darken/bootstrap.go:83-105` (the `ensureAllSkillsStaged` function)
+
+- [ ] **Step 1: Read the current function**
+
+```bash
+sed -n '80,106p' cmd/darken/bootstrap.go
+```
+
+Note the structure: resolve dir, defer cleanup, set DARKEN_TEMPLATES_DIR env, iterate dirs running stage-skills.sh per harness.
+
+- [ ] **Step 2: Add the import call after the stage-skills loop, before cleanup runs**
+
+Replace `cmd/darken/bootstrap.go:83-105` with:
+
+```go
+func ensureAllSkillsStaged() error {
+	templatesDir, cleanup, err := resolveTemplatesDir()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := withTemplatesDirEnv(templatesDir, func() error {
+		dirs, err := os.ReadDir(templatesDir)
+		if err != nil {
+			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
+		}
+		for _, d := range dirs {
+			if !d.IsDir() || d.Name() == "base" {
+				continue
+			}
+			if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
+				fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Register every canonical role with scion's local template store so
+	// uploadAllTemplatesToHub can push them. The deferred cleanup above
+	// removes the source dir; scion's import copies bodies into its own
+	// store, so post-cleanup push works.
+	if err := defaultScionClient.ImportAllTemplates(templatesDir); err != nil {
+		return fmt.Errorf("import templates: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `go test ./cmd/darken/ -run TestSetup_UploadsAllTemplatesToHub -v`
+
+Expected: PASS. Bootstrap now imports before upload; the stub recognizes the imported roles when push runs.
+
+- [ ] **Step 4: Run the full cmd/darken test suite**
+
+Run: `go test ./cmd/darken/ -count=1`
+
+Expected: all tests PASS. No regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/darken/bootstrap.go
+git commit -m "fix(bootstrap): import templates into scion before Hub push
+
+darken up extracts embedded templates to a tmpdir, stages skills,
+then deferred-cleanup removes the dir. Subsequent
+uploadAllTemplatesToHub then called scion templates push <role>
+with nothing in scion's local store and got a 404. Call
+ImportAllTemplates inside the same scope as the extraction so
+scion has the bodies before cleanup runs and before push fires.
+
+Fixes 'darken up' in any project that does not have
+.scion/templates/ committed at the repo root (e.g. fresh
+non-darkish-factory checkouts)."
+```
+
+---
+
+## Task 4: Add unit test guarding the wiring (regression guard)
+
+The integration test in Task 1/3 is observable-outcome (push succeeds). Add a unit test that pins the implementation invariant: `ensureAllSkillsStaged` calls `ImportAllTemplates` exactly once with the templatesDir.
+
+**Files:**
+- Create: `cmd/darken/bootstrap_test.go`
+
+- [ ] **Step 1: Check whether bootstrap_test.go already exists**
+
+```bash
+ls cmd/darken/bootstrap_test.go 2>&1 || echo "missing"
+```
+
+If the file exists, the new test goes inside it. If missing, create it. The instructions below assume creation; if it exists, splice the new test in next to other tests that share the package and skip the package declaration.
+
+- [ ] **Step 2: Write the test**
+
+Create `cmd/darken/bootstrap_test.go` with this content (or append the function if the file exists):
+
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore asserts that
+// ensureAllSkillsStaged calls ImportAllTemplates with the resolved
+// templatesDir. This is the regression guard for the darken-up
+// template-upload bug: without the import, scion's local store is empty
+// when uploadAllTemplatesToHub later calls templates push.
+func TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore(t *testing.T) {
+	// Prepare a fake project root with .scion/templates/ so resolveTemplatesDir
+	// returns a known, no-cleanup path. resolveTemplatesDir's first preference
+	// is repoRoot()/.scion/templates/.
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	templatesDir := filepath.Join(root, ".scion", "templates")
+	for _, role := range []string{"admin", "researcher"} {
+		dir := filepath.Join(templatesDir, role)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Plant a minimal manifest so stage-skills doesn't barf on missing yaml.
+		manifest := filepath.Join(dir, "scion-agent.yaml")
+		if err := os.WriteFile(manifest, []byte("schema_version: \"1\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Stub bash on PATH so runSubstrateScript no-ops.
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "bash"),
+		[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := ensureAllSkillsStaged(); err != nil {
+		t.Fatalf("ensureAllSkillsStaged: %v", err)
+	}
+
+	if got := len(mc.importAllTemplatesCalls); got != 1 {
+		t.Fatalf("expected exactly 1 ImportAllTemplates call; got %d: %v",
+			got, mc.importAllTemplatesCalls)
+	}
+	if got := mc.importAllTemplatesCalls[0]; got != templatesDir {
+		t.Errorf("ImportAllTemplates called with %q; want %q", got, templatesDir)
+	}
+}
+```
+
+- [ ] **Step 3: Run the new test**
+
+Run: `go test ./cmd/darken/ -run TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore -v`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full cmd/darken test suite once more**
+
+Run: `go test ./cmd/darken/ -count=1`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/darken/bootstrap_test.go
+git commit -m "test(bootstrap): pin ImportAllTemplates wiring as regression guard
+
+The integration test in setup_test.go covers the observable outcome
+(push succeeds). This unit test pins the implementation invariant:
+ensureAllSkillsStaged calls ImportAllTemplates exactly once with the
+resolved templatesDir. Catches future refactors that drop or move
+the call."
+```
+
+---
+
+## Task 5: Document the precondition on `uploadAllTemplatesToHub`
+
+**Files:**
+- Modify: `cmd/darken/setup.go:47-58` (the `uploadAllTemplatesToHub` doc comment)
+
+- [ ] **Step 1: Update the comment**
+
+In `cmd/darken/setup.go`, replace the doc comment above `uploadAllTemplatesToHub` (currently lines 47-49):
+
+```go
+// uploadAllTemplatesToHub pushes all 14 canonical templates to the Hub at
+// user (global) scope via ScionClient.PushTemplate.
+// Runs after bootstrap so the scion server is guaranteed to be running.
+```
+
+with:
+
+```go
+// uploadAllTemplatesToHub pushes all 14 canonical templates to the Hub at
+// user (global) scope via ScionClient.PushTemplate.
+//
+// Precondition: scion's local template store contains every canonical
+// role. ensureAllSkillsStaged satisfies this by calling
+// ImportAllTemplates during bootstrap. Without that import, push fails
+// with "template not found locally" because scion looks up templates by
+// name in its own store and refuses to push what it has never seen.
+```
+
+- [ ] **Step 2: Verify build still works**
+
+Run: `go build ./cmd/darken/`
+
+Expected: success.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./cmd/darken/ -count=1`
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/darken/setup.go
+git commit -m "docs: record the import-before-push precondition
+
+Comment-only change. Makes the implicit dependency between bootstrap
+and upload explicit at the call site, so future readers don't reorder
+the bootstrap pipeline and re-introduce the silent-failure mode."
+```
+
+---
+
+## Self-review notes (post-plan)
+
+Spec coverage check:
+
+- Verification step 0 → done in the spec edit (commit 590766a). The plan reflects Q-A=yes / Q-B=no.
+- Branch A design → Tasks 2, 3 (interface method, wiring).
+- Test strategy primary (observable outcome) → Tasks 1 + 3 (stub tightening + the existing TestSetup_UploadsAllTemplatesToHub now actually catches the bug).
+- Test strategy secondary (Branch A invariant) → Task 4 (unit-level call assertion).
+- Test strategy existing-tests preservation → Tasks 2-4 keep the full suite green.
+- Error handling → Task 3's `fmt.Errorf("import templates: %w", err)`.
+- Backward-compat → Task 3's behavior in darkish-factory: `resolveTemplatesDir` returns the repo-root path, no-op cleanup, `ImportAllTemplates` runs against that path. The repo-root templates re-import to scion's global store every `darken up` — harmless (idempotent, scion overwrites).
+
+No placeholders. Each step shows the exact code or command. Method names (`ImportAllTemplates`, `importAllTemplatesCalls`, `importAllTemplatesErr`) consistent across tasks.

--- a/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
+++ b/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
@@ -1,0 +1,139 @@
+# Spec: `darken up` template-upload fix
+
+**Date:** 2026-05-01
+**Status:** Draft, awaiting operator approval of written spec
+**Topic:** Plug the leak in `uploadAllTemplatesToHub` so `darken up` succeeds in any project, not just the darkish-factory checkout.
+
+## Problem
+
+`darken up` fails at the template-upload step in any project that does not have `.scion/templates/<role>/` committed at the repo root. Symptom (observed in `~/base4m`):
+
+```
+uploading template admin to Hub (user scope) ...
+Error: template 'admin' not found locally: template 'admin' not found
+darken: upload template admin: exit status 1
+```
+
+The 8-stage bootstrap completes cleanly. The failure is in the post-bootstrap Hub-push step.
+
+### Root cause
+
+1. `runUp` (cmd/darken/up.go:45) calls `runBootstrap()` → `uploadAllTemplatesToHub()` in sequence.
+2. `runBootstrap` step 7 (`ensureAllSkillsStaged`, cmd/darken/bootstrap.go:83-105) calls `resolveTemplatesDir()` (bootstrap.go:129-140). When `repoRoot()/.scion/templates/` is absent, it falls through to `extractEmbeddedTemplates()` (bootstrap.go:142-181) which copies the embedded set into `os.MkdirTemp`.
+3. `ensureAllSkillsStaged` `defer`s the cleanup func from `extractEmbeddedTemplates`. The tmpdir is removed when bootstrap returns.
+4. `uploadAllTemplatesToHub` (cmd/darken/setup.go:50-58) then iterates `canonicalRoles` (roles.go:6-21) and shells `scion --global templates push <role>` (scion_client.go:84). Scion looks in its own local store; nothing is registered → 404.
+
+In darkish-factory, `.scion/templates/<role>/` exists in the repo root, `resolveTemplatesDir` returns that path with no extraction, no cleanup ever runs, and scion finds the templates via its file-system convention. The bug is masked.
+
+### Why tests miss it
+
+`scion_client_test.go:119` and `setup_test.go:276-303` mock `ScionClient.PushTemplate`. The mock never observes the directory state at the moment `PushTemplate` would have been called. README.md:22 ("the `darken` binary is self-contained — templates, scripts, Dockerfiles, and the host-mode skills are embedded") is partly true: the bootstrap-stage path honors it; the upload-templates path silently does not.
+
+## Scope
+
+**In scope.**
+
+- Fix `darken up` so all 14 canonical templates are registered with the Hub when run in any project.
+- Test coverage that fails today and passes after the fix.
+- Honor README.md:22's "self-contained" claim.
+
+**Out of scope.**
+
+- Per-project template overrides. `resolveTemplatesDir()` already prefers `repoRoot()/.scion/templates/` when present, so a fork or custom checkout still works. A formal override design (merge semantics, conflict rules, custom-role support) is a separate spec triggered by a real user request.
+- Partial-progress retry. Current fail-fast on first push error stays. Recovery stays "re-run `darken up`".
+- The existing dual-source resolver (`repoRoot()/.scion/templates/` vs. embedded fallback). The fix preserves that precedence.
+
+## Design
+
+### Tmpdir ownership moves up to `runUp`
+
+`runUp` (cmd/darken/up.go:45) becomes the single owner of the resolved templates dir. Both bootstrap stage-skills and upload-templates borrow the path.
+
+Pseudocode:
+
+```go
+func runUp(...) error {
+    dir, cleanup, err := resolveTemplatesDir()
+    if err != nil { return err }
+    defer cleanup()
+
+    if err := runBootstrap(dir, ...); err != nil { return err }
+    if err := uploadAllTemplatesToHub(dir); err != nil { return err }
+    return nil
+}
+```
+
+### Function signature changes
+
+| File | Function | Before | After |
+|---|---|---|---|
+| cmd/darken/bootstrap.go:83 | `ensureAllSkillsStaged` | resolves internally | takes `dir string` |
+| cmd/darken/bootstrap.go:129 | `resolveTemplatesDir` | unchanged (still callable from `runUp`) | unchanged |
+| cmd/darken/setup.go:50 | `uploadAllTemplatesToHub` | iterates roles, calls `client.PushTemplate(role)` | takes `dir string`, calls `client.PushTemplate(role, dir)` |
+| cmd/darken/scion_client.go:83 | `ScionClient.PushTemplate` | `PushTemplate(role string)` | `PushTemplate(role, dir string)` |
+| cmd/darken/scion_client.go:84 | exec form | `scion --global templates push <role>` | `scion --global templates push <role> --from <dir>/<role>` (preferred) OR two-step (fallback) |
+
+### Verification gap (implementation step 0)
+
+Before coding, verify what `scion templates push` accepts:
+
+```bash
+scion templates push --help
+```
+
+- If `--from <path>` is supported: one-step form.
+- If not: two-step — `scion templates create <role> <dir>/<role>` followed by `scion templates push <role>`. The `create` step makes scion aware of the local template; the subsequent `push` ships it to the Hub.
+
+The spec records this as a verification gap, not a guess. The implementer reports back which form scion supports and the test/code follow that path.
+
+### Error handling
+
+Existing fail-fast preserved (setup.go:53-55). On any push error:
+
+```go
+return fmt.Errorf("upload template %s: %w", role, err)
+```
+
+This bubbles to `runUp`, which returns. The deferred cleanup runs. The operator's recovery is `darken up` again. No partial-progress state to manage.
+
+## Test strategy
+
+PATH-stub scion. The pattern at setup_test.go:194 already substitutes a fake `scion` binary on `PATH` that logs invocations. Extend it:
+
+1. **Stub records dir-state at invocation time.** When the stub is called for `templates push <role> [--from <dir>]` (or the two-step form), it asserts the source directory exists on the filesystem AND contains the role's `template.yaml`. Records pass/fail per call.
+
+2. **New test: `TestRunUp_TemplateDirSurvivesUntilPush`** in cmd/darken/up_test.go. Setup:
+   - Fresh tmpdir as the consuming project (no `.scion/templates/`).
+   - PATH-stub scion as above.
+   - Run `runUp(...)` end-to-end (excluding actual Docker/Hub calls — those are separately mocked or stubbed).
+   - Assert: every one of the 14 canonical roles produced a successful push call (stub recorded a live source dir).
+
+3. **Failing-state coverage.** The new test fails on `main` today (push happens after cleanup). Verifies the bug. Passes after the fix.
+
+4. **Existing coverage stays.** `scion_client_test.go:119` (mocked `PushTemplate` records call count) keeps catching client-API regressions; `setup_test.go:276-303` keeps verifying the `--global templates push <role>` invocation shape.
+
+## Backward-compatibility
+
+- **darkish-factory.** `.scion/templates/<role>/` exists at repo root. `resolveTemplatesDir` returns repo-root path with a no-op cleanup. No extraction. Behavior identical to today.
+- **All other projects.** One extraction per `darken up` (was: zero successful uploads). Net win.
+- **Public function signatures.** `ScionClient.PushTemplate` gains a parameter — breaking change for any external caller. There are none in the repo. Mock at scion_client_test.go:43 must update to match. No external Go-import surface to consider.
+
+## Migration
+
+Single PR. No staged rollout needed. The fix is internal to `cmd/darken` and the test stub.
+
+## Open questions for operator
+
+1. **Branch / PR shape.** Single PR for fix + test, or split (test-first as a failing test on its own commit, then fix as a second commit on the same PR)? Spec defaults to single PR with both commits.
+2. **Verification gap escalation.** If `scion templates push --from` is NOT supported, the two-step form adds a second exec per role (28 exec calls instead of 14). Acceptable, or worth a scion-side feature request to add `--from`? Spec defaults to "use two-step, file scion issue separately."
+
+## File-paths cited
+
+- cmd/darken/up.go:45
+- cmd/darken/setup.go:50-58
+- cmd/darken/bootstrap.go:83-105, 129-181
+- cmd/darken/scion_client.go:83-88
+- cmd/darken/roles.go:6-21
+- cmd/darken/scion_client_test.go:43, 117-135
+- cmd/darken/setup_test.go:192-203, 276-303
+- README.md:22

--- a/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
+++ b/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
@@ -113,7 +113,7 @@ Files changed: bootstrap.go (one new loop), scion_client.go (new `CreateTemplate
 
 Applies when **Q-A is no** (scion `create` is reference-only) **AND** Q-B answers either yes or no — both push variants need the dir alive for the same reason.
 
-`runUp` (cmd/darken/up.go:45) becomes the single owner of the resolved templates dir. Both bootstrap stage-skills and upload-templates borrow the path.
+`runUp` resolves the templates dir, defers cleanup, and constructs a `ScionClient` that holds the dir as hidden state. The dir-lifetime concern lives in two scopes only: `runUp` (owner) and `ScionClient` (consumer). Bootstrap and upload-templates are dir-blind — they call `client.PushTemplate(role)` and don't know where the bytes live.
 
 ```go
 func runUp(...) error {
@@ -121,20 +121,24 @@ func runUp(...) error {
     if err != nil { return err }
     defer cleanup()
 
-    if err := runBootstrap(dir, ...); err != nil { return err }
-    if err := uploadAllTemplatesToHub(dir); err != nil { return err }
+    client := NewScionClient(WithTemplatesDir(dir))
+
+    if err := runBootstrap(client, ...); err != nil { return err }
+    if err := uploadAllTemplatesToHub(client); err != nil { return err }
     return nil
 }
 ```
 
+`ScionClient.PushTemplate(role)` signature stays as today. Internally, when scion's CLI requires a path (either `--from` or two-step `create`), the client reads its own `templatesDir` field and assembles the per-role path. Callers ask for "push template admin" without knowing about dirs.
+
 | File | Function | Before | After |
 |---|---|---|---|
-| cmd/darken/bootstrap.go:83 | `ensureAllSkillsStaged` | resolves internally | takes `dir string` |
-| cmd/darken/setup.go:50 | `uploadAllTemplatesToHub` | iterates roles, `client.PushTemplate(role)` | takes `dir string`, calls `client.PushTemplate(role, dir)` |
-| cmd/darken/scion_client.go:83 | `PushTemplate` | `PushTemplate(role)` | `PushTemplate(role, dir)` |
-| cmd/darken/scion_client.go:84 | exec form | `scion --global templates push <role>` | `scion --global templates push <role> --from <dir>/<role>` (Q-B yes) OR two-step `create <role> <dir>/<role>` then `push <role>` (Q-B no) |
+| cmd/darken/scion_client.go | `ScionClient` constructor | implicit zero-value | `NewScionClient(opts ...Option)` with `WithTemplatesDir(dir)` functional option |
+| cmd/darken/scion_client.go:83 | `PushTemplate(role)` | shells `scion --global templates push <role>` | shells `scion --global templates push <role> --from <c.templatesDir>/<role>` (Q-B yes) OR two-step `create <role> <c.templatesDir>/<role>` then `push <role>` (Q-B no) |
+| cmd/darken/setup.go:50 | `uploadAllTemplatesToHub` | uses `defaultScionClient` | takes `client ScionClient`; iterates roles; calls `client.PushTemplate(role)` |
+| cmd/darken/bootstrap.go:83 | `ensureAllSkillsStaged` | resolves internally | takes the resolved `dir string` |
 
-Branch B accepts the cost of widening `PushTemplate`'s interface and wiring the dir through three layers because no other path is available given Q-A no.
+`PushTemplate` signature unchanged. Test mocks at scion_client_test.go:43 unchanged.
 
 ### Decision rule
 
@@ -183,15 +187,15 @@ Both are invariant tests guarding against regressions in the chosen design.
 
 ### Existing tests
 
-`scion_client_test.go:119` (mocked `PushTemplate` call-count) keeps catching client-API regressions. Under Branch A it stays as-is; under Branch B the mock signature updates to match.
+`scion_client_test.go:119` (mocked `PushTemplate` call-count) keeps catching client-API regressions under either branch — `PushTemplate(role)` signature is unchanged.
 
 `setup_test.go:276-303` (verifies the `--global templates push <role>` invocation shape) keeps catching invocation-shape regressions.
 
 ## Backward-compatibility
 
 - **darkish-factory.** `.scion/templates/<role>/` exists at repo root. `resolveTemplatesDir` returns repo-root path with a no-op cleanup. No extraction. No behavior change under either branch.
-- **All other projects.** Branch A: 14 extra `templates create` execs during bootstrap; templates registered. Branch B: the dir survives until push (one-step) or until create+push (two-step). Either way: zero successful uploads → fourteen.
-- **Public function signatures.** Branch A: `ScionClient` gains a method (`CreateTemplate`); no existing method changes. Branch B: `ScionClient.PushTemplate` gains a parameter — breaking change for any external caller. There are none in the repo. No external Go-import surface in either case.
+- **All other projects.** Branch A: 14 extra `templates create` execs during bootstrap; templates registered. Branch B: client holds the dir; push reads its per-role path internally. Either way: zero successful uploads → fourteen.
+- **Public function signatures.** Branch A: `ScionClient` gains a method (`CreateTemplate`); no existing method changes. Branch B: `ScionClient` gains an optional constructor (`NewScionClient(WithTemplatesDir(...))`) and an internal field; `PushTemplate(role)` signature unchanged. No breaking change to existing callers in either branch.
 
 ## Migration
 

--- a/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
+++ b/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
@@ -55,18 +55,22 @@ scion templates list --help     # for the test assertion
 
 Two questions to answer:
 
-**Q-A. Does `scion templates create <role> <path>` intern (copy) the template body into scion's own store?** Run a one-line probe:
+**Q-A. Does scion offer a command to copy a template body from a path into its own local store?**
+
+Verified 2026-05-01: **yes**, via `scion --global templates import <path>` (single) or `scion --global templates import --all <dir>` (batch from a directory of templates). The body is copied to `~/.scion/templates/<role>` and survives source-dir deletion. Probe used:
 
 ```bash
-tmp=$(mktemp -d); cp -r .scion/templates/admin "$tmp/admin"; \
-  scion --global templates create admin "$tmp/admin"; \
-  rm -rf "$tmp"; \
-  scion --global templates list | grep admin
+tmp=$(mktemp -d); cp -r .scion/templates/admin "$tmp/admin"
+scion --global templates import "$tmp/admin"
+rm -rf "$tmp"
+scion --global templates list | grep admin   # admin still appears; body at ~/.scion/templates/admin
 ```
 
-If `admin` still appears after `rm -rf`, scion interns the body. If `templates list` errors or `admin` is gone, scion stored a path reference and the dir must outlive every later operation.
+(Note: `templates create` — referenced earlier as a guess — actually creates an empty template, not what we want. `import` is the correct command.)
 
-**Q-B. Does `scion templates push <role>` accept a `--from <path>` flag** that lets the caller pass the dir at push time? Read `--help` output; presence/absence is a binary fact.
+**Q-B. Does `scion templates push <role>` accept a `--from <path>` flag?**
+
+Verified 2026-05-01: **no**. `templates push` accepts only `--all` and `--name`. It looks up the template by name in scion's own local store; the caller cannot pass a path at push time.
 
 The implementer records both answers in the PR description before writing code. The design branch follows.
 
@@ -74,11 +78,11 @@ The implementer records both answers in the PR description before writing code. 
 
 The two branches are scored against Ousterhout principles. Pick whichever the verification step rules in.
 
-### Branch A — register-at-extract (preferred)
+### Branch A — register-at-extract (verification-confirmed)
 
-Applies when **Q-A is yes** (`create` interns the body).
+Verification ruled in this branch (Q-A yes, Q-B no).
 
-Single change site: `ensureAllSkillsStaged` (bootstrap.go:83-105) gains one extra step inside its existing extract→stage→cleanup window. After staging, before cleanup, call `scion --global templates create <role> <dir>/<role>` for each role. Scion now has the bodies internalized in its own template store. The deferred cleanup runs and removes the tmpdir. The `uploadAllTemplatesToHub` step (setup.go:50-58) then runs unchanged — `scion --global templates push <role>` succeeds because scion already has the body.
+Single change site: `ensureAllSkillsStaged` (bootstrap.go:83-105) gains one extra step inside its existing extract→stage→cleanup window. After staging, before cleanup, call `scion --global templates import --all <dir>` once. Scion copies all 14 canonical role bodies into its own template store at `~/.scion/templates/<role>`. The deferred cleanup runs and removes the tmpdir. The `uploadAllTemplatesToHub` step (setup.go:50-58) then runs unchanged — `scion --global templates push <role>` succeeds because scion has the bodies.
 
 Pseudocode:
 
@@ -90,16 +94,14 @@ func ensureAllSkillsStaged(...) error {
 
     if err := stageSkillsFrom(dir); err != nil { return err }
 
-    for _, role := range canonicalRoles {
-        if err := defaultScionClient.CreateTemplate(role, filepath.Join(dir, role)); err != nil {
-            return fmt.Errorf("create template %s: %w", role, err)
-        }
+    if err := defaultScionClient.ImportAllTemplates(dir); err != nil {
+        return fmt.Errorf("import templates: %w", err)
     }
     return nil
 }
 ```
 
-Files changed: bootstrap.go (one new loop), scion_client.go (new `CreateTemplate(role, dir)` method), scion_client_test.go (mock gains the new method).
+Files changed: bootstrap.go (one new call), scion_client.go (new `ImportAllTemplates(dir)` method), scion_client_test.go (mock gains the new method).
 
 `uploadAllTemplatesToHub`, `PushTemplate`, `runUp`, `up.go`, `setup.go`: untouched.
 
@@ -151,10 +153,10 @@ The implementer picks the branch in the PR after running step 0, and the rest of
 
 ## Error handling
 
-Existing fail-fast preserved. On any error from `CreateTemplate` (Branch A) or `PushTemplate` (Branch B), `runBootstrap` or `uploadAllTemplatesToHub` returns the wrapped error. The deferred cleanup runs. The operator's recovery is `darken up` again.
+Existing fail-fast preserved. On any error from `ImportAllTemplates` (Branch A) or `PushTemplate` (Branch B), `runBootstrap` or `uploadAllTemplatesToHub` returns the wrapped error. The deferred cleanup runs. The operator's recovery is `darken up` again.
 
 ```go
-return fmt.Errorf("create template %s: %w", role, err)
+return fmt.Errorf("import templates: %w", err)
 // or
 return fmt.Errorf("upload template %s: %w", role, err)
 ```
@@ -170,7 +172,7 @@ The test asserts the **observable outcome**, not the implementation invariant. T
 `TestRunUp_AllTemplatesRegisteredAfterUp` in cmd/darken/up_test.go.
 
 1. Fresh tmpdir as the consuming project (no `.scion/templates/`).
-2. PATH-stub scion that records every invocation AND maintains an in-memory map of registered roles. The stub mimics scion's own behavior: `templates create <role> <path>` records the role in the map; `templates push <role>` requires the role be in the map (returns "not found locally" otherwise — the exact production error); `templates list` returns the map keys.
+2. PATH-stub scion that records every invocation AND maintains an in-memory map of registered roles. The stub mimics scion's own behavior: `templates import <path>` and `templates import --all <dir>` register the role(s) in the map; `templates push <role>` requires the role be in the map (returns "not found locally" otherwise — the exact production error); `templates list` returns the map keys.
 3. Run `runUp(...)` end-to-end. Docker/Hub calls remain stubbed.
 4. After return, invoke the PATH-stub `scion --global templates list` and assert all 14 canonical roles appear.
 
@@ -180,7 +182,7 @@ This test fails on `main` (no role ever gets registered before push). It passes 
 
 Once the implementer picks a branch:
 
-- **Branch A:** assert `templates create` was invoked once per role during bootstrap (stub records call sequence).
+- **Branch A:** assert `templates import --all <dir>` was invoked exactly once during bootstrap, with `<dir>` containing all 14 canonical role subdirectories at call time (stub records call sequence and inspects argument).
 - **Branch B:** assert the source dir exists on disk at the moment every `templates push <role>` (or the two-step form) is recorded by the stub.
 
 Both are invariant tests guarding against regressions in the chosen design.
@@ -194,8 +196,8 @@ Both are invariant tests guarding against regressions in the chosen design.
 ## Backward-compatibility
 
 - **darkish-factory.** `.scion/templates/<role>/` exists at repo root. `resolveTemplatesDir` returns repo-root path with a no-op cleanup. No extraction. No behavior change under either branch.
-- **All other projects.** Branch A: 14 extra `templates create` execs during bootstrap; templates registered. Branch B: client holds the dir; push reads its per-role path internally. Either way: zero successful uploads → fourteen.
-- **Public function signatures.** Branch A: `ScionClient` gains a method (`CreateTemplate`); no existing method changes. Branch B: `ScionClient` gains an optional constructor (`NewScionClient(WithTemplatesDir(...))`) and an internal field; `PushTemplate(role)` signature unchanged. No breaking change to existing callers in either branch.
+- **All other projects.** Branch A: one `templates import --all <dir>` exec during bootstrap; all 14 templates registered to scion's local store. Branch B: client holds the dir; push reads its per-role path internally. Either way: zero successful uploads → fourteen.
+- **Public function signatures.** Branch A: `ScionClient` gains a method (`ImportAllTemplates`); no existing method changes. Branch B: `ScionClient` gains an optional constructor (`NewScionClient(WithTemplatesDir(...))`) and an internal field; `PushTemplate(role)` signature unchanged. No breaking change to existing callers in either branch.
 
 ## Migration
 
@@ -204,7 +206,7 @@ Single PR. No staged rollout. The fix is internal to `cmd/darken` and the test s
 ## Open questions for operator
 
 1. **Branch / PR shape.** Single PR for verification + fix + test, or split (verification commit reporting Q-A/Q-B, then design-branch commit, then test commit)? Spec defaults to single PR; PR description records the verification answers and selected branch.
-2. **If Branch B with Q-B no (two-step).** The fallback path adds 14 extra exec calls (`templates create` per role). Acceptable, or worth a scion-side feature request for `templates push --from`? Spec defaults to "ship two-step, file scion issue separately."
+2. **Verification ruled in Branch A.** Branch B is documented as a fallback for completeness; not pursued by the implementation.
 
 ## File-paths cited
 

--- a/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
+++ b/docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md
@@ -43,13 +43,77 @@ In darkish-factory, `.scion/templates/<role>/` exists in the repo root, `resolve
 - Partial-progress retry. Current fail-fast on first push error stays. Recovery stays "re-run `darken up`".
 - The existing dual-source resolver (`repoRoot()/.scion/templates/` vs. embedded fallback). The fix preserves that precedence.
 
-## Design
+## Verification step 0 — scion CLI semantics
 
-### Tmpdir ownership moves up to `runUp`
+The right design depends on a fact about scion that the spec cannot assume. Before writing any code, the implementer establishes the scion CLI surface by running:
 
-`runUp` (cmd/darken/up.go:45) becomes the single owner of the resolved templates dir. Both bootstrap stage-skills and upload-templates borrow the path.
+```bash
+scion templates push --help
+scion templates create --help
+scion templates list --help     # for the test assertion
+```
+
+Two questions to answer:
+
+**Q-A. Does `scion templates create <role> <path>` intern (copy) the template body into scion's own store?** Run a one-line probe:
+
+```bash
+tmp=$(mktemp -d); cp -r .scion/templates/admin "$tmp/admin"; \
+  scion --global templates create admin "$tmp/admin"; \
+  rm -rf "$tmp"; \
+  scion --global templates list | grep admin
+```
+
+If `admin` still appears after `rm -rf`, scion interns the body. If `templates list` errors or `admin` is gone, scion stored a path reference and the dir must outlive every later operation.
+
+**Q-B. Does `scion templates push <role>` accept a `--from <path>` flag** that lets the caller pass the dir at push time? Read `--help` output; presence/absence is a binary fact.
+
+The implementer records both answers in the PR description before writing code. The design branch follows.
+
+## Design — two conditional branches
+
+The two branches are scored against Ousterhout principles. Pick whichever the verification step rules in.
+
+### Branch A — register-at-extract (preferred)
+
+Applies when **Q-A is yes** (`create` interns the body).
+
+Single change site: `ensureAllSkillsStaged` (bootstrap.go:83-105) gains one extra step inside its existing extract→stage→cleanup window. After staging, before cleanup, call `scion --global templates create <role> <dir>/<role>` for each role. Scion now has the bodies internalized in its own template store. The deferred cleanup runs and removes the tmpdir. The `uploadAllTemplatesToHub` step (setup.go:50-58) then runs unchanged — `scion --global templates push <role>` succeeds because scion already has the body.
 
 Pseudocode:
+
+```go
+func ensureAllSkillsStaged(...) error {
+    dir, cleanup, err := resolveTemplatesDir()
+    if err != nil { return err }
+    defer cleanup()
+
+    if err := stageSkillsFrom(dir); err != nil { return err }
+
+    for _, role := range canonicalRoles {
+        if err := defaultScionClient.CreateTemplate(role, filepath.Join(dir, role)); err != nil {
+            return fmt.Errorf("create template %s: %w", role, err)
+        }
+    }
+    return nil
+}
+```
+
+Files changed: bootstrap.go (one new loop), scion_client.go (new `CreateTemplate(role, dir)` method), scion_client_test.go (mock gains the new method).
+
+`uploadAllTemplatesToHub`, `PushTemplate`, `runUp`, `up.go`, `setup.go`: untouched.
+
+**Why this is the deeper module.**
+
+- `runUp` doesn't learn about templates resolution. The `runBootstrap()` post-condition becomes "scion has all 14 canonical templates registered locally." That precondition is what `uploadAllTemplatesToHub` already implicitly assumes.
+- The error class "tmpdir gone before push" is defined out of existence — push never reads the tmpdir.
+- One file changed, one new method. No signature breakage on `PushTemplate`.
+
+### Branch B — tmpdir-lifetime-spans-up-flow (fallback)
+
+Applies when **Q-A is no** (scion `create` is reference-only) **AND** Q-B answers either yes or no — both push variants need the dir alive for the same reason.
+
+`runUp` (cmd/darken/up.go:45) becomes the single owner of the resolved templates dir. Both bootstrap stage-skills and upload-templates borrow the path.
 
 ```go
 func runUp(...) error {
@@ -63,69 +127,80 @@ func runUp(...) error {
 }
 ```
 
-### Function signature changes
-
 | File | Function | Before | After |
 |---|---|---|---|
 | cmd/darken/bootstrap.go:83 | `ensureAllSkillsStaged` | resolves internally | takes `dir string` |
-| cmd/darken/bootstrap.go:129 | `resolveTemplatesDir` | unchanged (still callable from `runUp`) | unchanged |
-| cmd/darken/setup.go:50 | `uploadAllTemplatesToHub` | iterates roles, calls `client.PushTemplate(role)` | takes `dir string`, calls `client.PushTemplate(role, dir)` |
-| cmd/darken/scion_client.go:83 | `ScionClient.PushTemplate` | `PushTemplate(role string)` | `PushTemplate(role, dir string)` |
-| cmd/darken/scion_client.go:84 | exec form | `scion --global templates push <role>` | `scion --global templates push <role> --from <dir>/<role>` (preferred) OR two-step (fallback) |
+| cmd/darken/setup.go:50 | `uploadAllTemplatesToHub` | iterates roles, `client.PushTemplate(role)` | takes `dir string`, calls `client.PushTemplate(role, dir)` |
+| cmd/darken/scion_client.go:83 | `PushTemplate` | `PushTemplate(role)` | `PushTemplate(role, dir)` |
+| cmd/darken/scion_client.go:84 | exec form | `scion --global templates push <role>` | `scion --global templates push <role> --from <dir>/<role>` (Q-B yes) OR two-step `create <role> <dir>/<role>` then `push <role>` (Q-B no) |
 
-### Verification gap (implementation step 0)
+Branch B accepts the cost of widening `PushTemplate`'s interface and wiring the dir through three layers because no other path is available given Q-A no.
 
-Before coding, verify what `scion templates push` accepts:
+### Decision rule
 
-```bash
-scion templates push --help
+```
+Q-A yes → Branch A.
+Q-A no  → Branch B (with Q-B picking one-step vs two-step exec form).
 ```
 
-- If `--from <path>` is supported: one-step form.
-- If not: two-step — `scion templates create <role> <dir>/<role>` followed by `scion templates push <role>`. The `create` step makes scion aware of the local template; the subsequent `push` ships it to the Hub.
+The implementer picks the branch in the PR after running step 0, and the rest of the implementation follows.
 
-The spec records this as a verification gap, not a guess. The implementer reports back which form scion supports and the test/code follow that path.
+## Error handling
 
-### Error handling
-
-Existing fail-fast preserved (setup.go:53-55). On any push error:
+Existing fail-fast preserved. On any error from `CreateTemplate` (Branch A) or `PushTemplate` (Branch B), `runBootstrap` or `uploadAllTemplatesToHub` returns the wrapped error. The deferred cleanup runs. The operator's recovery is `darken up` again.
 
 ```go
+return fmt.Errorf("create template %s: %w", role, err)
+// or
 return fmt.Errorf("upload template %s: %w", role, err)
 ```
 
-This bubbles to `runUp`, which returns. The deferred cleanup runs. The operator's recovery is `darken up` again. No partial-progress state to manage.
+No partial-progress retry. Out of scope.
 
 ## Test strategy
 
-PATH-stub scion. The pattern at setup_test.go:194 already substitutes a fake `scion` binary on `PATH` that logs invocations. Extend it:
+The test asserts the **observable outcome**, not the implementation invariant. This makes the test correct regardless of which branch ships.
 
-1. **Stub records dir-state at invocation time.** When the stub is called for `templates push <role> [--from <dir>]` (or the two-step form), it asserts the source directory exists on the filesystem AND contains the role's `template.yaml`. Records pass/fail per call.
+### Primary test — observable outcome
 
-2. **New test: `TestRunUp_TemplateDirSurvivesUntilPush`** in cmd/darken/up_test.go. Setup:
-   - Fresh tmpdir as the consuming project (no `.scion/templates/`).
-   - PATH-stub scion as above.
-   - Run `runUp(...)` end-to-end (excluding actual Docker/Hub calls — those are separately mocked or stubbed).
-   - Assert: every one of the 14 canonical roles produced a successful push call (stub recorded a live source dir).
+`TestRunUp_AllTemplatesRegisteredAfterUp` in cmd/darken/up_test.go.
 
-3. **Failing-state coverage.** The new test fails on `main` today (push happens after cleanup). Verifies the bug. Passes after the fix.
+1. Fresh tmpdir as the consuming project (no `.scion/templates/`).
+2. PATH-stub scion that records every invocation AND maintains an in-memory map of registered roles. The stub mimics scion's own behavior: `templates create <role> <path>` records the role in the map; `templates push <role>` requires the role be in the map (returns "not found locally" otherwise — the exact production error); `templates list` returns the map keys.
+3. Run `runUp(...)` end-to-end. Docker/Hub calls remain stubbed.
+4. After return, invoke the PATH-stub `scion --global templates list` and assert all 14 canonical roles appear.
 
-4. **Existing coverage stays.** `scion_client_test.go:119` (mocked `PushTemplate` records call count) keeps catching client-API regressions; `setup_test.go:276-303` keeps verifying the `--global templates push <role>` invocation shape.
+This test fails on `main` (no role ever gets registered before push). It passes under either Branch A or Branch B because both end with scion's local store containing the 14 roles. The assertion is design-agnostic.
+
+### Secondary test — branch-specific lifecycle
+
+Once the implementer picks a branch:
+
+- **Branch A:** assert `templates create` was invoked once per role during bootstrap (stub records call sequence).
+- **Branch B:** assert the source dir exists on disk at the moment every `templates push <role>` (or the two-step form) is recorded by the stub.
+
+Both are invariant tests guarding against regressions in the chosen design.
+
+### Existing tests
+
+`scion_client_test.go:119` (mocked `PushTemplate` call-count) keeps catching client-API regressions. Under Branch A it stays as-is; under Branch B the mock signature updates to match.
+
+`setup_test.go:276-303` (verifies the `--global templates push <role>` invocation shape) keeps catching invocation-shape regressions.
 
 ## Backward-compatibility
 
-- **darkish-factory.** `.scion/templates/<role>/` exists at repo root. `resolveTemplatesDir` returns repo-root path with a no-op cleanup. No extraction. Behavior identical to today.
-- **All other projects.** One extraction per `darken up` (was: zero successful uploads). Net win.
-- **Public function signatures.** `ScionClient.PushTemplate` gains a parameter — breaking change for any external caller. There are none in the repo. Mock at scion_client_test.go:43 must update to match. No external Go-import surface to consider.
+- **darkish-factory.** `.scion/templates/<role>/` exists at repo root. `resolveTemplatesDir` returns repo-root path with a no-op cleanup. No extraction. No behavior change under either branch.
+- **All other projects.** Branch A: 14 extra `templates create` execs during bootstrap; templates registered. Branch B: the dir survives until push (one-step) or until create+push (two-step). Either way: zero successful uploads → fourteen.
+- **Public function signatures.** Branch A: `ScionClient` gains a method (`CreateTemplate`); no existing method changes. Branch B: `ScionClient.PushTemplate` gains a parameter — breaking change for any external caller. There are none in the repo. No external Go-import surface in either case.
 
 ## Migration
 
-Single PR. No staged rollout needed. The fix is internal to `cmd/darken` and the test stub.
+Single PR. No staged rollout. The fix is internal to `cmd/darken` and the test stub.
 
 ## Open questions for operator
 
-1. **Branch / PR shape.** Single PR for fix + test, or split (test-first as a failing test on its own commit, then fix as a second commit on the same PR)? Spec defaults to single PR with both commits.
-2. **Verification gap escalation.** If `scion templates push --from` is NOT supported, the two-step form adds a second exec per role (28 exec calls instead of 14). Acceptable, or worth a scion-side feature request to add `--from`? Spec defaults to "use two-step, file scion issue separately."
+1. **Branch / PR shape.** Single PR for verification + fix + test, or split (verification commit reporting Q-A/Q-B, then design-branch commit, then test commit)? Spec defaults to single PR; PR description records the verification answers and selected branch.
+2. **If Branch B with Q-B no (two-step).** The fallback path adds 14 extra exec calls (`templates create` per role). Acceptable, or worth a scion-side feature request for `templates push --from`? Spec defaults to "ship two-step, file scion issue separately."
 
 ## File-paths cited
 


### PR DESCRIPTION
## Summary

- Fixes `darken up` failing in any project that doesn't have `.scion/templates/` committed at the repo root (e.g. fresh `~/base4m`-shaped checkouts). Symptom: `Error: template 'admin' not found locally`.
- Root cause: bootstrap extracted embedded templates to a tmpdir, deferred-cleaned the dir, then upload-templates tried `scion templates push <role>` against an empty local store.
- Fix (Branch A from the spec): one new `scion --global templates import --all <dir>` call inside the same scope as the extraction. Scion copies bodies into its permanent store; later push succeeds because scion has them.
- Spec at \`docs/superpowers/specs/2026-05-01-darken-up-template-upload-fix.md\` (verification step 0 confirmed Q-A=yes, Q-B=no).
- Plan at \`docs/superpowers/plans/2026-05-01-darken-up-template-upload-fix.md\`.

## Changes

- \`cmd/darken/scion_client.go\`: add \`ImportAllTemplates(dir)\` to \`ScionClient\`; implement on \`execScionClient\`.
- \`cmd/darken/scion_client_test.go\`: extend \`mockScionClient\` with the new method + tracking fields.
- \`cmd/darken/bootstrap.go\`: call \`ImportAllTemplates\` from \`ensureAllSkillsStaged\` before deferred cleanup runs.
- \`cmd/darken/setup_test.go\`: tighten the PATH-stub scion to model real import-before-push semantics so the existing \`TestSetup_UploadsAllTemplatesToHub\` actually catches the bug class.
- \`cmd/darken/bootstrap_test.go\`: regression-guard unit test pinning the call.
- \`cmd/darken/setup.go\`: doc comment on \`uploadAllTemplatesToHub\` recording the precondition.

## Test plan

- [x] \`go test ./cmd/darken/ -count=1\` passes (201 tests)
- [x] \`go build ./...\` clean
- [x] E2E: \`darken bootstrap\` in a fresh tmpdir registers all 14 canonical roles into \`~/.scion/templates/\` (verified via \`scion --global templates list\`)