### PR TITLE
fix(makefile): include .scion/modes/ in sync-embed-data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ sync-embed-data:
 		$(SUBSTRATE_DATA)/images $(SUBSTRATE_DATA)/skills \
 		$(SUBSTRATE_DATA)/templates; \
 	cp -R .scion/templates $(SUBSTRATE_DATA)/.scion/; \
+	cp -R .scion/modes $(SUBSTRATE_DATA)/.scion/; \
 	cp scripts/bootstrap.sh scripts/spawn.sh scripts/stage-creds.sh \
 		scripts/stage-skills.sh $(SUBSTRATE_DATA)/scripts/; \
 	cp images/Makefile images/README.md $(SUBSTRATE_DATA)/images/; \


### PR DESCRIPTION
## Summary

- v0.1.23 release tag failed because \`scripts/test-embed-drift.sh\` detected drift between \`internal/substrate/data/.scion/modes/\` (added in #41) and what \`make sync-embed-data\` would produce.
- Root cause: the Makefile target was never updated to copy \`.scion/modes/\` into the embedded tree alongside \`.scion/templates/\`.
- One-line fix: add \`cp -R .scion/modes \$(SUBSTRATE_DATA)/.scion/\` next to the templates copy.

## Test plan

- [x] \`make sync-embed-data\` runs cleanly
- [x] \`bash scripts/test-embed-drift.sh\` reports PASS
- [x] After merge, retag (v0.1.23 already burned by the failed run; new tag e.g. v0.1.24 to ship the spec 1+2 changes via the homebrew tap)