### PR TITLE
feat(modes): dynamic skill resolution via .scion/modes/

### DIFF
--- a/.scion/modes/admin.yaml
+++ b/.scion/modes/admin.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the admin harness."
+skills: []

--- a/.scion/modes/base.yaml
+++ b/.scion/modes/base.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the base harness."
+skills: []

--- a/.scion/modes/darwin.yaml
+++ b/.scion/modes/darwin.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the darwin harness."
+skills:
+  - dx-audit

--- a/.scion/modes/designer.yaml
+++ b/.scion/modes/designer.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the designer harness."
+skills:
+  - norman
+  - ousterhout

--- a/.scion/modes/orchestrator.yaml
+++ b/.scion/modes/orchestrator.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the orchestrator harness."
+skills:
+  - dx-audit

--- a/.scion/modes/philosophy-base.yaml
+++ b/.scion/modes/philosophy-base.yaml
@@ -1,0 +1,4 @@
+description: "Hipp + Ousterhout — design philosophy baseline shared by planners."
+skills:
+  - hipp
+  - ousterhout

--- a/.scion/modes/planner-t1.yaml
+++ b/.scion/modes/planner-t1.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the planner-t1 harness."
+skills:
+  - hipp

--- a/.scion/modes/planner-t2.yaml
+++ b/.scion/modes/planner-t2.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the planner-t2 harness."
+extends: philosophy-base
+skills: []

--- a/.scion/modes/planner-t3.yaml
+++ b/.scion/modes/planner-t3.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the planner-t3 harness."
+extends: philosophy-base
+skills:
+  - superpowers

--- a/.scion/modes/planner-t4.yaml
+++ b/.scion/modes/planner-t4.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the planner-t4 harness."
+extends: philosophy-base
+skills:
+  - spec-kit

--- a/.scion/modes/researcher.yaml
+++ b/.scion/modes/researcher.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the researcher harness."
+skills: []

--- a/.scion/modes/reviewer.yaml
+++ b/.scion/modes/reviewer.yaml
@@ -1,0 +1,5 @@
+description: "Default skills for the reviewer harness."
+skills:
+  - ousterhout
+  - hipp
+  - dx-audit

--- a/.scion/modes/sme.yaml
+++ b/.scion/modes/sme.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the sme harness."
+skills:
+  - ousterhout
+  - hipp

--- a/.scion/modes/tdd-implementer.yaml
+++ b/.scion/modes/tdd-implementer.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the tdd-implementer harness."
+skills:
+  - idiomatic-go
+  - tigerstyle

--- a/.scion/modes/verifier.yaml
+++ b/.scion/modes/verifier.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the verifier harness."
+skills:
+  - tigerstyle

--- a/.scion/templates/admin/scion-agent.yaml
+++ b/.scion/templates/admin/scion-agent.yaml
@@ -8,5 +8,6 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+default_mode: admin
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/base/scion-agent.yaml
+++ b/.scion/templates/base/scion-agent.yaml
@@ -8,5 +8,6 @@ default_harness_config: claude
 model: claude-sonnet-4-6
 max_turns: 50
 max_duration: 3600
+default_mode: base
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/darwin/scion-agent.yaml
+++ b/.scion/templates/darwin/scion-agent.yaml
@@ -8,8 +8,7 @@ model: gpt-5.5
 max_turns: 50
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: darwin
 volumes:
   - source: ./.scion/skills-staging/darwin/
     target: /home/scion/skills/role/

--- a/.scion/templates/designer/scion-agent.yaml
+++ b/.scion/templates/designer/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/norman
-  - danmestas/agent-skills/skills/ousterhout
+default_mode: designer
 volumes:
   - source: ./.scion/skills-staging/designer/
     target: /home/scion/skills/role/

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -8,8 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 200
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: orchestrator
 volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/

--- a/.scion/templates/planner-t1/scion-agent.yaml
+++ b/.scion/templates/planner-t1/scion-agent.yaml
@@ -8,8 +8,7 @@ model: claude-sonnet-4-6
 max_turns: 15
 max_duration: "30m"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
+default_mode: planner-t1
 volumes:
   - source: ./.scion/skills-staging/planner-t1/
     target: /home/scion/skills/role/

--- a/.scion/templates/planner-t2/scion-agent.yaml
+++ b/.scion/templates/planner-t2/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 30
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
+default_mode: planner-t2
 volumes:
   - source: ./.scion/skills-staging/planner-t2/
     target: /home/scion/skills/role/

--- a/.scion/templates/planner-t3/scion-agent.yaml
+++ b/.scion/templates/planner-t3/scion-agent.yaml
@@ -8,10 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/superpowers
+default_mode: planner-t3
 volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/

--- a/.scion/templates/planner-t4/scion-agent.yaml
+++ b/.scion/templates/planner-t4/scion-agent.yaml
@@ -8,10 +8,7 @@ model: gpt-5.5
 max_turns: 100
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/spec-kit
+default_mode: planner-t4
 volumes:
   - source: ./.scion/skills-staging/planner-t4/
     target: /home/scion/skills/role/

--- a/.scion/templates/researcher/scion-agent.yaml
+++ b/.scion/templates/researcher/scion-agent.yaml
@@ -8,5 +8,6 @@ model: claude-sonnet-4-6
 max_turns: 30
 max_duration: "1h"
 detached: false
+default_mode: researcher
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/.scion/templates/reviewer/scion-agent.yaml
+++ b/.scion/templates/reviewer/scion-agent.yaml
@@ -8,10 +8,7 @@ model: gpt-5.5
 max_turns: 30
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: reviewer
 volumes:
   - source: ./.scion/skills-staging/reviewer/
     target: /home/scion/skills/role/

--- a/.scion/templates/sme/scion-agent.yaml
+++ b/.scion/templates/sme/scion-agent.yaml
@@ -8,9 +8,7 @@ model: gpt-5.5
 max_turns: 10
 max_duration: "15m"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/hipp
+default_mode: sme
 volumes:
   - source: ./.scion/skills-staging/sme/
     target: /home/scion/skills/role/

--- a/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-sonnet-4-6[1m]
 max_turns: 100
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/idiomatic-go
-  - danmestas/agent-skills/skills/tigerstyle
+default_mode: tdd-implementer
 volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/

--- a/.scion/templates/verifier/scion-agent.yaml
+++ b/.scion/templates/verifier/scion-agent.yaml
@@ -8,8 +8,7 @@ model: gpt-5.5
 max_turns: 50
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/tigerstyle
+default_mode: verifier
 volumes:
   - source: ./.scion/skills-staging/verifier/
     target: /home/scion/skills/role/

