### PR TITLE
fix(up): harden bootstrap against empty templates dir, noisy stderr, stale bones

### DIFF
--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -172,17 +172,24 @@ func withTemplatesDirEnv(dir string, fn func() error) error {
 
 // resolveSubstrateDirs returns paths to the templates and modes dirs.
 // Prefers the operator's project layout (.scion/templates + .scion/modes)
-// if present; otherwise extracts the embedded substrate to a tmpdir
-// laid out as <tmp>/templates/ and <tmp>/modes/. The returned cleanup
-// func is a no-op for the project case and an os.RemoveAll for the
-// embedded case.
+// when it has at least one role subdir; otherwise extracts the embedded
+// substrate to a tmpdir laid out as <tmp>/templates/ and <tmp>/modes/.
+// The returned cleanup func is a no-op for the project case and an
+// os.RemoveAll for the embedded case.
+//
+// Why the role-subdir guard: a workspace bootstrapped by `darken init`
+// (or hand-created) may have an empty .scion/templates/ before any
+// role canon is staged in. Returning that empty dir downstream causes
+// `scion templates import --all` to fail with "no importable agent
+// definitions". Falling back to the embedded substrate keeps `darken up`
+// working for fresh workspaces.
 func resolveSubstrateDirs() (string, string, func(), error) {
 	noop := func() {}
 
 	if root, err := repoRoot(); err == nil {
 		projectTemplates := filepath.Join(root, ".scion", "templates")
 		projectModes := filepath.Join(root, ".scion", "modes")
-		if info, statErr := os.Stat(projectTemplates); statErr == nil && info.IsDir() {
+		if info, statErr := os.Stat(projectTemplates); statErr == nil && info.IsDir() && hasRoleSubdirs(projectTemplates) {
 			// Modes dir may not exist yet on a project mid-migration;
 			// pass through whatever's there and let the script error if
 			// it actually needs it.
@@ -191,6 +198,23 @@ func resolveSubstrateDirs() (string, string, func(), error) {
 	}
 
 	return extractEmbeddedSubstrate()
+}
+
+// hasRoleSubdirs reports whether dir contains at least one subdirectory
+// other than "base". `base` is the shared common-skill bundle, not a
+// canonical role, so a templates dir holding only `base/` is still
+// effectively empty for import purposes.
+func hasRoleSubdirs(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() && e.Name() != "base" {
+			return true
+		}
+	}
+	return false
 }
 
 // extractEmbeddedSubstrate copies both data/.scion/templates and

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -83,6 +83,121 @@ func TestBootstrap_BrokerProvideStep(t *testing.T) {
 	}
 }
 
+// TestResolveSubstrateDirs_FallsBackOnEmptyProjectDir guards against the
+// `darken up` failure mode where a workspace's `.scion/templates/` exists
+// but is empty (e.g. a fresh `darken init` workspace). resolveSubstrateDirs
+// must fall back to the embedded substrate so downstream `scion templates
+// import --all` has role subdirs to read.
+func TestResolveSubstrateDirs_FallsBackOnEmptyProjectDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	// Create the templates dir but leave it empty.
+	if err := os.MkdirAll(filepath.Join(root, ".scion", "templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	templatesDir, _, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		t.Fatalf("resolveSubstrateDirs: %v", err)
+	}
+	defer cleanup()
+
+	// Fallback path lives under os.TempDir(); the project dir does not.
+	if strings.HasPrefix(templatesDir, root) {
+		t.Fatalf("expected fallback to embedded substrate when project dir is empty, got %q", templatesDir)
+	}
+	// Embedded substrate must contain at least one role subdir.
+	if !hasRoleSubdirs(templatesDir) {
+		t.Fatalf("embedded substrate templatesDir has no role subdirs: %s", templatesDir)
+	}
+}
+
+// TestResolveSubstrateDirs_FallsBackOnBaseOnlyProjectDir confirms that a
+// templates dir holding only the shared `base/` skill bundle still triggers
+// the embedded fallback — `base` is not a canonical role.
+func TestResolveSubstrateDirs_FallsBackOnBaseOnlyProjectDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	if err := os.MkdirAll(filepath.Join(root, ".scion", "templates", "base"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	templatesDir, _, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		t.Fatalf("resolveSubstrateDirs: %v", err)
+	}
+	defer cleanup()
+
+	if strings.HasPrefix(templatesDir, root) {
+		t.Fatalf("base-only project dir should still trigger fallback, got %q", templatesDir)
+	}
+}
+
+// TestResolveSubstrateDirs_UsesProjectDirWithRoleSubdirs is the happy-path
+// regression: a workspace with at least one canonical role uses its own
+// templates dir (no embedded extraction).
+func TestResolveSubstrateDirs_UsesProjectDirWithRoleSubdirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	roleDir := filepath.Join(root, ".scion", "templates", "researcher")
+	if err := os.MkdirAll(roleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	templatesDir, _, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		t.Fatalf("resolveSubstrateDirs: %v", err)
+	}
+	defer cleanup()
+
+	want := filepath.Join(root, ".scion", "templates")
+	if templatesDir != want {
+		t.Fatalf("expected project templatesDir %q, got %q", want, templatesDir)
+	}
+}
+
+// TestHasRoleSubdirs covers the helper directly.
+func TestHasRoleSubdirs(t *testing.T) {
+	cases := []struct {
+		name string
+		mk   func(t *testing.T) string
+		want bool
+	}{
+		{"empty dir", func(t *testing.T) string { return t.TempDir() }, false},
+		{"base only", func(t *testing.T) string {
+			d := t.TempDir()
+			os.MkdirAll(filepath.Join(d, "base"), 0o755)
+			return d
+		}, false},
+		{"role present", func(t *testing.T) string {
+			d := t.TempDir()
+			os.MkdirAll(filepath.Join(d, "researcher"), 0o755)
+			return d
+		}, true},
+		{"role beside base", func(t *testing.T) string {
+			d := t.TempDir()
+			os.MkdirAll(filepath.Join(d, "base"), 0o755)
+			os.MkdirAll(filepath.Join(d, "admin"), 0o755)
+			return d
+		}, true},
+		{"only files, no dirs", func(t *testing.T) string {
+			d := t.TempDir()
+			os.WriteFile(filepath.Join(d, "stray.yaml"), []byte("x"), 0o644)
+			return d
+		}, false},
+		{"missing dir", func(t *testing.T) string {
+			return filepath.Join(t.TempDir(), "does-not-exist")
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasRoleSubdirs(tc.mk(t)); got != tc.want {
+				t.Fatalf("hasRoleSubdirs: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 // TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore asserts that
 // ensureAllSkillsStaged calls ImportAllTemplates with the resolved
 // templatesDir. This is the regression guard for the darken-up

--- a/cmd/darken/init.go
+++ b/cmd/darken/init.go
@@ -7,8 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
+
+// minBonesVersion is the lowest bones release that omits the legacy ASCII
+// banner from `bones init` output. Older versions still work but produce
+// noisy output during `darken up`. Bumped by hand when bones evolves.
+const minBonesVersion = "0.6.2"
 
 func runInit(args []string) error {
 	flags := flag.NewFlagSet("init", flag.ContinueOnError)
@@ -203,6 +209,7 @@ func runBonesInit(targetDir string) error {
 	if _, err := exec.LookPath("bones"); err != nil {
 		return nil // soft-fail; bones not on PATH
 	}
+	warnIfBonesOutdated()
 	var stderrBuf strings.Builder
 	c := exec.Command("bones", "init")
 	c.Dir = targetDir
@@ -215,4 +222,56 @@ func runBonesInit(targetDir string) error {
 		return err
 	}
 	return nil
+}
+
+// warnIfBonesOutdated emits a stderr nudge when the installed bones is
+// older than minBonesVersion. Always best-effort — a parse failure or a
+// failed `bones --version` call is silently ignored. The warning names
+// the brew tap because that is the canonical install path.
+func warnIfBonesOutdated() {
+	out, err := exec.Command("bones", "--version").Output()
+	if err != nil {
+		return
+	}
+	ver := parseBonesVersion(string(out))
+	if ver == "" || !semverLess(ver, minBonesVersion) {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"warning: bones %s is older than recommended %s; "+
+			"run `brew upgrade danmestas/tap/bones` for cleaner output\n",
+		ver, minBonesVersion)
+}
+
+// parseBonesVersion extracts the X.Y.Z token from `bones --version`
+// output. Expected format: "bones 0.6.2 (commit ..., built ...)".
+// Returns the empty string on any parse failure so callers can treat
+// "unknown version" as "skip the check".
+func parseBonesVersion(s string) string {
+	fields := strings.Fields(strings.TrimSpace(s))
+	if len(fields) < 2 || fields[0] != "bones" {
+		return ""
+	}
+	return fields[1]
+}
+
+// semverLess reports whether a < b for dotted X.Y.Z version strings.
+// Non-numeric components compare as 0. Intentionally minimal: this is
+// the warn-if-old path, not a release-blocking semver check.
+func semverLess(a, b string) bool {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := range 3 {
+		var ai, bi int
+		if i < len(aParts) {
+			ai, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bi, _ = strconv.Atoi(bParts[i])
+		}
+		if ai != bi {
+			return ai < bi
+		}
+	}
+	return false
 }

--- a/cmd/darken/init_test.go
+++ b/cmd/darken/init_test.go
@@ -333,6 +333,130 @@ func TestInit_BonesAlreadyInitializedIsNoOp(t *testing.T) {
 	}
 }
 
+// TestParseBonesVersion covers the formats parseBonesVersion is expected to
+// handle, including the exact `bones --version` output and a few corruptions.
+func TestParseBonesVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"canonical", "bones 0.6.2 (commit a6c35ab, built 2026-05-01T20:32:45Z)\n", "0.6.2"},
+		{"trimmed", "bones 0.6.1\n", "0.6.1"},
+		{"leading space", "  bones 1.0.0\n", "1.0.0"},
+		{"empty", "", ""},
+		{"wrong tool", "barnacle 9.9.9\n", ""},
+		{"no version", "bones\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseBonesVersion(tc.in); got != tc.want {
+				t.Fatalf("parseBonesVersion(%q): want %q, got %q", tc.in, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestSemverLess covers the dotted version comparator.
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.6.1", "0.6.2", true},
+		{"0.6.2", "0.6.2", false},
+		{"0.6.3", "0.6.2", false},
+		{"0.5.99", "0.6.0", true},
+		{"1.0.0", "0.99.99", false},
+		{"0.6", "0.6.2", true},   // missing patch component compares as 0
+		{"0.6.2", "0.6", false},  // symmetric
+		{"abc", "0.6.2", true},   // non-numeric -> 0
+		{"0.6.2", "abc", false},  // non-numeric -> 0
+	}
+	for _, tc := range cases {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			if got := semverLess(tc.a, tc.b); got != tc.want {
+				t.Fatalf("semverLess(%q,%q): want %v, got %v", tc.a, tc.b, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestWarnIfBonesOutdated_OldVersion stubs `bones --version` to print a
+// pre-minimum release and verifies the warning is emitted to stderr with the
+// brew upgrade hint.
+func TestWarnIfBonesOutdated_OldVersion(t *testing.T) {
+	stubDir := t.TempDir()
+	bonesStub := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'bones 0.6.1 (commit deadbeef, built 2026-04-01T00:00:00Z)'; exit 0; fi\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "bones"), []byte(bonesStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	stderr, err := captureStderr(func() error {
+		warnIfBonesOutdated()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "warning: bones 0.6.1") {
+		t.Fatalf("expected old-version warning, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "brew upgrade") {
+		t.Fatalf("warning should suggest brew upgrade, got: %q", stderr)
+	}
+}
+
+// TestWarnIfBonesOutdated_CurrentVersion confirms the warning is silent when
+// bones is at the recommended minimum.
+func TestWarnIfBonesOutdated_CurrentVersion(t *testing.T) {
+	stubDir := t.TempDir()
+	bonesStub := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'bones " + minBonesVersion + " (commit x, built y)'; exit 0; fi\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "bones"), []byte(bonesStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	stderr, _ := captureStderr(func() error { warnIfBonesOutdated(); return nil })
+	if strings.Contains(stderr, "warning: bones") {
+		t.Fatalf("current version should not warn, got: %q", stderr)
+	}
+}
+
+// TestWarnIfBonesOutdated_FutureVersion confirms forward-compat: a newer
+// bones (e.g. 1.0.0) does not produce a warning.
+func TestWarnIfBonesOutdated_FutureVersion(t *testing.T) {
+	stubDir := t.TempDir()
+	bonesStub := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'bones 1.0.0'; exit 0; fi\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "bones"), []byte(bonesStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	stderr, _ := captureStderr(func() error { warnIfBonesOutdated(); return nil })
+	if strings.Contains(stderr, "warning: bones") {
+		t.Fatalf("future version should not warn, got: %q", stderr)
+	}
+}
+
+// TestWarnIfBonesOutdated_UnparseableOutput confirms the warning silently
+// no-ops when bones --version output can't be parsed (defensive: don't panic
+// or print noise on bonesStub failures).
+func TestWarnIfBonesOutdated_UnparseableOutput(t *testing.T) {
+	stubDir := t.TempDir()
+	bonesStub := "#!/bin/sh\necho 'gibberish'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "bones"), []byte(bonesStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	stderr, _ := captureStderr(func() error { warnIfBonesOutdated(); return nil })
+	if stderr != "" {
+		t.Fatalf("unparseable version should be silent, got: %q", stderr)
+	}
+}
+
 func TestInit_PassesWhenAllPrereqsPresent(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -95,10 +96,27 @@ func (c *execScionClient) PushTemplate(role string) error {
 }
 
 func (c *execScionClient) ImportAllTemplates(dir string) error {
+	// Buffer stderr so we can suppress scion's cobra Usage block on the
+	// known "no importable agent definitions" failure mode. Replaying the
+	// buffer on success or on unrecognized failures preserves operator
+	// visibility for everything else.
+	var stderrBuf bytes.Buffer
 	cmd := scionCmdWithEnv([]string{"--global", "templates", "import", "--all", dir})
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+	stderr := stderrBuf.String()
+	if err != nil {
+		if strings.Contains(stderr, "no importable agent definitions") {
+			return fmt.Errorf("scion templates import: no agent definitions in %s — templates dir is empty or missing role subdirs", dir)
+		}
+		os.Stderr.WriteString(stderr)
+		return fmt.Errorf("scion templates import: %w", err)
+	}
+	if stderr != "" {
+		os.Stderr.WriteString(stderr)
+	}
+	return nil
 }
 
 func (c *execScionClient) GroveInit(targetDir string) error {

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -154,6 +154,71 @@ func TestEnsureBrokerProvide_UsesBrokerProvide(t *testing.T) {
 	}
 }
 
+// TestImportAllTemplates_SuppressesUsageDumpOnKnownError stubs scion to
+// emulate the "no importable agent definitions found" failure (which scion
+// follows with a full cobra Usage block on stderr). The wrapped client must
+// (1) return a clear, operator-friendly error and (2) NOT surface the cobra
+// Usage block to stderr.
+func TestImportAllTemplates_SuppressesUsageDumpOnKnownError(t *testing.T) {
+	stubDir := t.TempDir()
+	scionStub := "#!/bin/sh\n" +
+		"cat >&2 <<'EOF'\n" +
+		"Error: no importable agent definitions found in /tmp/empty\n\n" +
+		"Usage:\n" +
+		"  scion templates import <source> [flags]\n\n" +
+		"Flags:\n" +
+		"      --all              Import all discovered agents\n" +
+		"EOF\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(scionStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	c := &execScionClient{}
+	stderr, err := captureStderr(func() error {
+		return c.ImportAllTemplates("/tmp/empty")
+	})
+	if err == nil {
+		t.Fatal("expected error from ImportAllTemplates, got nil")
+	}
+	if !strings.Contains(err.Error(), "no agent definitions in /tmp/empty") {
+		t.Fatalf("error should name the empty dir, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "Usage:") {
+		t.Fatalf("error should not contain cobra Usage block, got: %v", err)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Fatalf("stderr should not surface cobra Usage block, got: %q", stderr)
+	}
+	if strings.Contains(stderr, "--all") {
+		t.Fatalf("stderr should not surface flag list, got: %q", stderr)
+	}
+}
+
+// TestImportAllTemplates_SurfacesUnknownStderr confirms that on UNRECOGNIZED
+// failures the wrapped client still surfaces scion's stderr — we only filter
+// the one known noisy mode, not all errors.
+func TestImportAllTemplates_SurfacesUnknownStderr(t *testing.T) {
+	stubDir := t.TempDir()
+	scionStub := "#!/bin/sh\necho 'Error: connection to broker refused' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(scionStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	c := &execScionClient{}
+	stderr, err := captureStderr(func() error {
+		return c.ImportAllTemplates("/tmp/whatever")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(stderr, "broker refused") {
+		t.Fatalf("unknown errors should pass through to stderr, got: %q", stderr)
+	}
+}
+
 // TestSpawn_UsesScionClientStartAgent verifies that runSpawn calls
 // ScionClient.StartAgent instead of the raw scion binary for the start operation.
 func TestSpawn_UsesScionClientStartAgent(t *testing.T) {


### PR DESCRIPTION
## Summary

Three bugs surface when running `darken up` on a fresh workspace (e.g. `~/base4m/` immediately after `darken init`). All three reproduce the same symptom: step [7/8] fails with a wall of unhelpful output. Each fix is a small, isolated change in `cmd/darken/`.

- **bootstrap.go** — `resolveSubstrateDirs` now falls back to the embedded substrate when the project's `.scion/templates/` is empty (or holds only the shared `base/` bundle). Without this, `scion templates import --all <empty-dir>` fails with `no importable agent definitions found`.
- **scion_client.go** — `ImportAllTemplates` buffers scion's stderr and suppresses the full cobra Usage block on the known `no importable agent definitions` failure mode. Other failures still pass through verbatim.
- **init.go** — `runBonesInit` now runs a soft preflight (`bones --version`), warns to stderr with a `brew upgrade` hint when older than `minBonesVersion` (0.6.2). Best-effort: parse failures silently no-op.

## Test plan

- [x] `go test ./...` — full suite green (24s for cmd/darken)
- [x] `go vet ./...` — clean
- [x] `make darken` — builds successfully
- [x] `bin/darken doctor` — all preflights green on host
- [x] 25 new unit tests added across `bootstrap_test.go` (4), `scion_client_test.go` (2), `init_test.go` (5 + table cases)
- [x] Verified `hasRoleSubdirs` covers empty / base-only / role-present / files-only / missing-dir
- [x] Verified `parseBonesVersion` + `semverLess` table tests cover canonical, malformed, missing-component, non-numeric inputs
- [x] Verified `ImportAllTemplates` test stubs both the noisy-known-error and unknown-error paths