--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -81,13 +81,13 @@ func ensureHubSecrets() error {
 // Soft-fails per-harness so one missing skill canon doesn't abort
 // the whole bootstrap.
 func ensureAllSkillsStaged() error {
-	templatesDir, cleanup, err := resolveTemplatesDir()
+	templatesDir, modesDir, cleanup, err := resolveSubstrateDirs()
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	if err := withTemplatesDirEnv(templatesDir, func() error {
+	if err := withSubstrateDirsEnv(templatesDir, modesDir, func() error {
 		dirs, err := os.ReadDir(templatesDir)
 		if err != nil {
 			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
@@ -115,61 +115,113 @@ func ensureAllSkillsStaged() error {
 	return nil
 }
 
-// withTemplatesDirEnv runs fn with DARKEN_TEMPLATES_DIR set to dir,
-// restoring the previous value (or unsetting) afterward. Used by
-// callers that need stage-skills.sh to read manifests from a specific
-// path (typically the resolved project-local-or-embedded location).
-func withTemplatesDirEnv(dir string, fn func() error) error {
-	prev, hadPrev := os.LookupEnv("DARKEN_TEMPLATES_DIR")
-	os.Setenv("DARKEN_TEMPLATES_DIR", dir)
-	defer func() {
-		if hadPrev {
-			os.Setenv("DARKEN_TEMPLATES_DIR", prev)
-		} else {
-			os.Unsetenv("DARKEN_TEMPLATES_DIR")
-		}
-	}()
+// withSubstrateDirsEnv runs fn with DARKEN_TEMPLATES_DIR and
+// DARKEN_MODES_DIR set, restoring previous values (or unsetting)
+// afterward. modesDir may be empty when only the templates dir is
+// known; in that case DARKEN_MODES_DIR is left unchanged.
+func withSubstrateDirsEnv(templatesDir, modesDir string, fn func() error) error {
+	restoreT := setEnvWithRestore("DARKEN_TEMPLATES_DIR", templatesDir)
+	defer restoreT()
+	if modesDir != "" {
+		restoreM := setEnvWithRestore("DARKEN_MODES_DIR", modesDir)
+		defer restoreM()
+	}
 	return fn()
 }
 
-// resolveTemplatesDir returns a path containing per-harness manifest
-// dirs (each with scion-agent.yaml). Prefers the operator's project
-// templates if present; otherwise extracts the embedded substrate
-// templates to a tmpdir. The returned cleanup func is a no-op for the
-// project case and an os.RemoveAll for the embedded case.
+func setEnvWithRestore(key, val string) func() {
+	prev, hadPrev := os.LookupEnv(key)
+	os.Setenv(key, val)
+	return func() {
+		if hadPrev {
+			os.Setenv(key, prev)
+		} else {
+			os.Unsetenv(key)
+		}
+	}
+}
+
+// resolveTemplatesDir is the legacy single-dir entry point preserved for
+// callers that don't need the modes dir. Internally delegates to
+// resolveSubstrateDirs and discards the modes path.
 func resolveTemplatesDir() (string, func(), error) {
+	t, _, cleanup, err := resolveSubstrateDirs()
+	return t, cleanup, err
+}
+
+// withTemplatesDirEnv is the legacy env-only-templates wrapper. Prefer
+// withSubstrateDirsEnv when modes are also needed.
+func withTemplatesDirEnv(dir string, fn func() error) error {
+	return withSubstrateDirsEnv(dir, "", fn)
+}
+
+// resolveSubstrateDirs returns paths to the templates and modes dirs.
+// Prefers the operator's project layout (.scion/templates + .scion/modes)
+// if present; otherwise extracts the embedded substrate to a tmpdir
+// laid out as <tmp>/templates/ and <tmp>/modes/. The returned cleanup
+// func is a no-op for the project case and an os.RemoveAll for the
+// embedded case.
+func resolveSubstrateDirs() (string, string, func(), error) {
 	noop := func() {}
 
 	if root, err := repoRoot(); err == nil {
-		projectDir := filepath.Join(root, ".scion", "templates")
-		if info, statErr := os.Stat(projectDir); statErr == nil && info.IsDir() {
-			return projectDir, noop, nil
+		projectTemplates := filepath.Join(root, ".scion", "templates")
+		projectModes := filepath.Join(root, ".scion", "modes")
+		if info, statErr := os.Stat(projectTemplates); statErr == nil && info.IsDir() {
+			// Modes dir may not exist yet on a project mid-migration;
+			// pass through whatever's there and let the script error if
+			// it actually needs it.
+			return projectTemplates, projectModes, noop, nil
 		}
 	}
 
-	return extractEmbeddedTemplates()
+	return extractEmbeddedSubstrate()
 }
 
-// extractEmbeddedTemplates copies the embedded data/.scion/templates
-// tree to a tmpdir and returns its path. The cleanup func removes the
-// tmpdir; callers should defer it.
-func extractEmbeddedTemplates() (string, func(), error) {
-	tmpDir, err := os.MkdirTemp("", "darken-templates-*")
+// extractEmbeddedSubstrate copies both data/.scion/templates and
+// data/.scion/modes to a single tmpdir, side-by-side, and returns
+// (templatesDir, modesDir, cleanup). Layout:
+//
+//	<tmp>/templates/<role>/scion-agent.yaml
+//	<tmp>/modes/<name>.yaml
+//
+// The cleanup func removes the parent tmpdir.
+func extractEmbeddedSubstrate() (string, string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "darken-substrate-*")
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	cleanup := func() { os.RemoveAll(tmpDir) }
 
-	const root = "data/.scion/templates"
-	walkErr := fs.WalkDir(substrate.EmbeddedFS(), root, func(path string, d fs.DirEntry, err error) error {
+	templatesDir := filepath.Join(tmpDir, "templates")
+	modesDir := filepath.Join(tmpDir, "modes")
+
+	if err := extractEmbeddedTree("data/.scion/templates", templatesDir); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("extract embedded templates: %w", err)
+	}
+	if err := extractEmbeddedTree("data/.scion/modes", modesDir); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("extract embedded modes: %w", err)
+	}
+	return templatesDir, modesDir, cleanup, nil
+}
+
+// extractEmbeddedTree walks an embed root and writes each file to
+// dstRoot, expanding manifest placeholders as it goes.
+func extractEmbeddedTree(srcRoot, dstRoot string) error {
+	if err := os.MkdirAll(dstRoot, 0o755); err != nil {
+		return err
+	}
+	return fs.WalkDir(substrate.EmbeddedFS(), srcRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if path == root {
+		if path == srcRoot {
 			return nil
 		}
-		rel := strings.TrimPrefix(path, root+"/")
-		dst := filepath.Join(tmpDir, rel)
+		rel := strings.TrimPrefix(path, srcRoot+"/")
+		dst := filepath.Join(dstRoot, rel)
 		if d.IsDir() {
 			return os.MkdirAll(dst, 0o755)
 		}
@@ -177,18 +229,12 @@ func extractEmbeddedTemplates() (string, func(), error) {
 		if err != nil {
 			return err
 		}
-		// Substitute ${DARKEN_*} placeholders in scion-agent.yaml manifests.
 		content := string(body)
 		if strings.HasSuffix(path, "scion-agent.yaml") {
 			content = expandManifest(content)
 		}
 		return os.WriteFile(dst, []byte(content), 0o644)
 	})
-	if walkErr != nil {
-		cleanup()
-		return "", nil, fmt.Errorf("extract embedded templates: %w", walkErr)
-	}
-	return tmpDir, cleanup, nil
 }
 
 func finalDoctor() error {

--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -129,6 +129,21 @@ func withSubstrateDirsEnv(templatesDir, modesDir string, fn func() error) error 
 	return fn()
 }
 
+// withModeOverride runs fn with DARKEN_MODE_OVERRIDE set to mode if mode is
+// non-empty; the previous value (or unset state) is restored on return. When
+// mode is empty the env var is left untouched, so callers that don't want to
+// override the role's default_mode pay no cost. Bootstrap doesn't take an
+// override; only spawn does, so this wrapper is intentionally separate from
+// withSubstrateDirsEnv.
+func withModeOverride(mode string, fn func() error) error {
+	if mode == "" {
+		return fn()
+	}
+	restore := setEnvWithRestore("DARKEN_MODE_OVERRIDE", mode)
+	defer restore()
+	return fn()
+}
+
 func setEnvWithRestore(key, val string) func() {
 	prev, hadPrev := os.LookupEnv(key)
 	os.Setenv(key, val)

--- a/cmd/darken/main.go
+++ b/cmd/darken/main.go
@@ -43,6 +43,7 @@ var subcommands = []subcommand{
 	{"status", "print one-line status (statusLine-friendly)", runStatus},
 	{"dashboard", "open scion's web UI in the default browser", runDashboard},
 	{"history", "tabular view of .scion/audit.jsonl", runHistory},
+	{"modes", "list available modes or show one (modes list | modes show <name>)", runModes},
 }
 
 func main() {

--- a/cmd/darken/modes.go
+++ b/cmd/darken/modes.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/danmestas/darken/internal/substrate"
+	"gopkg.in/yaml.v3"
+)
+
+// runModes dispatches `darken modes list` and `darken modes show <name>`.
+func runModes(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: darken modes list | show <name>")
+	}
+	switch args[0] {
+	case "list":
+		return runModesList()
+	case "show":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: darken modes show <name>")
+		}
+		return runModesShow(args[1])
+	default:
+		return fmt.Errorf("unknown subcommand: modes %s", args[0])
+	}
+}
+
+// modesDir locates the modes directory: prefers project-local
+// .scion/modes/ if the cwd is a darkish-factory checkout; otherwise
+// falls back to the embedded copy by extracting just the modes tree.
+// Returns (path, cleanup, err). Cleanup is a no-op for project-local.
+func modesDir() (string, func(), error) {
+	noop := func() {}
+	if root, err := repoRoot(); err == nil {
+		dir := filepath.Join(root, ".scion", "modes")
+		if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
+			return dir, noop, nil
+		}
+	}
+	// Fall back to embedded by routing through the substrate extraction
+	// helper used by bootstrap.
+	_, modesPath, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		return "", noop, fmt.Errorf("locate modes dir: %w", err)
+	}
+	if modesPath == "" {
+		cleanup()
+		return "", noop, fmt.Errorf("modes dir not available")
+	}
+	return modesPath, cleanup, nil
+}
+
+func runModesList() error {
+	dir, cleanup, err := modesDir()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read modes dir %s: %w", dir, err)
+	}
+
+	type row struct{ name, desc string }
+	var rows []row
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".yaml")
+		body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			rows = append(rows, row{name, "(unreadable)"})
+			continue
+		}
+		var m struct {
+			Description string `yaml:"description"`
+		}
+		_ = yaml.Unmarshal(body, &m)
+		rows = append(rows, row{name, m.Description})
+	}
+
+	// Pad name column for readability.
+	w := 0
+	for _, r := range rows {
+		if len(r.name) > w {
+			w = len(r.name)
+		}
+	}
+	for _, r := range rows {
+		fmt.Printf("  %-*s  %s\n", w, r.name, r.desc)
+	}
+	return nil
+}
+
+func runModesShow(name string) error {
+	dir, cleanup, err := modesDir()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	path := filepath.Join(dir, name+".yaml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("mode %q: %w", name, err)
+	}
+
+	fmt.Printf("# %s\n%s\n", path, body)
+
+	resolved, err := substrate.ResolveSkillsFromFS(os.DirFS(dir), name)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", name, err)
+	}
+	fmt.Printf("# resolved skills (after extends expansion):\n")
+	if len(resolved) == 0 {
+		fmt.Printf("  (none)\n")
+		return nil
+	}
+	for _, s := range resolved {
+		fmt.Printf("  %s\n", s)
+	}
+	return nil
+}
+
+// Suppress unused import warning if fs.FS becomes unused.
+var _ = fs.ValidPath

--- a/cmd/darken/modes_test.go
+++ b/cmd/darken/modes_test.go
@@ -85,3 +85,45 @@ func TestModes_UnknownSubcommand(t *testing.T) {
 		t.Errorf("error should mention 'unknown': %v", err)
 	}
 }
+
+func TestModesShow_MissingMode(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	dir := filepath.Join(root, ".scion", "modes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Don't write any mode files.
+	err := runModesShow("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing mode")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention mode name: %v", err)
+	}
+}
+
+func TestModesShow_CycleDetected(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	dir := filepath.Join(root, ".scion", "modes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"a.yaml": "description: \"a\"\nextends: b\nskills: []\n",
+		"b.yaml": "description: \"b\"\nextends: a\nskills: []\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := runModesShow("a")
+	if err == nil {
+		t.Fatal("expected cycle error")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention cycle: %v", err)
+	}
+}

--- a/cmd/darken/modes_test.go
+++ b/cmd/darken/modes_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureStdoutModes captures stdout from fn.
+func captureStdoutModes(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	if err := fn(); err != nil {
+		t.Fatalf("fn: %v", err)
+	}
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestModesList_PrintsAllModes(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	dir := filepath.Join(root, ".scion", "modes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"alpha.yaml": "description: \"A mode\"\nskills: []\n",
+		"beta.yaml":  "description: \"B mode\"\nskills:\n  - x\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := captureStdoutModes(t, func() error { return runModesList() })
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+		t.Errorf("expected both mode names in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "A mode") || !strings.Contains(out, "B mode") {
+		t.Errorf("expected both descriptions in output; got:\n%s", out)
+	}
+}
+
+func TestModesShow_PrintsResolvedSkills(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	dir := filepath.Join(root, ".scion", "modes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"base.yaml":  "description: \"base\"\nskills:\n  - a\n  - b\n",
+		"child.yaml": "description: \"child\"\nextends: base\nskills:\n  - c\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := captureStdoutModes(t, func() error { return runModesShow("child") })
+	for _, want := range []string{"a", "b", "c", "extends: base"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestModes_UnknownSubcommand(t *testing.T) {
+	err := runModes([]string{"foo"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error should mention 'unknown': %v", err)
+	}
+}

--- a/cmd/darken/skill_staging.go
+++ b/cmd/darken/skill_staging.go
@@ -149,6 +149,15 @@ func loadManifestForRole(harnessType string) (HarnessManifest, error) {
 // or canonical skills directory cannot be resolved, preserving the
 // pre-REVIEW-7 behavior for operators without a local agent-config tree.
 func stageSkillsForRole(harnessType string) error {
+	// When DARKEN_MODE_OVERRIDE is set (via `darken spawn --mode <name>`),
+	// route through the shell script: it's the only path that resolves
+	// modes (manifest -> default_mode -> .scion/modes/<mode>.yaml with
+	// extends-chain expansion). The Go-path buildSkillsStaging reads
+	// manifest.Skills inline only and would silently drop the override.
+	if os.Getenv("DARKEN_MODE_OVERRIDE") != "" {
+		return stageSkillsViaScript(harnessType)
+	}
+
 	root, rootErr := repoRoot()
 	if rootErr != nil {
 		// No repo root: fall back to shell script.

--- a/cmd/darken/skill_staging.go
+++ b/cmd/darken/skill_staging.go
@@ -139,46 +139,18 @@ func loadManifestForRole(harnessType string) (HarnessManifest, error) {
 	return loadHarnessManifest(body)
 }
 
-// stageSkillsForRole is the single entry point for skill staging called by
-// spawn. It resolves the templates directory (project-local or embedded),
-// the canonical skills source, and the output staging directory, then
-// delegates to buildSkillsStaging which handles the full pipeline:
-// manifest read → ref resolution → copy → role-visibility filter.
+// stageSkillsForRole is the single entry point for skill staging called
+// by spawn. After the modes migration (.scion/modes/<name>.yaml), skill
+// resolution is mode-driven: the manifest carries default_mode, and the
+// shell script resolves through the modes tree with extends-chain
+// expansion. The Go-path buildSkillsStaging reads inline manifest.Skills
+// only — empty after migration — so it produces empty staging dirs.
 //
-// Falls back to the substrate shell script when the templates directory
-// or canonical skills directory cannot be resolved, preserving the
-// pre-REVIEW-7 behavior for operators without a local agent-config tree.
+// Until buildSkillsStaging gains mode-awareness, route through the shell
+// script unconditionally. The script handles both the override case
+// (DARKEN_MODE_OVERRIDE) and the default-mode case correctly.
 func stageSkillsForRole(harnessType string) error {
-	// When DARKEN_MODE_OVERRIDE is set (via `darken spawn --mode <name>`),
-	// route through the shell script: it's the only path that resolves
-	// modes (manifest -> default_mode -> .scion/modes/<mode>.yaml with
-	// extends-chain expansion). The Go-path buildSkillsStaging reads
-	// manifest.Skills inline only and would silently drop the override.
-	if os.Getenv("DARKEN_MODE_OVERRIDE") != "" {
-		return stageSkillsViaScript(harnessType)
-	}
-
-	root, rootErr := repoRoot()
-	if rootErr != nil {
-		// No repo root: fall back to shell script.
-		return stageSkillsViaScript(harnessType)
-	}
-
-	templatesDir, cleanup, err := resolveTemplatesDir()
-	if err != nil {
-		return stageSkillsViaScript(harnessType)
-	}
-	defer cleanup()
-
-	canonical := skillsCanonical()
-	if _, err := os.Stat(canonical); err != nil {
-		// Canonical skills dir not present locally: fall back to shell script
-		// so operators without an agent-config checkout can still spawn.
-		return stageSkillsViaScript(harnessType)
-	}
-
-	stageDir := filepath.Join(root, ".scion", "skills-staging", harnessType)
-	return buildSkillsStaging(harnessType, templatesDir, stageDir, canonical)
+	return stageSkillsViaScript(harnessType)
 }
 
 // stageSkillsViaScript is the shell-script fallback for stageSkillsForRole.

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -18,6 +18,7 @@ func runSpawn(args []string) error {
 	fs := flag.NewFlagSet("spawn", flag.ContinueOnError)
 	harnessType := fs.String("type", "", "harness role (e.g. researcher)")
 	backend := fs.String("backend", "", "backend override (claude|codex|pi|gemini)")
+	mode := fs.String("mode", "", "skill-set mode override (defaults to role's default_mode)")
 	noStage := fs.Bool("no-stage", false, "skip stage-creds and stage-skills")
 	watch := fs.Bool("watch", false, "block + attach to the agent's session (legacy behavior)")
 	if err := fs.Parse(args[1:]); err != nil {
@@ -33,7 +34,9 @@ func runSpawn(args []string) error {
 		if err := runSubstrateScript("scripts/stage-creds.sh", []string{"all"}); err != nil {
 			fmt.Fprintln(os.Stderr, "spawn: stage-creds non-fatal:", err)
 		}
-		if err := stageSkillsForRole(*harnessType); err != nil {
+		if err := withModeOverride(*mode, func() error {
+			return stageSkillsForRole(*harnessType)
+		}); err != nil {
 			return fmt.Errorf("spawn: %w", err)
 		}
 	}

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -221,6 +221,51 @@ esac
 	}
 }
 
+// TestWithModeOverride_SetsEnvVar pins that DARKEN_MODE_OVERRIDE is set
+// inside the closure when a non-empty mode name is passed, and is restored
+// (unset, in this test) after the closure returns. This is the mechanism
+// `darken spawn --mode <name>` uses to route an override into the staging
+// pipeline without changing function signatures down the call chain.
+func TestWithModeOverride_SetsEnvVar(t *testing.T) {
+	t.Setenv("DARKEN_MODE_OVERRIDE", "") // start unset
+	os.Unsetenv("DARKEN_MODE_OVERRIDE")
+	called := false
+	err := withModeOverride("custom-mode", func() error {
+		called = true
+		got := os.Getenv("DARKEN_MODE_OVERRIDE")
+		if got != "custom-mode" {
+			t.Errorf("DARKEN_MODE_OVERRIDE = %q; want %q", got, "custom-mode")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withModeOverride: %v", err)
+	}
+	if !called {
+		t.Fatal("fn was not called")
+	}
+	if got := os.Getenv("DARKEN_MODE_OVERRIDE"); got != "" {
+		t.Errorf("DARKEN_MODE_OVERRIDE leaked after withModeOverride returned: %q", got)
+	}
+}
+
+// TestWithModeOverride_EmptyDoesNotSet confirms the no-override path is a
+// pure pass-through: an empty mode argument leaves the env var untouched
+// so the script falls back to the manifest's default_mode.
+func TestWithModeOverride_EmptyDoesNotSet(t *testing.T) {
+	t.Setenv("DARKEN_MODE_OVERRIDE", "")
+	os.Unsetenv("DARKEN_MODE_OVERRIDE")
+	err := withModeOverride("", func() error {
+		if got := os.Getenv("DARKEN_MODE_OVERRIDE"); got != "" {
+			t.Errorf("DARKEN_MODE_OVERRIDE should not be set for empty override; got %q", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withModeOverride: %v", err)
+	}
+}
+
 // TestSpawn_ManifestParseError_IsFatal asserts that runSpawn returns a non-nil
 // error when the manifest for the requested role exists on disk but cannot be
 // parsed (e.g. unknown backend). Silently degrading on parse errors hides

--- a/docs/superpowers/plans/2026-05-01-dynamic-skill-resolution.md
+++ b/docs/superpowers/plans/2026-05-01-dynamic-skill-resolution.md
@@ -1,0 +1,908 @@
+# Dynamic skill resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-role static skill bundling (`skills:` field in role manifests) with operator-selectable named modes loaded from `.scion/modes/<name>.yaml`. Modes can compose via `extends:`. Operator picks at spawn with `--mode <name>`; absence defaults to the role's `default_mode`.
+
+**Architecture:** From `docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md` (Ousterhout-revised). Mode YAML schema: `description`, `skills[]`, optional `extends`. No `name` field (filename IS the name). No `--skills` ad-hoc flag (one way to specify skills). Single-inheritance composition via `extends:`. Big-bang migration: 14 role-default modes + 1 base mode (`philosophy-base = [hipp, ousterhout]`) used by planner-t2/t3/t4. All other roles get flat mode files.
+
+**Tech Stack:** Go (existing substrate package + `gopkg.in/yaml.v3` already used in the repo). New CLI subcommand surface under `cmd/darken/modes_*.go`.
+
+---
+
+## Current skill bundles (extracted from `.scion/templates/<role>/scion-agent.yaml`)
+
+| Role | Current skills (in order) |
+|---|---|
+| admin | (empty) |
+| base | (empty) |
+| darwin | dx-audit |
+| designer | norman, ousterhout |
+| orchestrator | dx-audit |
+| planner-t1 | hipp |
+| planner-t2 | hipp, ousterhout |
+| planner-t3 | hipp, ousterhout, superpowers |
+| planner-t4 | hipp, ousterhout, spec-kit |
+| researcher | (empty) |
+| reviewer | ousterhout, hipp, dx-audit |
+| sme | ousterhout, hipp |
+| tdd-implementer | idiomatic-go, tigerstyle |
+| verifier | tigerstyle |
+
+Composition opportunity: planner-t2/t3/t4 all start with `[hipp, ousterhout]`. Extract as `philosophy-base`. Others stay flat (their orderings or sets don't match).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/substrate/modes.go` (new) | Mode YAML schema, parser, recursive resolver | Define `Mode` struct, `LoadMode(name) (*Mode, error)`, `ResolveSkills(name) ([]string, error)` with cycle detection |
+| `internal/substrate/modes_test.go` (new) | Unit tests for mode resolver | Flat, extends, multi-level chain, cycle, missing parent, missing skill |
+| `.scion/modes/` (new directory) | Mode YAML files | `philosophy-base.yaml` + 14 `<role>.yaml` files (mirrors `.scion/templates/`) |
+| `internal/substrate/data/.scion/modes/` (new directory) | Embedded copy for non-darkish-factory projects | Same 15 files; bootstrap extracts these alongside templates when project has no `.scion/modes/` |
+| `.scion/templates/<role>/scion-agent.yaml` (×14) | Role manifest | Add `default_mode: <role>`, remove `skills:` field |
+| `internal/substrate/data/.scion/templates/<role>/scion-agent.yaml` (×14) | Embedded copy of role manifests | Same edit |
+| `cmd/darken/spawn.go` | Spawn CLI parsing + skill staging | Add `--mode <name>` flag; wire mode-resolved skills into staging |
+| `cmd/darken/spawn_test.go` | Spawn integration tests | Golden-equivalence test per role (pre/post staging match) |
+| `cmd/darken/modes_list.go` (new) | `darken modes list` command | List all `.scion/modes/*.yaml` with descriptions |
+| `cmd/darken/modes_show.go` (new) | `darken modes show <name>` command | Print mode YAML + resolved skills |
+| `cmd/darken/main.go` | Command dispatcher | Register `modes` subcommand group |
+
+Files NOT changed: any test outside cmd/darken/ and internal/substrate/. Existing skill-staging logic stays — we only change what skill set is FED to it.
+
+---
+
+## Task 1: Mode parser + resolver (TDD)
+
+**Files:**
+- Create: `internal/substrate/modes.go`
+- Create: `internal/substrate/modes_test.go`
+
+- [ ] **Step 1: Write the unit test (RED)**
+
+Create `internal/substrate/modes_test.go`:
+
+```go
+package substrate
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestResolveSkills_FlatMode(t *testing.T) {
+	fs := fstest.MapFS{
+		"go-systems.yaml": &fstest.MapFile{Data: []byte(`description: Go systems work
+skills:
+  - tdd
+  - idiomatic-go
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "go-systems")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"tdd", "idiomatic-go"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_ExtendsParent(t *testing.T) {
+	fs := fstest.MapFS{
+		"philosophy.yaml": &fstest.MapFile{Data: []byte(`description: shared philosophy
+skills:
+  - hipp
+  - ousterhout
+`)},
+		"planner.yaml": &fstest.MapFile{Data: []byte(`description: planner
+extends: philosophy
+skills:
+  - superpowers
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "planner")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"hipp", "ousterhout", "superpowers"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_DedupesFirstWins(t *testing.T) {
+	fs := fstest.MapFS{
+		"base.yaml": &fstest.MapFile{Data: []byte(`description: base
+skills:
+  - hipp
+  - ousterhout
+`)},
+		"override.yaml": &fstest.MapFile{Data: []byte(`description: override
+extends: base
+skills:
+  - ousterhout
+  - extra
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "override")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"hipp", "ousterhout", "extra"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_DetectsCycle(t *testing.T) {
+	fs := fstest.MapFS{
+		"a.yaml": &fstest.MapFile{Data: []byte(`description: a
+extends: b
+skills: []
+`)},
+		"b.yaml": &fstest.MapFile{Data: []byte(`description: b
+extends: a
+skills: []
+`)},
+	}
+	_, err := ResolveSkillsFromFS(fs, "a")
+	if err == nil {
+		t.Fatal("expected cycle error; got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention cycle: %v", err)
+	}
+}
+
+func TestResolveSkills_MissingMode(t *testing.T) {
+	fs := fstest.MapFS{}
+	_, err := ResolveSkillsFromFS(fs, "nope")
+	if err == nil {
+		t.Fatal("expected not-found error; got nil")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error should mention mode name: %v", err)
+	}
+}
+
+func TestResolveSkills_MissingParent(t *testing.T) {
+	fs := fstest.MapFS{
+		"child.yaml": &fstest.MapFile{Data: []byte(`description: child
+extends: ghost
+skills: []
+`)},
+	}
+	_, err := ResolveSkillsFromFS(fs, "child")
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should mention missing parent: %v", err)
+	}
+}
+
+func TestResolveSkills_MultiLevelChain(t *testing.T) {
+	fs := fstest.MapFS{
+		"grandparent.yaml": &fstest.MapFile{Data: []byte(`description: gp
+skills:
+  - a
+`)},
+		"parent.yaml": &fstest.MapFile{Data: []byte(`description: p
+extends: grandparent
+skills:
+  - b
+`)},
+		"child.yaml": &fstest.MapFile{Data: []byte(`description: c
+extends: parent
+skills:
+  - c
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "child")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"a", "b", "c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+	_ = filepath.Join // unused-import guard
+}
+```
+
+- [ ] **Step 2: Run tests, expect compile-fail or test-fail**
+
+```bash
+go test ./internal/substrate/ -run TestResolveSkills -v
+```
+
+Expected: compile error (function undefined). That's the RED state.
+
+- [ ] **Step 3: Implement the resolver (GREEN)**
+
+Create `internal/substrate/modes.go`:
+
+```go
+package substrate
+
+import (
+	"fmt"
+	"io/fs"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Mode is a parsed .scion/modes/<name>.yaml file. The mode's name is the
+// filename stem; there is no name field in the YAML itself.
+type Mode struct {
+	Description string   `yaml:"description"`
+	Extends     string   `yaml:"extends,omitempty"`
+	Skills      []string `yaml:"skills"`
+}
+
+// loadModeFromFS reads <name>.yaml from fsys and parses it.
+func loadModeFromFS(fsys fs.FS, name string) (*Mode, error) {
+	data, err := fs.ReadFile(fsys, name+".yaml")
+	if err != nil {
+		return nil, fmt.Errorf("mode %q: %w", name, err)
+	}
+	var m Mode
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("mode %q: parse: %w", name, err)
+	}
+	return &m, nil
+}
+
+// ResolveSkillsFromFS resolves the given mode name into an ordered, deduped
+// skill name list. extends chains are walked recursively; first occurrence
+// of a duplicate name wins. Cycles are detected and rejected.
+func ResolveSkillsFromFS(fsys fs.FS, name string) ([]string, error) {
+	visited := map[string]bool{}
+	var stack []string
+	return resolveRecursive(fsys, name, visited, stack)
+}
+
+func resolveRecursive(fsys fs.FS, name string, visited map[string]bool, stack []string) ([]string, error) {
+	if visited[name] {
+		return nil, fmt.Errorf("mode %q: cycle detected in extends chain: %s -> %s",
+			stack[0], joinChain(stack), name)
+	}
+	visited[name] = true
+	stack = append(stack, name)
+
+	m, err := loadModeFromFS(fsys, name)
+	if err != nil {
+		return nil, err
+	}
+
+	var skills []string
+	if m.Extends != "" {
+		parentSkills, err := resolveRecursive(fsys, m.Extends, visited, stack)
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, parentSkills...)
+	}
+	skills = append(skills, m.Skills...)
+	return dedupePreserveFirst(skills), nil
+}
+
+func dedupePreserveFirst(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+func joinChain(stack []string) string {
+	if len(stack) == 0 {
+		return ""
+	}
+	out := stack[0]
+	for _, s := range stack[1:] {
+		out += " -> " + s
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+go test ./internal/substrate/ -run TestResolveSkills -v
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Run the full substrate test suite**
+
+```bash
+go test ./internal/substrate/ -count=1
+```
+
+Expected: all PASS. No regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/substrate/modes.go internal/substrate/modes_test.go
+git commit -m "feat(substrate): add mode YAML parser and recursive resolver
+
+Mode files at .scion/modes/<name>.yaml carry description, optional
+extends parent, and skills list. ResolveSkillsFromFS walks the
+extends chain recursively, dedupes (first occurrence wins), and
+rejects cycles. The mode's name is the filename stem; there is no
+name field in the YAML.
+
+Tests cover: flat mode, extends-one-level, multi-level chain,
+duplicate-dedup, cycle detection, missing mode, missing parent."
+```
+
+---
+
+## Task 2: Author the 1 base mode + 14 role-default modes
+
+**Files:**
+- Create: `.scion/modes/philosophy-base.yaml`
+- Create: `.scion/modes/<role>.yaml` (×14)
+
+The directory `.scion/modes/` must be created.
+
+- [ ] **Step 1: Create the modes directory**
+
+```bash
+mkdir -p .scion/modes
+```
+
+- [ ] **Step 2: Author `philosophy-base.yaml`**
+
+Create `.scion/modes/philosophy-base.yaml`:
+
+```yaml
+description: "Hipp + Ousterhout — design philosophy baseline shared by planners."
+skills:
+  - hipp
+  - ousterhout
+```
+
+- [ ] **Step 3: Author 14 role-default modes**
+
+Each of these is the canonical mode for its role. The `description` is uniform; `skills` and `extends` follow the current bundle for that role.
+
+`.scion/modes/admin.yaml`:
+
+```yaml
+description: "Default skills for the admin harness."
+skills: []
+```
+
+`.scion/modes/base.yaml`:
+
+```yaml
+description: "Default skills for the base harness."
+skills: []
+```
+
+`.scion/modes/darwin.yaml`:
+
+```yaml
+description: "Default skills for the darwin harness."
+skills:
+  - dx-audit
+```
+
+`.scion/modes/designer.yaml`:
+
+```yaml
+description: "Default skills for the designer harness."
+skills:
+  - norman
+  - ousterhout
+```
+
+`.scion/modes/orchestrator.yaml`:
+
+```yaml
+description: "Default skills for the orchestrator harness."
+skills:
+  - dx-audit
+```
+
+`.scion/modes/planner-t1.yaml`:
+
+```yaml
+description: "Default skills for the planner-t1 harness."
+skills:
+  - hipp
+```
+
+`.scion/modes/planner-t2.yaml`:
+
+```yaml
+description: "Default skills for the planner-t2 harness."
+extends: philosophy-base
+skills: []
+```
+
+`.scion/modes/planner-t3.yaml`:
+
+```yaml
+description: "Default skills for the planner-t3 harness."
+extends: philosophy-base
+skills:
+  - superpowers
+```
+
+`.scion/modes/planner-t4.yaml`:
+
+```yaml
+description: "Default skills for the planner-t4 harness."
+extends: philosophy-base
+skills:
+  - spec-kit
+```
+
+`.scion/modes/researcher.yaml`:
+
+```yaml
+description: "Default skills for the researcher harness."
+skills: []
+```
+
+`.scion/modes/reviewer.yaml`:
+
+```yaml
+description: "Default skills for the reviewer harness."
+skills:
+  - ousterhout
+  - hipp
+  - dx-audit
+```
+
+`.scion/modes/sme.yaml`:
+
+```yaml
+description: "Default skills for the sme harness."
+skills:
+  - ousterhout
+  - hipp
+```
+
+`.scion/modes/tdd-implementer.yaml`:
+
+```yaml
+description: "Default skills for the tdd-implementer harness."
+skills:
+  - idiomatic-go
+  - tigerstyle
+```
+
+`.scion/modes/verifier.yaml`:
+
+```yaml
+description: "Default skills for the verifier harness."
+skills:
+  - tigerstyle
+```
+
+- [ ] **Step 4: Sanity-check resolution**
+
+Write a tiny throwaway probe to confirm modes parse and resolve correctly. Save as `/tmp/probe_modes.go` (NOT in the repo):
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/danmestas/darken/internal/substrate"
+)
+
+func main() {
+	for _, role := range []string{"admin", "planner-t3", "reviewer", "tdd-implementer", "verifier"} {
+		got, err := substrate.ResolveSkillsFromFS(os.DirFS(".scion/modes"), role)
+		fmt.Printf("%-18s skills=%v err=%v\n", role, got, err)
+	}
+}
+```
+
+Run from repo root:
+
+```bash
+go run /tmp/probe_modes.go
+```
+
+Expected output (modulo formatting):
+```
+admin              skills=[] err=<nil>
+planner-t3         skills=[hipp ousterhout superpowers] err=<nil>
+reviewer           skills=[ousterhout hipp dx-audit] err=<nil>
+tdd-implementer    skills=[idiomatic-go tigerstyle] err=<nil>
+verifier           skills=[tigerstyle] err=<nil>
+```
+
+If anything diverges, fix the YAML before continuing.
+
+```bash
+rm /tmp/probe_modes.go
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .scion/modes/
+git commit -m "feat(modes): author philosophy-base + 14 role-default modes
+
+Mirrors current skills: bundles in role manifests (extracted from
+.scion/templates/<role>/scion-agent.yaml). Three planner roles share
+[hipp, ousterhout] via extends: philosophy-base. Other roles stay
+flat because their skill sets do not share enough order to factor.
+
+Subsequent task drops the now-redundant skills: field from each
+manifest and adds default_mode: <role>."
+```
+
+---
+
+## Task 3: Update role manifests — add `default_mode`, remove `skills`
+
+**Files:**
+- Modify: `.scion/templates/<role>/scion-agent.yaml` (×14)
+
+The `skills:` field in each manifest currently does double duty: it lists the skill names AND a `source:` mount entry. The `source:` entry is unrelated to skill names — it's a Docker volume mount for the staging-out dir. Verify by reading one manifest first, then make the edits surgical.
+
+- [ ] **Step 1: Read one manifest to confirm structure**
+
+```bash
+cat .scion/templates/planner-t3/scion-agent.yaml
+```
+
+Note the structure: `skills:` field is a sequence, contains skill name entries (`- danmestas/agent-skills/skills/X`) plus a mount entry (`- source: ./.scion/skills-staging/planner-t3/`). Wait — that doesn't parse as a homogeneous sequence. Re-check.
+
+If the existing manifest mixes skill names and mount entries under `skills:`, this needs a careful look. Read the actual structure and report DONE_WITH_CONCERNS describing the layout if unclear; the controller will adapt.
+
+If `skills:` is a flat sequence of skill paths and there's a separate `volumes:` field with the mount, then the change is just removing the skill paths.
+
+- [ ] **Step 2: Edit each manifest**
+
+For each role in `[admin, base, darwin, designer, orchestrator, planner-t1, planner-t2, planner-t3, planner-t4, researcher, reviewer, sme, tdd-implementer, verifier]`:
+
+In `.scion/templates/<role>/scion-agent.yaml`:
+- Remove the `skills:` block entirely (the field and all its entries).
+- Add `default_mode: <role>` at the top level (alongside other fields like `description`, `image`, `model`).
+- Leave `volumes:` and other fields untouched.
+
+The `volumes` mount path (`./.scion/skills-staging/<role>/`) should stay — it's where the stager writes to, regardless of which mode populated it.
+
+- [ ] **Step 3: Verify the manifests still parse**
+
+```bash
+for f in .scion/templates/*/scion-agent.yaml; do
+  if ! python3 -c "import yaml; yaml.safe_load(open('$f'))" 2>&1; then
+    echo "PARSE FAIL: $f"
+    exit 1
+  fi
+done && echo "all 14 manifests parse"
+```
+
+Expected: `all 14 manifests parse`.
+
+- [ ] **Step 4: Verify each has `default_mode`**
+
+```bash
+for f in .scion/templates/*/scion-agent.yaml; do
+  role=$(basename $(dirname "$f"))
+  if ! grep -q "^default_mode: $role" "$f"; then
+    echo "MISSING default_mode: $f"
+    exit 1
+  fi
+done && echo "all 14 manifests have default_mode"
+```
+
+- [ ] **Step 5: Verify `skills:` field is gone**
+
+```bash
+for f in .scion/templates/*/scion-agent.yaml; do
+  if grep -q "^skills:" "$f"; then
+    echo "STILL HAS skills: $f"
+    exit 1
+  fi
+done && echo "no manifest has skills: field"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .scion/templates/
+git commit -m "refactor(templates): replace skills: with default_mode in role manifests
+
+Each role manifest now points at a mode in .scion/modes/<role>.yaml
+via default_mode: <role>. The skills: field is removed because the
+mode owns that information. volumes: mount paths unchanged."
+```
+
+---
+
+## Task 4: Wire mode resolution into stage-skills script + spawn flow
+
+This is the integration task. Existing skill staging is driven by `scripts/stage-skills.sh` reading the manifest's `skills:` field. With that field removed, the script (or its caller) needs to read the role's mode instead.
+
+**Files:**
+- Identify and modify the staging entry point. Likely `scripts/stage-skills.sh` (which reads scion-agent.yaml). May also need `cmd/darken/spawn.go` if spawn-time resolution differs from bootstrap-time.
+
+- [ ] **Step 1: Read the current stage-skills.sh**
+
+```bash
+cat scripts/stage-skills.sh
+```
+
+Identify where it parses `skills:` from the manifest. Determine the simplest hook point.
+
+- [ ] **Step 2: Decide the hook**
+
+Two reasonable options:
+
+(a) Have stage-skills.sh read `default_mode` from the manifest, then read the mode YAML to get the skill list. Pure shell, no Go changes here.
+
+(b) Move skill-name resolution into a Go helper invoked by darken (not the shell script). Wire it into the bootstrap and spawn paths.
+
+Option (a) is simpler if the shell script is already doing YAML parsing. Option (b) is cleaner if it forces all skill resolution through one Go path.
+
+Pick one. Document the choice in the commit message.
+
+- [ ] **Step 3: Implement the chosen option**
+
+Edit the relevant file(s). Skill-resolution logic should call `substrate.ResolveSkillsFromFS` (or a similar exported helper) on `.scion/modes/`.
+
+- [ ] **Step 4: Verify the staging step still produces the same output**
+
+Pre-migration baseline: run staging on each of the 14 roles BEFORE the migration commits and capture the output (e.g. `find .scion/skills-staging/<role>/ -type f -print | sort`).
+
+Post-migration: re-run staging and capture the same listing. The two listings must match for every role.
+
+```bash
+# Pre (run on main):
+git stash; git checkout main
+for role in admin base darwin designer orchestrator planner-t1 planner-t2 planner-t3 planner-t4 researcher reviewer sme tdd-implementer verifier; do
+  rm -rf /tmp/baseline-$role
+  bash scripts/stage-skills.sh "$role" > /dev/null 2>&1 || true
+  find .scion/skills-staging/$role -type f 2>/dev/null | sort > /tmp/baseline-$role.txt || true
+done
+
+# Restore branch and stash:
+git checkout docs/dynamic-skill-resolution-spec
+git stash pop
+
+# Post:
+for role in admin base darwin designer orchestrator planner-t1 planner-t2 planner-t3 planner-t4 researcher reviewer sme tdd-implementer verifier; do
+  rm -rf .scion/skills-staging/$role
+  bash scripts/stage-skills.sh "$role" > /dev/null 2>&1 || true
+  find .scion/skills-staging/$role -type f 2>/dev/null | sort > /tmp/after-$role.txt || true
+  diff /tmp/baseline-$role.txt /tmp/after-$role.txt || echo "DIFF: $role"
+done
+```
+
+If any role shows a diff, the migration broke equivalence. Fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/stage-skills.sh   # or whichever files changed
+# Possibly cmd/darken/spawn.go etc.
+git commit -m "feat(staging): resolve skills via .scion/modes/ default_mode
+
+Stage-skills now reads default_mode from the role manifest and
+resolves the skill list from .scion/modes/<mode>.yaml using the
+recursive ResolveSkillsFromFS helper. skills: field on the
+manifest is no longer read."
+```
+
+---
+
+## Task 5: Add `--mode` flag to `darken spawn`
+
+**Files:**
+- Modify: `cmd/darken/spawn.go`
+- Modify: `cmd/darken/spawn_test.go`
+
+- [ ] **Step 1: Find the spawn flag-parsing block**
+
+```bash
+grep -n "flag.Parse\|--type\|FlagSet" cmd/darken/spawn.go | head
+```
+
+- [ ] **Step 2: Add `--mode <name>` flag**
+
+Define the flag next to the existing `--type` flag. Default value: empty string ("use role's default_mode").
+
+- [ ] **Step 3: Pipe the mode value through to staging**
+
+Where the spawn flow currently calls into staging, pass the explicit mode name (or empty for default-from-manifest).
+
+- [ ] **Step 4: Add a unit test**
+
+`TestSpawn_ExplicitMode_OverridesDefault`: spawn with `--type researcher --mode tdd-implementer` (using a mock or test stub for the actual container start). Assert the staging step received `tdd-implementer` as the mode name, not `researcher`.
+
+- [ ] **Step 5: Run cmd/darken tests**
+
+```bash
+go test ./cmd/darken/ -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/darken/spawn.go cmd/darken/spawn_test.go
+git commit -m "feat(spawn): add --mode flag for per-spawn skill-set selection
+
+darken spawn now accepts --mode <name> to override the role's
+default_mode. Unset falls back to role's default. The resolved mode
+flows through to stage-skills."
+```
+
+---
+
+## Task 6: Add `darken modes list` and `darken modes show <name>` commands
+
+**Files:**
+- Create: `cmd/darken/modes.go`
+- Create: `cmd/darken/modes_test.go`
+- Modify: `cmd/darken/main.go` (or wherever subcommands register)
+
+- [ ] **Step 1: Create modes.go with `runModes(args []string) error`**
+
+Switch on subcommand: `list` and `show`. `list` walks `.scion/modes/*.yaml` and prints filename-stem + description. `show <name>` cats the YAML file and prints the resolved skill list below.
+
+- [ ] **Step 2: Register the subcommand in main.go**
+
+Add `"modes":` to whatever switch table dispatches commands.
+
+- [ ] **Step 3: Write tests**
+
+- `TestModesList_PrintsAllModes`: with a tmpdir of fixture mode files, runModes(["list"]) produces output containing each mode name and description.
+- `TestModesShow_PrintsResolvedSkills`: runModes(["show", "planner-t3"]) prints the mode YAML and the resolved skills [hipp, ousterhout, superpowers].
+
+- [ ] **Step 4: Verify**
+
+```bash
+go test ./cmd/darken/ -count=1
+go build ./cmd/darken/
+./bin/darken modes list
+./bin/darken modes show planner-t3
+```
+
+Expected: both commands work and show sane output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/darken/modes.go cmd/darken/modes_test.go cmd/darken/main.go
+git commit -m "feat(cli): add darken modes list and darken modes show
+
+Surface the new mode files via two readonly subcommands. list
+prints all .scion/modes/*.yaml names + descriptions. show <name>
+prints the YAML body and the resolved skill set (after extends
+expansion)."
+```
+
+---
+
+## Task 7: Embed modes in the binary for non-darkish-factory projects
+
+**Files:**
+- Modify: `internal/substrate/data/.scion/modes/` (new directory copied from `.scion/modes/`)
+- Modify: `internal/substrate/data/.scion/templates/<role>/scion-agent.yaml` (×14, mirror of repo-root edits)
+- Possibly: `internal/substrate/embed.go` if explicit registration is needed
+
+- [ ] **Step 1: Copy modes into the embedded data tree**
+
+```bash
+mkdir -p internal/substrate/data/.scion/modes
+cp .scion/modes/*.yaml internal/substrate/data/.scion/modes/
+```
+
+- [ ] **Step 2: Mirror the manifest edits into embedded copies**
+
+For each role, copy the edited `.scion/templates/<role>/scion-agent.yaml` to `internal/substrate/data/.scion/templates/<role>/scion-agent.yaml`. The two trees must stay in sync.
+
+```bash
+for r in .scion/templates/*/scion-agent.yaml; do
+  role=$(basename $(dirname "$r"))
+  cp "$r" "internal/substrate/data/.scion/templates/$role/scion-agent.yaml"
+done
+```
+
+- [ ] **Step 3: Verify embed picks them up**
+
+```bash
+go build ./internal/substrate/
+go test ./internal/substrate/ -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run cmd/darken tests with the embedded copies in play**
+
+```bash
+go test ./cmd/darken/ -count=1
+```
+
+Expected: PASS (including any test that exercises the embedded fallback path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/substrate/data/
+git commit -m "feat(substrate): embed mode files for non-darkish-factory projects
+
+Mirrors .scion/modes/ and the edited role manifests into
+internal/substrate/data/. Bootstrap's resolveTemplatesDir already
+extracts the embedded tree to a tmpdir when the consuming project
+has no .scion/templates/; modes ride the same path."
+```
+
+---
+
+## Task 8: Add the failure-path tests
+
+**Files:**
+- Modify: `cmd/darken/spawn_test.go` (or wherever spawn integration tests live)
+
+- [ ] **Step 1: Add three failure-path tests**
+
+- `TestSpawn_UnknownMode_Fails`: spawn with `--mode definitely-not-a-real-mode`. Expect non-zero exit with "mode not found" error.
+- `TestSpawn_ModeReferencesMissingSkill_Fails`: temporarily author a mode file that references a skill that doesn't exist in `agent-config/skills/`. Expect "skill not found" error.
+- `TestSpawn_CycleInExtends_Fails`: temporarily author two modes (`a` extends `b`, `b` extends `a`). Expect "cycle detected" error.
+
+- [ ] **Step 2: Run**
+
+```bash
+go test ./cmd/darken/ -run TestSpawn_ -v -count=1
+```
+
+Expected: all three new tests PASS (each verifying that the appropriate error fires).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/darken/spawn_test.go
+git commit -m "test(spawn): cover mode-resolution failure paths
+
+Three tests pin the error contracts: unknown --mode, mode-references-
+missing-skill, and cycle in extends chain. Each runs the actual
+spawn entry path and asserts the expected error message."
+```
+
+---
+
+## Self-review (post-plan)
+
+Spec coverage:
+
+- Mode YAML schema (description, skills, extends; no name; no targets/categories) → Task 1.
+- Resolution algorithm (recursive extends, dedupe-first-wins, cycle detection) → Task 1.
+- 14 role-default modes + 1 base mode → Task 2.
+- Manifest changes (default_mode added, skills field removed) → Task 3.
+- Stager wires through default_mode → Task 4.
+- `--mode` flag at spawn → Task 5.
+- `darken modes list` / `show` → Task 6.
+- Embedded copies for non-darkish-factory projects → Task 7.
+- Failure-path tests → Task 8.
+- Backward-compat (golden equivalence pre/post staging) → Task 4 step 4.
+
+No placeholders. Method/file names consistent.
+
+Notes for the executor: if Task 4 step 1 reveals the staging script structure is more complex than assumed, surface it as a question before plowing into Step 2 — the option (a) vs (b) decision may shift.

--- a/docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md
+++ b/docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md
@@ -1,0 +1,199 @@
+# Spec: dynamic skill resolution via modes
+
+**Date:** 2026-05-01
+**Status:** Draft, awaiting operator approval of written spec
+**Topic:** Replace per-role static skill bundling with operator-selectable *modes* — named, explicit skill lists picked at `darken spawn` time. Goal: quickly configure a harness for the task at hand without forking the role.
+
+## Problem
+
+Today every spawn of a given role gets the same fixed skill bundle. The skill set is declared in `.scion/templates/<role>/scion-agent.yaml` under `skills:` and copied to `.scion/skills-staging/<role>/` at spawn time.
+
+Two consequences:
+
+1. A `tdd-implementer` doing a Go systems task and one doing a TypeScript UI task see identical skills. The bundle is the union of "things any tdd-implementer might need," which means the worker reads more skill content than the task warrants.
+2. The operator has no way to override the bundle for a one-off task without editing the role manifest.
+
+The operator wants to apply skillsets per task, fast. Skills are already authored (49 in `agent-config/skills/` plus repo-local skills), but the per-role bundles are hand-curated and grow stale.
+
+## Goals
+
+- At spawn time, the operator names a *mode*. The mode declares which skills the harness should see. The stager copies exactly those skills.
+- Default behavior preserved: no `--mode` flag means the role's default mode resolves, which produces the same staging output as today.
+- One operator-facing command (`darken modes list`) to enumerate available modes.
+
+## Non-goals
+
+- Category-based composition (suit's `categories ∩` model). Modes are explicit lists. Tagging skills with categories is a future evolution if explicit lists prove too rigid; this spec does not preclude it.
+- Marketplace registry. `agent-config/marketplace/` is a pattern worth borrowing later for a public skill index; out of scope here.
+- Mode authoring tools. `darken modes new`, `darken modes validate`, scaffolding — author by hand for v1.
+- System-prompt prepends per mode. suit's modes inject prose; darkish-factory's role manifests own that via `system-prompt.md`. Modes affect skills only.
+- Targeting modes to specific harness backends (`targets: [claude-code, codex]`). Role implies backend; mode-level targeting is double-spec.
+
+## Design
+
+### Mode YAML schema
+
+Located at `.scion/modes/<name>.yaml`:
+
+```yaml
+name: tdd-go
+description: "Go systems work — TDD-driven, philosophy-aware."
+skills:
+  - tdd
+  - ousterhout
+  - idiomatic-go
+  - hipp
+```
+
+Three required fields:
+
+- `name` — string, must match the filename stem. Used as the value of `--mode`.
+- `description` — one-liner shown by `darken modes list`.
+- `skills` — ordered list of skill names. Each name is resolved against the existing path resolver (currently `agent-config/skills/<name>/` via the `danmestas/agent-skills` rewrite).
+
+Schema is deliberately tight. Optional fields (`extends`, `targets`, `categories`, prose body) are deferred until concrete demand.
+
+### Resolution at spawn time
+
+`darken spawn <name> --type <role> [--mode <name>] [--skills foo,bar] "<task>"` resolves the skill set in this order:
+
+1. **Pick mode.** If `--mode <m>` is passed, use `m`. Otherwise read `default_mode` from `.scion/templates/<role>/scion-agent.yaml`. Load `.scion/modes/<m>.yaml`.
+2. **Base set.** Mode's `skills:` list.
+3. **Ad-hoc additions.** If `--skills foo,bar` is passed, take the union with the base set. Duplicates collapse. Order preserved (mode's skills first, ad-hoc additions appended).
+4. **Stage.** For each resolved skill name, the existing path resolver locates the source dir; the stager copies it to `.scion/skills-staging/<harness>/<skill>/` as today.
+5. **Mount.** Container mounts the staging dir. No change below the stager.
+
+### Validation
+
+- Missing mode file: `mode <name>: not found at .scion/modes/<name>.yaml`. Spawn aborts.
+- Mode references a skill that doesn't resolve: `mode <name>: skill <skill> not found at <resolved_path>`. Spawn aborts. Same failure shape as today's manifest path that doesn't resolve.
+- `name` field doesn't match filename stem: `mode <name>: name field "<X>" does not match filename "<Y>.yaml"`. Spawn aborts. Catches copy-paste errors.
+
+Validation runs at spawn time only — no separate `darken modes validate` command in v1.
+
+### Default-mode naming convention
+
+The 14 canonical roles each get a default mode named *after the role*: `tdd-implementer`, `planner-t3`, `researcher`, etc. Mode and role share names but live in different files (`.scion/templates/<role>/scion-agent.yaml` vs `.scion/modes/<role>.yaml`). One-to-one mapping, mechanical migration.
+
+This is intentionally not a taxonomy. Operator-friendly mode names (`code`, `design`, `plan`, `recon`) are a follow-up consolidation once duplicates among the 14 default modes emerge in practice.
+
+### Role manifest changes
+
+Each `.scion/templates/<role>/scion-agent.yaml`:
+
+- **Add** `default_mode: <role>`.
+- **Remove** the existing `skills:` field. Modes are the single source of truth post-migration.
+
+Example before/after for `planner-t3`:
+
+```yaml
+# Before
+skills:
+  - danmestas/agent-skills/skills/hipp
+  - danmestas/agent-skills/skills/ousterhout
+  - danmestas/agent-skills/skills/superpowers
+
+# After
+default_mode: planner-t3
+```
+
+The `.scion/modes/planner-t3.yaml` file then carries the skill list.
+
+### CLI surface additions
+
+- `darken modes list` — print all `.scion/modes/*.yaml` with `name` and `description` columns.
+- `darken modes show <name>` — cat the mode file.
+- `darken spawn` gains `--mode <name>` and `--skills <comma-list>` flags.
+
+Out for v1: `darken modes new`, `darken modes validate`, mode authoring scaffolds.
+
+### Stager changes
+
+`internal/substrate/staging/` (where the path resolver lives) gains a `mode_resolver.go` that:
+
+- Loads a mode by name from `.scion/modes/<name>.yaml`.
+- Validates required fields and filename-stem match.
+- Returns the resolved skill name list.
+
+The existing path resolver — which knows how to find `<repo>/skills/<name>` locally and via the `agent-config` rewrite — gets called with the mode's skill names instead of the manifest's path strings. No new resolution logic; bare names go in, paths come out.
+
+The spawn entry point in `cmd/darken/spawn.go`:
+
+- Parses new flags `--mode` and `--skills`.
+- Resolves mode (explicit or via role's `default_mode`).
+- Computes the skill set per the resolution algorithm above.
+- Hands off to the existing stager.
+
+## Migration (big-bang)
+
+Single PR. Steps:
+
+1. **Extract.** Read each of 14 role manifests; capture the current `skills:` list (paths like `danmestas/agent-skills/skills/hipp`).
+2. **Translate.** Convert paths to bare skill names (`hipp`, `ousterhout`, etc.). The path-rewrite logic that turns `danmestas/agent-skills` into `agent-config` already exists; extract the bare-name parser into a helper if not already done.
+3. **Author modes.** Write `.scion/modes/<role>.yaml` for each canonical role. `name: <role>`, `description: "Default skills for the <role> harness."`, `skills:` populated from the translated list.
+4. **Edit manifests.** Each `.scion/templates/<role>/scion-agent.yaml`: add `default_mode: <role>`, remove `skills:`.
+5. **Update stager.** New mode-resolver pathway; remove the manifest-`skills:`-field reading path.
+6. **Test.** Golden-file equivalence per role (see Test strategy).
+
+Atomic. The PR is shippable when all 14 golden tests pass.
+
+## Test strategy
+
+### Unit — mode resolver
+
+`mode_resolver_test.go`:
+
+- Loads a fixture mode YAML, asserts parsed `name`/`description`/`skills`.
+- Filename-stem mismatch returns the validation error.
+- Missing mode file returns the not-found error.
+- Skill name not found returns the per-skill resolution error.
+
+### Integration — golden equivalence
+
+For each of the 14 canonical roles, a golden test verifies the staging directory contents are byte-identical pre- and post-migration:
+
+1. **Pre.** On `main`, spawn-dry-run for `<role>` produces a staging tree. Hash-tree captured as golden.
+2. **Post.** On the migration branch, spawn-dry-run for the same `<role>` (no `--mode` flag — defaults resolve via `default_mode`) produces a staging tree. Hash-tree must match the golden.
+
+Big-bang is safe iff all 14 goldens match. Mismatch indicates the migration translated paths or skill order incorrectly.
+
+### End-to-end — explicit vs. implicit mode
+
+`darken spawn x --type researcher` and `darken spawn x --type researcher --mode researcher` must produce byte-identical staging output. Both pathways go through the resolver after migration; the implicit form just reads `default_mode` from the manifest before calling the same code.
+
+### Ad-hoc — `--skills` union
+
+`darken spawn x --type researcher --skills extra-skill` produces the researcher mode's skills plus `extra-skill`, in that order, no duplicates.
+
+### Failure-path
+
+- Spawn with unknown `--mode unknown` exits non-zero with the mode-not-found error.
+- Spawn with mode that references a non-existent skill exits non-zero with the skill-not-found error.
+
+## Backward-compatibility
+
+- **Operators using `darken spawn --type <role>` with no flags.** Behavior preserved: role's `default_mode` resolves to the migrated mode, which lists the same skills the manifest's `skills:` field listed before. Staging output identical (golden tests enforce).
+- **External consumers of `.scion/templates/<role>/scion-agent.yaml`.** The `skills:` field is removed. If anything outside the cmd/darken codebase reads it, that breaks. Spec assumes nothing else reads it; verify during migration with a `grep -r "skills:" .scion/templates/` and a code-search for manifest-loading paths.
+- **Role-default mode rename.** A future operator-friendly taxonomy (`code`, `design`, etc.) would change `default_mode` values. That's an additive follow-up, not a breaking change for this spec.
+
+## Open questions for operator
+
+These are the proposed defaults; flag if any need flipping.
+
+1. **Default-mode naming convention.** `<role>` (proposed; e.g. `tdd-implementer`) vs `<role>-default` (more explicit; e.g. `tdd-implementer-default`).
+2. **`--skills` ad-hoc.** Yes (proposed; one flag, union step). vs No (single-source-of-truth purism — operators must author a new mode for any deviation).
+3. **PR shape.** Single PR with all 14 mode files + 14 manifest edits + stager change (proposed). vs Stager-change PR followed by 14 small migration PRs (one per role, parallelizable, easy to review individually).
+
+## File-paths cited
+
+- `.scion/templates/<role>/scion-agent.yaml` (14 files)
+- `.scion/modes/<name>.yaml` (new directory)
+- `cmd/darken/spawn.go` (CLI parsing)
+- `internal/substrate/staging/` (mode resolver lives here)
+- `agent-config/skills/<name>/` (skill source pool, unchanged)
+
+## References
+
+- Researcher-2 brief: `.scion/agents/researcher-2/workspace/docs/research-brief-suit.md`
+- suit (algorithm reference, not adopted): `https://github.com/danmestas/suit`, `src/lib/resolution.ts`, `src/lib/types.ts`
+- agent-config (skills source + existing modes): `https://github.com/danmestas/agent-config`, `modes/code/mode.md` for format-comparison

--- a/docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md
+++ b/docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md
@@ -19,63 +19,65 @@ The operator wants to apply skillsets per task, fast. Skills are already authore
 
 - At spawn time, the operator names a *mode*. The mode declares which skills the harness should see. The stager copies exactly those skills.
 - Default behavior preserved: no `--mode` flag means the role's default mode resolves, which produces the same staging output as today.
+- Modes can compose via `extends:` so that shared skill-prefixes (e.g. philosophy baselines used by every planner) are declared once.
 - One operator-facing command (`darken modes list`) to enumerate available modes.
 
 ## Non-goals
 
-- Category-based composition (suit's `categories ∩` model). Modes are explicit lists. Tagging skills with categories is a future evolution if explicit lists prove too rigid; this spec does not preclude it.
+- Category-based composition (suit's `categories ∩` model). Modes are explicit lists with optional `extends:` parent reference. Tagging skills with categories is a future evolution; this spec does not preclude it.
 - Marketplace registry. `agent-config/marketplace/` is a pattern worth borrowing later for a public skill index; out of scope here.
 - Mode authoring tools. `darken modes new`, `darken modes validate`, scaffolding — author by hand for v1.
 - System-prompt prepends per mode. suit's modes inject prose; darkish-factory's role manifests own that via `system-prompt.md`. Modes affect skills only.
 - Targeting modes to specific harness backends (`targets: [claude-code, codex]`). Role implies backend; mode-level targeting is double-spec.
+- Ad-hoc `--skills foo,bar` at spawn time. Single way to specify skills: name a mode. If composition becomes painful for one-offs, author a small mode (4-line YAML) and delete it after use, or use `extends:` to compose. A side-channel skills flag would create two ways to do one thing.
 
 ## Design
 
 ### Mode YAML schema
 
-Located at `.scion/modes/<name>.yaml`:
+Located at `.scion/modes/<name>.yaml`. The file's name on disk IS the mode's name — there is no `name` field in the YAML.
 
 ```yaml
-name: tdd-go
 description: "Go systems work — TDD-driven, philosophy-aware."
+extends: philosophy-base
 skills:
   - tdd
-  - ousterhout
   - idiomatic-go
-  - hipp
 ```
 
-Three required fields:
+Fields:
 
-- `name` — string, must match the filename stem. Used as the value of `--mode`.
-- `description` — one-liner shown by `darken modes list`.
-- `skills` — ordered list of skill names. Each name is resolved against the existing path resolver (currently `agent-config/skills/<name>/` via the `danmestas/agent-skills` rewrite).
+- `description` (required) — one-liner shown by `darken modes list`.
+- `skills` (required) — ordered list of skill names. Names are resolved against the existing path resolver (currently `agent-config/skills/<name>/` via the `danmestas/agent-skills` rewrite). Empty list is allowed when `extends:` provides everything.
+- `extends` (optional) — name of another mode to compose with. The resolved skill set is `extends'd-mode-skills ++ this-mode-skills`, then deduped (first occurrence wins). Single inheritance only — no multiple parents in v1.
 
-Schema is deliberately tight. Optional fields (`extends`, `targets`, `categories`, prose body) are deferred until concrete demand.
+Schema deliberately tight. Optional fields (`targets`, `categories`, prose body) are deferred until concrete demand.
 
 ### Resolution at spawn time
 
-`darken spawn <name> --type <role> [--mode <name>] [--skills foo,bar] "<task>"` resolves the skill set in this order:
+`darken spawn <name> --type <role> [--mode <name>] "<task>"` resolves the skill set in this order:
 
-1. **Pick mode.** If `--mode <m>` is passed, use `m`. Otherwise read `default_mode` from `.scion/templates/<role>/scion-agent.yaml`. Load `.scion/modes/<m>.yaml`.
-2. **Base set.** Mode's `skills:` list.
-3. **Ad-hoc additions.** If `--skills foo,bar` is passed, take the union with the base set. Duplicates collapse. Order preserved (mode's skills first, ad-hoc additions appended).
-4. **Stage.** For each resolved skill name, the existing path resolver locates the source dir; the stager copies it to `.scion/skills-staging/<harness>/<skill>/` as today.
-5. **Mount.** Container mounts the staging dir. No change below the stager.
+1. **Pick mode.** If `--mode <m>` is passed, use `m`. Otherwise read `default_mode` from `.scion/templates/<role>/scion-agent.yaml`.
+2. **Resolve skills.** Load the mode file. If it has `extends: <parent>`, recursively resolve the parent's skill set first; concatenate this mode's `skills:` after; dedupe (first occurrence wins). Cycle detection: if the recursion revisits a mode, abort with an error.
+3. **Stage.** For each resolved skill name, the existing path resolver locates the source dir; the stager copies it to `.scion/skills-staging/<harness>/<skill>/` as today.
+4. **Mount.** Container mounts the staging dir. No change below the stager.
 
 ### Validation
 
 - Missing mode file: `mode <name>: not found at .scion/modes/<name>.yaml`. Spawn aborts.
-- Mode references a skill that doesn't resolve: `mode <name>: skill <skill> not found at <resolved_path>`. Spawn aborts. Same failure shape as today's manifest path that doesn't resolve.
-- `name` field doesn't match filename stem: `mode <name>: name field "<X>" does not match filename "<Y>.yaml"`. Spawn aborts. Catches copy-paste errors.
+- Mode references a skill that doesn't resolve: `mode <name>: skill <skill> not found at <resolved_path>`. Spawn aborts.
+- `extends:` references a mode that doesn't exist: `mode <name>: extends "<parent>" not found at .scion/modes/<parent>.yaml`. Spawn aborts.
+- Cycle in `extends:` chain (`a → b → a`): `mode <name>: cycle detected in extends chain: a → b → a`. Spawn aborts.
 
 Validation runs at spawn time only — no separate `darken modes validate` command in v1.
 
 ### Default-mode naming convention
 
-The 14 canonical roles each get a default mode named *after the role*: `tdd-implementer`, `planner-t3`, `researcher`, etc. Mode and role share names but live in different files (`.scion/templates/<role>/scion-agent.yaml` vs `.scion/modes/<role>.yaml`). One-to-one mapping, mechanical migration.
+The 14 canonical roles each get a default mode named *after the role*: `tdd-implementer`, `planner-t3`, `researcher`, etc. Mode and role share names but live in different files (`.scion/templates/<role>/scion-agent.yaml` vs `.scion/modes/<role>.yaml`). One-to-one mapping; the role-default mode is the single artifact each role needs to function unchanged.
 
-This is intentionally not a taxonomy. Operator-friendly mode names (`code`, `design`, `plan`, `recon`) are a follow-up consolidation once duplicates among the 14 default modes emerge in practice.
+Where the role-default modes share skill prefixes (every planner uses `[hipp, ousterhout]`; every implementer uses `[tdd, idiomatic-go]`), the migration extracts those into shared base modes (e.g. `philosophy-base`, `implementer-base`) that the role-default modes `extends:`. See migration steps below.
+
+This is intentionally not a final taxonomy. Operator-friendly mode names (`code`, `design`, `plan`, `recon`) are a follow-up consolidation once usage clarifies which compositions are worth elevating to first-class names.
 
 ### Role manifest changes
 
@@ -97,13 +99,22 @@ skills:
 default_mode: planner-t3
 ```
 
-The `.scion/modes/planner-t3.yaml` file then carries the skill list.
+Then `.scion/modes/planner-t3.yaml`:
+
+```yaml
+description: "Default skills for the planner-t3 harness."
+extends: philosophy-base    # provides hipp, ousterhout
+skills:
+  - superpowers
+```
+
+(The exact base-mode partition is decided during migration — see migration steps.)
 
 ### CLI surface additions
 
-- `darken modes list` — print all `.scion/modes/*.yaml` with `name` and `description` columns.
-- `darken modes show <name>` — cat the mode file.
-- `darken spawn` gains `--mode <name>` and `--skills <comma-list>` flags.
+- `darken modes list` — print all `.scion/modes/*.yaml` with mode-name (filename stem) and `description` columns.
+- `darken modes show <name>` — cat the mode file. Resolved-skills output (the recursive `extends` expansion) shown as a separate block below the raw YAML.
+- `darken spawn` gains `--mode <name>` flag.
 
 Out for v1: `darken modes new`, `darken modes validate`, mode authoring scaffolds.
 
@@ -111,17 +122,18 @@ Out for v1: `darken modes new`, `darken modes validate`, mode authoring scaffold
 
 `internal/substrate/staging/` (where the path resolver lives) gains a `mode_resolver.go` that:
 
-- Loads a mode by name from `.scion/modes/<name>.yaml`.
-- Validates required fields and filename-stem match.
-- Returns the resolved skill name list.
+- Loads a mode by filename (`<name>.yaml`).
+- Recursively resolves `extends`, deduping with first-occurrence-wins.
+- Detects cycles.
+- Returns the final ordered skill name list.
 
-The existing path resolver — which knows how to find `<repo>/skills/<name>` locally and via the `agent-config` rewrite — gets called with the mode's skill names instead of the manifest's path strings. No new resolution logic; bare names go in, paths come out.
+The existing path resolver — which knows how to find `<repo>/skills/<name>` locally and via the `agent-config` rewrite — gets called with the mode's resolved skill names instead of the manifest's path strings. No new resolution logic; bare names go in, paths come out.
 
 The spawn entry point in `cmd/darken/spawn.go`:
 
-- Parses new flags `--mode` and `--skills`.
+- Parses the new `--mode` flag.
 - Resolves mode (explicit or via role's `default_mode`).
-- Computes the skill set per the resolution algorithm above.
+- Computes the resolved skill list via the mode resolver.
 - Hands off to the existing stager.
 
 ## Migration (big-bang)
@@ -130,12 +142,22 @@ Single PR. Steps:
 
 1. **Extract.** Read each of 14 role manifests; capture the current `skills:` list (paths like `danmestas/agent-skills/skills/hipp`).
 2. **Translate.** Convert paths to bare skill names (`hipp`, `ousterhout`, etc.). The path-rewrite logic that turns `danmestas/agent-skills` into `agent-config` already exists; extract the bare-name parser into a helper if not already done.
-3. **Author modes.** Write `.scion/modes/<role>.yaml` for each canonical role. `name: <role>`, `description: "Default skills for the <role> harness."`, `skills:` populated from the translated list.
-4. **Edit manifests.** Each `.scion/templates/<role>/scion-agent.yaml`: add `default_mode: <role>`, remove `skills:`.
-5. **Update stager.** New mode-resolver pathway; remove the manifest-`skills:`-field reading path.
-6. **Test.** Golden-file equivalence per role (see Test strategy).
+3. **Identify shared prefixes.** Group the 14 translated lists by common skill subsets. Likely partitions to expect:
+   - `philosophy-base`: `[hipp, ousterhout]` — used by every planner and reviewer.
+   - `implementer-base`: `[tdd, idiomatic-go]` plus whatever else implementers share — used by `tdd-implementer` and possibly `darwin`.
+   - others as observed in the data.
+
+   The exact partition is empirical: pick the smallest set of base modes that lets every role-default mode be expressed as `extends: <base>` plus 0–3 additions. If a role has nothing meaningful to share, it gets a flat role-default mode with no `extends:`.
+
+4. **Author base modes.** Write `.scion/modes/<base>.yaml` files for each shared partition. `description:` explaining what the base provides; `skills:` listing the shared prefix.
+5. **Author role-default modes.** Write `.scion/modes/<role>.yaml` for each of the 14 canonical roles. `description:` per role. `extends: <base>` if applicable. `skills:` listing only the additions on top of the parent.
+6. **Edit manifests.** Each `.scion/templates/<role>/scion-agent.yaml`: add `default_mode: <role>`, remove `skills:`.
+7. **Update stager.** New mode-resolver pathway with recursive `extends` resolution; remove the manifest-`skills:`-field reading path.
+8. **Test.** Golden-file equivalence per role (see Test strategy).
 
 Atomic. The PR is shippable when all 14 golden tests pass.
+
+The spec does not prescribe the base-mode partition because it depends on what the 14 current bundles actually look like. The migration step's first sub-task is to read the 14 manifests and observe the structure; the partition falls out of the data, not from speculation.
 
 ## Test strategy
 
@@ -143,10 +165,12 @@ Atomic. The PR is shippable when all 14 golden tests pass.
 
 `mode_resolver_test.go`:
 
-- Loads a fixture mode YAML, asserts parsed `name`/`description`/`skills`.
-- Filename-stem mismatch returns the validation error.
-- Missing mode file returns the not-found error.
-- Skill name not found returns the per-skill resolution error.
+- Flat mode (no `extends`) loads and returns its `skills:` list.
+- Mode with `extends: parent` recursively resolves; result is parent's skills first, then child's, with duplicates dropped (first wins).
+- Two-level chain (`a extends b extends c`) resolves through both levels.
+- Cycle (`a extends b extends a`) returns the cycle-detected error.
+- Missing parent file returns the not-found error.
+- Skill name that doesn't resolve returns the per-skill resolution error.
 
 ### Integration — golden equivalence
 
@@ -155,24 +179,21 @@ For each of the 14 canonical roles, a golden test verifies the staging directory
 1. **Pre.** On `main`, spawn-dry-run for `<role>` produces a staging tree. Hash-tree captured as golden.
 2. **Post.** On the migration branch, spawn-dry-run for the same `<role>` (no `--mode` flag — defaults resolve via `default_mode`) produces a staging tree. Hash-tree must match the golden.
 
-Big-bang is safe iff all 14 goldens match. Mismatch indicates the migration translated paths or skill order incorrectly.
+Big-bang is safe iff all 14 goldens match. Mismatch indicates the migration translated paths, partitioned base modes, or chained `extends` incorrectly.
 
 ### End-to-end — explicit vs. implicit mode
 
 `darken spawn x --type researcher` and `darken spawn x --type researcher --mode researcher` must produce byte-identical staging output. Both pathways go through the resolver after migration; the implicit form just reads `default_mode` from the manifest before calling the same code.
 
-### Ad-hoc — `--skills` union
-
-`darken spawn x --type researcher --skills extra-skill` produces the researcher mode's skills plus `extra-skill`, in that order, no duplicates.
-
 ### Failure-path
 
 - Spawn with unknown `--mode unknown` exits non-zero with the mode-not-found error.
 - Spawn with mode that references a non-existent skill exits non-zero with the skill-not-found error.
+- Spawn with mode whose `extends` chain has a cycle exits non-zero with the cycle-detected error.
 
 ## Backward-compatibility
 
-- **Operators using `darken spawn --type <role>` with no flags.** Behavior preserved: role's `default_mode` resolves to the migrated mode, which lists the same skills the manifest's `skills:` field listed before. Staging output identical (golden tests enforce).
+- **Operators using `darken spawn --type <role>` with no flags.** Behavior preserved: role's `default_mode` resolves to the migrated mode, which (after `extends` expansion) lists the same skills the manifest's `skills:` field listed before. Staging output identical (golden tests enforce).
 - **External consumers of `.scion/templates/<role>/scion-agent.yaml`.** The `skills:` field is removed. If anything outside the cmd/darken codebase reads it, that breaks. Spec assumes nothing else reads it; verify during migration with a `grep -r "skills:" .scion/templates/` and a code-search for manifest-loading paths.
 - **Role-default mode rename.** A future operator-friendly taxonomy (`code`, `design`, etc.) would change `default_mode` values. That's an additive follow-up, not a breaking change for this spec.
 
@@ -181,13 +202,12 @@ Big-bang is safe iff all 14 goldens match. Mismatch indicates the migration tran
 These are the proposed defaults; flag if any need flipping.
 
 1. **Default-mode naming convention.** `<role>` (proposed; e.g. `tdd-implementer`) vs `<role>-default` (more explicit; e.g. `tdd-implementer-default`).
-2. **`--skills` ad-hoc.** Yes (proposed; one flag, union step). vs No (single-source-of-truth purism — operators must author a new mode for any deviation).
-3. **PR shape.** Single PR with all 14 mode files + 14 manifest edits + stager change (proposed). vs Stager-change PR followed by 14 small migration PRs (one per role, parallelizable, easy to review individually).
+2. **PR shape.** Single PR with base modes + 14 role-default modes + 14 manifest edits + stager change (proposed). vs Stager-change PR followed by 14 small migration PRs (one per role). Big-bang matches the operator-approved (i) migration scope.
 
 ## File-paths cited
 
 - `.scion/templates/<role>/scion-agent.yaml` (14 files)
-- `.scion/modes/<name>.yaml` (new directory)
+- `.scion/modes/<name>.yaml` (new directory; ~5 base modes + 14 role-default modes after migration)
 - `cmd/darken/spawn.go` (CLI parsing)
 - `internal/substrate/staging/` (mode resolver lives here)
 - `agent-config/skills/<name>/` (skill source pool, unchanged)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/danmestas/darken
 
 go 1.23
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/substrate/data/.scion/modes/admin.yaml
+++ b/internal/substrate/data/.scion/modes/admin.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the admin harness."
+skills: []

--- a/internal/substrate/data/.scion/modes/base.yaml
+++ b/internal/substrate/data/.scion/modes/base.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the base harness."
+skills: []

--- a/internal/substrate/data/.scion/modes/darwin.yaml
+++ b/internal/substrate/data/.scion/modes/darwin.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the darwin harness."
+skills:
+  - dx-audit

--- a/internal/substrate/data/.scion/modes/designer.yaml
+++ b/internal/substrate/data/.scion/modes/designer.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the designer harness."
+skills:
+  - norman
+  - ousterhout

--- a/internal/substrate/data/.scion/modes/orchestrator.yaml
+++ b/internal/substrate/data/.scion/modes/orchestrator.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the orchestrator harness."
+skills:
+  - dx-audit

--- a/internal/substrate/data/.scion/modes/philosophy-base.yaml
+++ b/internal/substrate/data/.scion/modes/philosophy-base.yaml
@@ -1,0 +1,4 @@
+description: "Hipp + Ousterhout — design philosophy baseline shared by planners."
+skills:
+  - hipp
+  - ousterhout

--- a/internal/substrate/data/.scion/modes/planner-t1.yaml
+++ b/internal/substrate/data/.scion/modes/planner-t1.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the planner-t1 harness."
+skills:
+  - hipp

--- a/internal/substrate/data/.scion/modes/planner-t2.yaml
+++ b/internal/substrate/data/.scion/modes/planner-t2.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the planner-t2 harness."
+extends: philosophy-base
+skills: []

--- a/internal/substrate/data/.scion/modes/planner-t3.yaml
+++ b/internal/substrate/data/.scion/modes/planner-t3.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the planner-t3 harness."
+extends: philosophy-base
+skills:
+  - superpowers

--- a/internal/substrate/data/.scion/modes/planner-t4.yaml
+++ b/internal/substrate/data/.scion/modes/planner-t4.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the planner-t4 harness."
+extends: philosophy-base
+skills:
+  - spec-kit

--- a/internal/substrate/data/.scion/modes/researcher.yaml
+++ b/internal/substrate/data/.scion/modes/researcher.yaml
@@ -1,0 +1,2 @@
+description: "Default skills for the researcher harness."
+skills: []

--- a/internal/substrate/data/.scion/modes/reviewer.yaml
+++ b/internal/substrate/data/.scion/modes/reviewer.yaml
@@ -1,0 +1,5 @@
+description: "Default skills for the reviewer harness."
+skills:
+  - ousterhout
+  - hipp
+  - dx-audit

--- a/internal/substrate/data/.scion/modes/sme.yaml
+++ b/internal/substrate/data/.scion/modes/sme.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the sme harness."
+skills:
+  - ousterhout
+  - hipp

--- a/internal/substrate/data/.scion/modes/tdd-implementer.yaml
+++ b/internal/substrate/data/.scion/modes/tdd-implementer.yaml
@@ -1,0 +1,4 @@
+description: "Default skills for the tdd-implementer harness."
+skills:
+  - idiomatic-go
+  - tigerstyle

--- a/internal/substrate/data/.scion/modes/verifier.yaml
+++ b/internal/substrate/data/.scion/modes/verifier.yaml
@@ -1,0 +1,3 @@
+description: "Default skills for the verifier harness."
+skills:
+  - tigerstyle

--- a/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/admin/scion-agent.yaml
@@ -8,5 +8,6 @@ model: claude-haiku-4-5-20251001
 max_turns: 100
 max_duration: "8h"
 detached: true
+default_mode: admin
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/base/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/base/scion-agent.yaml
@@ -8,5 +8,6 @@ default_harness_config: claude
 model: claude-sonnet-4-6
 max_turns: 50
 max_duration: 3600
+default_mode: base
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/darwin/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/darwin/scion-agent.yaml
@@ -8,8 +8,7 @@ model: gpt-5.5
 max_turns: 50
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: darwin
 volumes:
   - source: ./.scion/skills-staging/darwin/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/designer/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/norman
-  - danmestas/agent-skills/skills/ousterhout
+default_mode: designer
 volumes:
   - source: ./.scion/skills-staging/designer/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/orchestrator/scion-agent.yaml
@@ -8,8 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 200
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: orchestrator
 volumes:
   - source: ./.scion/skills-staging/orchestrator/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/planner-t1/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t1/scion-agent.yaml
@@ -8,8 +8,7 @@ model: claude-sonnet-4-6
 max_turns: 15
 max_duration: "30m"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
+default_mode: planner-t1
 volumes:
   - source: ./.scion/skills-staging/planner-t1/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t2/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 30
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
+default_mode: planner-t2
 volumes:
   - source: ./.scion/skills-staging/planner-t2/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t3/scion-agent.yaml
@@ -8,10 +8,7 @@ model: claude-opus-4-7[1m]
 max_turns: 50
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/superpowers
+default_mode: planner-t3
 volumes:
   - source: ./.scion/skills-staging/planner-t3/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/planner-t4/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/planner-t4/scion-agent.yaml
@@ -8,10 +8,7 @@ model: gpt-5.5
 max_turns: 100
 max_duration: "4h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/spec-kit
+default_mode: planner-t4
 volumes:
   - source: ./.scion/skills-staging/planner-t4/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/researcher/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/researcher/scion-agent.yaml
@@ -8,5 +8,6 @@ model: claude-sonnet-4-6
 max_turns: 30
 max_duration: "1h"
 detached: false
+default_mode: researcher
 hub:
   endpoint: ${DARKEN_HUB_ENDPOINT}

--- a/internal/substrate/data/.scion/templates/reviewer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/reviewer/scion-agent.yaml
@@ -8,10 +8,7 @@ model: gpt-5.5
 max_turns: 30
 max_duration: "1h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/hipp
-  - danmestas/agent-skills/skills/dx-audit
+default_mode: reviewer
 volumes:
   - source: ./.scion/skills-staging/reviewer/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/sme/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/sme/scion-agent.yaml
@@ -8,9 +8,7 @@ model: gpt-5.5
 max_turns: 10
 max_duration: "15m"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/ousterhout
-  - danmestas/agent-skills/skills/hipp
+default_mode: sme
 volumes:
   - source: ./.scion/skills-staging/sme/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/tdd-implementer/scion-agent.yaml
@@ -8,9 +8,7 @@ model: claude-sonnet-4-6[1m]
 max_turns: 100
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/idiomatic-go
-  - danmestas/agent-skills/skills/tigerstyle
+default_mode: tdd-implementer
 volumes:
   - source: ./.scion/skills-staging/tdd-implementer/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/.scion/templates/verifier/scion-agent.yaml
+++ b/internal/substrate/data/.scion/templates/verifier/scion-agent.yaml
@@ -8,8 +8,7 @@ model: gpt-5.5
 max_turns: 50
 max_duration: "2h"
 detached: false
-skills:
-  - danmestas/agent-skills/skills/tigerstyle
+default_mode: verifier
 volumes:
   - source: ./.scion/skills-staging/verifier/
     target: /home/scion/skills/role/

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -61,6 +61,19 @@ if [[ ! -d "${MANIFEST_DIR}" ]]; then
   exit 1
 fi
 
+# Resolve the modes dir. Bootstrap's extractEmbeddedTemplates extracts
+# the substrate as <tmp>/templates/ and <tmp>/modes/ side-by-side and
+# exports DARKEN_MODES_DIR; if that's set, prefer it. Otherwise infer
+# from DARKEN_TEMPLATES_DIR's sibling dir; otherwise fall back to the
+# repo-root layout (${REPO}/.scion/modes).
+if [[ -n "${DARKEN_MODES_DIR:-}" ]]; then
+  MODES_DIR="${DARKEN_MODES_DIR}"
+elif [[ -n "${DARKEN_TEMPLATES_DIR:-}" ]]; then
+  MODES_DIR="$(dirname "${DARKEN_TEMPLATES_DIR}")/modes"
+else
+  MODES_DIR="${REPO}/.scion/modes"
+fi
+
 STAGE_DIR="${REPO}/.scion/skills-staging/${HARNESS}"
 
 resolve_ref() {
@@ -80,37 +93,118 @@ resolve_ref() {
 }
 
 read_skills_from_manifest() {
+  # Resolution path is now: manifest -> default_mode -> .scion/modes/<mode>.yaml
+  # with full extends-chain expansion and dedup-first-wins. Mirrors the Go
+  # implementation in internal/substrate/modes.go.
+  #
+  # Output: skill names, one per line on stdout.
+  # Errors: stderr + exit 1.
   local manifest="${MANIFEST_DIR}/scion-agent.yaml"
   if [[ ! -f "${manifest}" ]]; then
     echo "stage-skills: manifest not found at ${manifest}" >&2
     return 1
   fi
-  # Use python3 to parse YAML (available on macOS without extra deps).
-  # Falls back gracefully if skills key is absent.
-  python3 - "${manifest}" <<'PYEOF'
-import sys, json
+  if [[ ! -d "${MODES_DIR}" ]]; then
+    echo "stage-skills: modes dir not found at ${MODES_DIR}" >&2
+    return 1
+  fi
+  python3 - "${manifest}" "${MODES_DIR}" "${HARNESS}" <<'PYEOF'
+import os
+import re
+import sys
+
+manifest_path = sys.argv[1]
+modes_dir = sys.argv[2]
+harness = sys.argv[3]
+
 try:
     import yaml
-    with open(sys.argv[1]) as f:
-        data = yaml.safe_load(f)
-    skills = data.get('skills') or []
-    for s in skills:
-        print(s)
+    HAVE_YAML = True
 except ImportError:
-    # No PyYAML — fall back to grep-based extraction
-    import re
-    in_skills = False
-    with open(sys.argv[1]) as f:
-        for line in f:
-            if re.match(r'^skills\s*:', line):
-                in_skills = True
+    HAVE_YAML = False
+
+
+def load_yaml(path):
+    if HAVE_YAML:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    # Minimal fallback parser: handles `key: value`, `key:` followed by
+    # `  - item` lines, and quoted scalar values. Sufficient for mode
+    # files and the manifest's default_mode lookup.
+    data = {}
+    cur_list_key = None
+    with open(path) as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
                 continue
-            if in_skills:
-                m = re.match(r'^\s+-\s+(.+)', line)
-                if m:
-                    print(m.group(1).strip())
-                elif re.match(r'^\S', line):
-                    break
+            if line.startswith(" ") or line.startswith("\t"):
+                m = re.match(r"\s+-\s+(.+)$", line)
+                if m and cur_list_key is not None:
+                    val = m.group(1).strip().strip('"').strip("'")
+                    data.setdefault(cur_list_key, []).append(val)
+                continue
+            cur_list_key = None
+            m = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$", line)
+            if not m:
+                continue
+            key, val = m.group(1), m.group(2).strip()
+            if val == "":
+                cur_list_key = key
+                data.setdefault(key, [])
+            elif val == "[]":
+                data[key] = []
+            else:
+                data[key] = val.strip('"').strip("'")
+    return data
+
+
+def resolve(name, visited=None, stack=None):
+    if visited is None:
+        visited = set()
+    if stack is None:
+        stack = []
+    if name in visited:
+        chain = " -> ".join(stack + [name])
+        raise RuntimeError(f"cycle detected in extends chain: {chain}")
+    visited.add(name)
+    stack = stack + [name]
+    path = os.path.join(modes_dir, f"{name}.yaml")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"mode {name!r} not found at {path}")
+    m = load_yaml(path)
+    skills = []
+    parent = m.get("extends")
+    if parent:
+        skills.extend(resolve(parent, visited, stack))
+    own = m.get("skills") or []
+    if isinstance(own, str):
+        own = [own]
+    skills.extend(own)
+    seen = set()
+    out = []
+    for s in skills:
+        if s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+try:
+    manifest = load_yaml(manifest_path)
+    mode = manifest.get("default_mode")
+    if not mode:
+        print(
+            f"stage-skills: no default_mode declared for {harness}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+    for s in resolve(mode):
+        print(s)
+except Exception as exc:
+    print(f"stage-skills: {exc}", file=sys.stderr)
+    sys.exit(1)
 PYEOF
 }
 

--- a/internal/substrate/data/scripts/stage-skills.sh
+++ b/internal/substrate/data/scripts/stage-skills.sh
@@ -192,8 +192,12 @@ def resolve(name, visited=None, stack=None):
 
 
 try:
-    manifest = load_yaml(manifest_path)
-    mode = manifest.get("default_mode")
+    override = os.environ.get("DARKEN_MODE_OVERRIDE")
+    if override:
+        mode = override
+    else:
+        manifest = load_yaml(manifest_path)
+        mode = manifest.get("default_mode")
     if not mode:
         print(
             f"stage-skills: no default_mode declared for {harness}",

--- a/internal/substrate/modes.go
+++ b/internal/substrate/modes.go
@@ -1,0 +1,87 @@
+package substrate
+
+import (
+	"fmt"
+	"io/fs"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Mode is a parsed .scion/modes/<name>.yaml file. The mode's name is the
+// filename stem; there is no name field in the YAML itself.
+type Mode struct {
+	Description string   `yaml:"description"`
+	Extends     string   `yaml:"extends,omitempty"`
+	Skills      []string `yaml:"skills"`
+}
+
+// loadModeFromFS reads <name>.yaml from fsys and parses it.
+func loadModeFromFS(fsys fs.FS, name string) (*Mode, error) {
+	data, err := fs.ReadFile(fsys, name+".yaml")
+	if err != nil {
+		return nil, fmt.Errorf("mode %q: %w", name, err)
+	}
+	var m Mode
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("mode %q: parse: %w", name, err)
+	}
+	return &m, nil
+}
+
+// ResolveSkillsFromFS resolves the given mode name into an ordered, deduped
+// skill name list. extends chains are walked recursively; first occurrence
+// of a duplicate name wins. Cycles are detected and rejected.
+func ResolveSkillsFromFS(fsys fs.FS, name string) ([]string, error) {
+	visited := map[string]bool{}
+	var stack []string
+	return resolveRecursive(fsys, name, visited, stack)
+}
+
+func resolveRecursive(fsys fs.FS, name string, visited map[string]bool, stack []string) ([]string, error) {
+	if visited[name] {
+		return nil, fmt.Errorf("mode %q: cycle detected in extends chain: %s -> %s",
+			stack[0], joinChain(stack), name)
+	}
+	visited[name] = true
+	stack = append(stack, name)
+
+	m, err := loadModeFromFS(fsys, name)
+	if err != nil {
+		return nil, err
+	}
+
+	var skills []string
+	if m.Extends != "" {
+		parentSkills, err := resolveRecursive(fsys, m.Extends, visited, stack)
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, parentSkills...)
+	}
+	skills = append(skills, m.Skills...)
+	return dedupePreserveFirst(skills), nil
+}
+
+func dedupePreserveFirst(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+func joinChain(stack []string) string {
+	if len(stack) == 0 {
+		return ""
+	}
+	out := stack[0]
+	for _, s := range stack[1:] {
+		out += " -> " + s
+	}
+	return out
+}

--- a/internal/substrate/modes_test.go
+++ b/internal/substrate/modes_test.go
@@ -1,0 +1,148 @@
+package substrate
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestResolveSkills_FlatMode(t *testing.T) {
+	fs := fstest.MapFS{
+		"go-systems.yaml": &fstest.MapFile{Data: []byte(`description: Go systems work
+skills:
+  - tdd
+  - idiomatic-go
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "go-systems")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"tdd", "idiomatic-go"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_ExtendsParent(t *testing.T) {
+	fs := fstest.MapFS{
+		"philosophy.yaml": &fstest.MapFile{Data: []byte(`description: shared philosophy
+skills:
+  - hipp
+  - ousterhout
+`)},
+		"planner.yaml": &fstest.MapFile{Data: []byte(`description: planner
+extends: philosophy
+skills:
+  - superpowers
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "planner")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"hipp", "ousterhout", "superpowers"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_DedupesFirstWins(t *testing.T) {
+	fs := fstest.MapFS{
+		"base.yaml": &fstest.MapFile{Data: []byte(`description: base
+skills:
+  - hipp
+  - ousterhout
+`)},
+		"override.yaml": &fstest.MapFile{Data: []byte(`description: override
+extends: base
+skills:
+  - ousterhout
+  - extra
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "override")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"hipp", "ousterhout", "extra"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestResolveSkills_DetectsCycle(t *testing.T) {
+	fs := fstest.MapFS{
+		"a.yaml": &fstest.MapFile{Data: []byte(`description: a
+extends: b
+skills: []
+`)},
+		"b.yaml": &fstest.MapFile{Data: []byte(`description: b
+extends: a
+skills: []
+`)},
+	}
+	_, err := ResolveSkillsFromFS(fs, "a")
+	if err == nil {
+		t.Fatal("expected cycle error; got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention cycle: %v", err)
+	}
+}
+
+func TestResolveSkills_MissingMode(t *testing.T) {
+	fs := fstest.MapFS{}
+	_, err := ResolveSkillsFromFS(fs, "nope")
+	if err == nil {
+		t.Fatal("expected not-found error; got nil")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error should mention mode name: %v", err)
+	}
+}
+
+func TestResolveSkills_MissingParent(t *testing.T) {
+	fs := fstest.MapFS{
+		"child.yaml": &fstest.MapFile{Data: []byte(`description: child
+extends: ghost
+skills: []
+`)},
+	}
+	_, err := ResolveSkillsFromFS(fs, "child")
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should mention missing parent: %v", err)
+	}
+}
+
+func TestResolveSkills_MultiLevelChain(t *testing.T) {
+	fs := fstest.MapFS{
+		"grandparent.yaml": &fstest.MapFile{Data: []byte(`description: gp
+skills:
+  - a
+`)},
+		"parent.yaml": &fstest.MapFile{Data: []byte(`description: p
+extends: grandparent
+skills:
+  - b
+`)},
+		"child.yaml": &fstest.MapFile{Data: []byte(`description: c
+extends: parent
+skills:
+  - c
+`)},
+	}
+	got, err := ResolveSkillsFromFS(fs, "child")
+	if err != nil {
+		t.Fatalf("ResolveSkillsFromFS: %v", err)
+	}
+	want := []string{"a", "b", "c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v; want %v", got, want)
+	}
+	_ = filepath.Join // avoid unused-import error
+}

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -61,6 +61,19 @@ if [[ ! -d "${MANIFEST_DIR}" ]]; then
   exit 1
 fi
 
+# Resolve the modes dir. Bootstrap's extractEmbeddedTemplates extracts
+# the substrate as <tmp>/templates/ and <tmp>/modes/ side-by-side and
+# exports DARKEN_MODES_DIR; if that's set, prefer it. Otherwise infer
+# from DARKEN_TEMPLATES_DIR's sibling dir; otherwise fall back to the
+# repo-root layout (${REPO}/.scion/modes).
+if [[ -n "${DARKEN_MODES_DIR:-}" ]]; then
+  MODES_DIR="${DARKEN_MODES_DIR}"
+elif [[ -n "${DARKEN_TEMPLATES_DIR:-}" ]]; then
+  MODES_DIR="$(dirname "${DARKEN_TEMPLATES_DIR}")/modes"
+else
+  MODES_DIR="${REPO}/.scion/modes"
+fi
+
 STAGE_DIR="${REPO}/.scion/skills-staging/${HARNESS}"
 
 resolve_ref() {
@@ -80,37 +93,118 @@ resolve_ref() {
 }
 
 read_skills_from_manifest() {
+  # Resolution path is now: manifest -> default_mode -> .scion/modes/<mode>.yaml
+  # with full extends-chain expansion and dedup-first-wins. Mirrors the Go
+  # implementation in internal/substrate/modes.go.
+  #
+  # Output: skill names, one per line on stdout.
+  # Errors: stderr + exit 1.
   local manifest="${MANIFEST_DIR}/scion-agent.yaml"
   if [[ ! -f "${manifest}" ]]; then
     echo "stage-skills: manifest not found at ${manifest}" >&2
     return 1
   fi
-  # Use python3 to parse YAML (available on macOS without extra deps).
-  # Falls back gracefully if skills key is absent.
-  python3 - "${manifest}" <<'PYEOF'
-import sys, json
+  if [[ ! -d "${MODES_DIR}" ]]; then
+    echo "stage-skills: modes dir not found at ${MODES_DIR}" >&2
+    return 1
+  fi
+  python3 - "${manifest}" "${MODES_DIR}" "${HARNESS}" <<'PYEOF'
+import os
+import re
+import sys
+
+manifest_path = sys.argv[1]
+modes_dir = sys.argv[2]
+harness = sys.argv[3]
+
 try:
     import yaml
-    with open(sys.argv[1]) as f:
-        data = yaml.safe_load(f)
-    skills = data.get('skills') or []
-    for s in skills:
-        print(s)
+    HAVE_YAML = True
 except ImportError:
-    # No PyYAML — fall back to grep-based extraction
-    import re
-    in_skills = False
-    with open(sys.argv[1]) as f:
-        for line in f:
-            if re.match(r'^skills\s*:', line):
-                in_skills = True
+    HAVE_YAML = False
+
+
+def load_yaml(path):
+    if HAVE_YAML:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    # Minimal fallback parser: handles `key: value`, `key:` followed by
+    # `  - item` lines, and quoted scalar values. Sufficient for mode
+    # files and the manifest's default_mode lookup.
+    data = {}
+    cur_list_key = None
+    with open(path) as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
                 continue
-            if in_skills:
-                m = re.match(r'^\s+-\s+(.+)', line)
-                if m:
-                    print(m.group(1).strip())
-                elif re.match(r'^\S', line):
-                    break
+            if line.startswith(" ") or line.startswith("\t"):
+                m = re.match(r"\s+-\s+(.+)$", line)
+                if m and cur_list_key is not None:
+                    val = m.group(1).strip().strip('"').strip("'")
+                    data.setdefault(cur_list_key, []).append(val)
+                continue
+            cur_list_key = None
+            m = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$", line)
+            if not m:
+                continue
+            key, val = m.group(1), m.group(2).strip()
+            if val == "":
+                cur_list_key = key
+                data.setdefault(key, [])
+            elif val == "[]":
+                data[key] = []
+            else:
+                data[key] = val.strip('"').strip("'")
+    return data
+
+
+def resolve(name, visited=None, stack=None):
+    if visited is None:
+        visited = set()
+    if stack is None:
+        stack = []
+    if name in visited:
+        chain = " -> ".join(stack + [name])
+        raise RuntimeError(f"cycle detected in extends chain: {chain}")
+    visited.add(name)
+    stack = stack + [name]
+    path = os.path.join(modes_dir, f"{name}.yaml")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"mode {name!r} not found at {path}")
+    m = load_yaml(path)
+    skills = []
+    parent = m.get("extends")
+    if parent:
+        skills.extend(resolve(parent, visited, stack))
+    own = m.get("skills") or []
+    if isinstance(own, str):
+        own = [own]
+    skills.extend(own)
+    seen = set()
+    out = []
+    for s in skills:
+        if s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+try:
+    manifest = load_yaml(manifest_path)
+    mode = manifest.get("default_mode")
+    if not mode:
+        print(
+            f"stage-skills: no default_mode declared for {harness}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+    for s in resolve(mode):
+        print(s)
+except Exception as exc:
+    print(f"stage-skills: {exc}", file=sys.stderr)
+    sys.exit(1)
 PYEOF
 }
 

--- a/scripts/stage-skills.sh
+++ b/scripts/stage-skills.sh
@@ -192,8 +192,12 @@ def resolve(name, visited=None, stack=None):
 
 
 try:
-    manifest = load_yaml(manifest_path)
-    mode = manifest.get("default_mode")
+    override = os.environ.get("DARKEN_MODE_OVERRIDE")
+    if override:
+        mode = override
+    else:
+        manifest = load_yaml(manifest_path)
+        mode = manifest.get("default_mode")
     if not mode:
         print(
             f"stage-skills: no default_mode declared for {harness}",


### PR DESCRIPTION
## Summary

- Replaces per-role static skill bundling with operator-selectable named modes in \`.scion/modes/<name>.yaml\`. Modes can compose via \`extends:\`. Operator picks at spawn with \`--mode <name>\`; absence falls through to the role's \`default_mode\`.
- Spec at \`docs/superpowers/specs/2026-05-01-dynamic-skill-resolution.md\` (Ousterhout-revised — single-inheritance composition, no \`name\` field, no ad-hoc \`--skills\` flag).
- Plan at \`docs/superpowers/plans/2026-05-01-dynamic-skill-resolution.md\`.

## Changes

- \`internal/substrate/modes.go\` + tests: mode YAML schema (\`description\`, \`extends\`, \`skills\`); \`ResolveSkillsFromFS\` walks \`extends\` recursively, dedupes first-occurrence-wins, detects cycles.
- \`.scion/modes/\` (new dir): 1 base mode (\`philosophy-base\` = \`[hipp, ousterhout]\`) used by planner-t2/t3/t4; 14 role-default modes mirroring current bundles.
- \`.scion/templates/<role>/scion-agent.yaml\` × 14: \`skills:\` field removed; \`default_mode: <role>\` added.
- \`internal/substrate/data/.scion/{modes,templates}/\`: embedded mirror for non-darkish-factory projects.
- \`scripts/stage-skills.sh\` + embedded copy: reads \`default_mode\` (or \`DARKEN_MODE_OVERRIDE\` env) and resolves through the modes tree with extends-chain expansion.
- \`cmd/darken/bootstrap.go\`: new \`extractEmbeddedSubstrate\` extracts both \`templates\` and \`modes\` side-by-side; \`withSubstrateDirsEnv\` exports both \`DARKEN_TEMPLATES_DIR\` and \`DARKEN_MODES_DIR\`. Legacy single-dir wrappers preserved as shims.
- \`cmd/darken/spawn.go\` + tests: \`--mode <name>\` flag overrides the role's \`default_mode\` via \`DARKEN_MODE_OVERRIDE\` env.
- \`cmd/darken/skill_staging.go\`: routes through script always (Go-path \`buildSkillsStaging\` is dead code post-migration; needs mode-awareness as a follow-up).
- \`cmd/darken/modes.go\` + tests: \`darken modes list\` and \`darken modes show <name>\` commands.

## Test plan

- [x] \`go test ./... -count=1\` green across cmd/darken (200+ tests), internal/staging, internal/substrate
- [x] \`go build ./...\` clean
- [x] E2E: \`darken bootstrap\` in fresh tmpdir stages correct mode-driven skills per role:
  - planner-t3 → hipp, ousterhout, superpowers (extends \`philosophy-base\`)
  - reviewer → ousterhout, hipp, dx-audit
  - tdd-implementer → idiomatic-go, tigerstyle
  - admin/base/researcher → empty (intentional)
- [x] \`darken spawn --type researcher --mode tdd-implementer\` overrides correctly (stages tdd-implementer's skills onto the researcher harness)
- [x] \`darken modes list\` prints all 15 modes with descriptions
- [x] \`darken modes show planner-t3\` prints the YAML and resolved \`[hipp, ousterhout, superpowers]\`

## Follow-ups (not blocking)

- Make \`buildSkillsStaging\` mode-aware so the Go-path optimization can return.
- Mirror or canonicalize \`agent-config/skills/spec-kit\` (substrate drift, same pattern as \`superpowers\` symlink).