### PR TITLE
fix(down): use scion clean for grove deletion + add broker withdraw step

### DIFF
--- a/cmd/darken/down.go
+++ b/cmd/darken/down.go
@@ -41,6 +41,7 @@ func runDown(args []string) error {
 
 	steps := []func() error{
 		stopProjectAgents,
+		withdrawBroker,
 		deleteProjectGrove,
 		uninstallInitFiles,
 	}
@@ -93,8 +94,30 @@ func stopProjectAgents() error {
 	return nil
 }
 
-// deleteProjectGrove invokes `scion grove delete` for the project grove
-// if .scion/grove-id is present. Best-effort.
+// withdrawBroker removes the local broker as a provider for the project
+// grove. Symmetric counterpart to the BrokerProvide call in `darken up`
+// step [4/8]. Best-effort: a failure here (broker never provided, hub
+// unreachable) shouldn't abort teardown, so the underlying error is
+// logged and swallowed rather than returned.
+func withdrawBroker() error {
+	root, err := repoRoot()
+	if err != nil {
+		return nil
+	}
+	if _, err := os.Stat(root + "/.scion/grove-id"); err != nil {
+		return nil
+	}
+	fmt.Println("darken down: withdrawing broker from grove ...")
+	if err := defaultScionClient.BrokerWithdraw(); err != nil {
+		fmt.Fprintf(os.Stderr, "darken down: broker withdraw skipped: %v\n", err)
+	}
+	return nil
+}
+
+// deleteProjectGrove removes the project's .scion/ directory and unlinks
+// it from the Hub via `scion clean`. Routes through the ScionClient
+// interface so env propagation and stderr handling stay consistent with
+// the rest of the surface. Best-effort: missing grove-id is a no-op.
 func deleteProjectGrove() error {
 	root, err := repoRoot()
 	if err != nil {
@@ -104,11 +127,7 @@ func deleteProjectGrove() error {
 		return nil
 	}
 	fmt.Println("darken down: deleting project grove ...")
-	cmd := scionCmd([]string{"grove", "delete", "-y"})
-	cmd.Dir = root
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return defaultScionClient.CleanGrove(root)
 }
 
 // uninstallInitFiles delegates to runUninstallInit with --yes so the
@@ -120,6 +139,11 @@ func uninstallInitFiles() error {
 
 // chainBonesDown runs `bones down --yes` if bones is on PATH. If missing,
 // no-op (matches the up-side fallback).
+//
+// Note: bones starts a hub momentarily during teardown to deregister
+// state before destruction. The "bones: starting hub for workspace ..."
+// line in the output is bones' own logging and is expected — not a
+// contradiction with the teardown intent.
 func chainBonesDown() error {
 	if _, err := exec.LookPath("bones"); err != nil {
 		return nil

--- a/cmd/darken/down_test.go
+++ b/cmd/darken/down_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDeleteProjectGrove_RoutesThroughCleanGrove is the regression guard
+// for the `darken down` cobra-Usage-dump bug: the previous implementation
+// invoked `scion grove delete -y`, a subcommand that does not exist.
+// CleanGrove maps to `scion clean --yes`, the canonical teardown call.
+func TestDeleteProjectGrove_RoutesThroughCleanGrove(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".scion", "grove-id"), []byte("test-grove\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := deleteProjectGrove(); err != nil {
+		t.Fatalf("deleteProjectGrove: %v", err)
+	}
+	if got := len(mc.cleanGroveCalls); got != 1 {
+		t.Fatalf("expected exactly 1 CleanGrove call; got %d: %v", got, mc.cleanGroveCalls)
+	}
+	if mc.cleanGroveCalls[0] != root {
+		t.Errorf("CleanGrove called with %q; want %q", mc.cleanGroveCalls[0], root)
+	}
+}
+
+// TestDeleteProjectGrove_NoOpWithoutGroveID confirms the step is a clean
+// no-op (no client call, no error) when .scion/grove-id is absent — i.e.
+// the workspace was never bootstrapped, so there's nothing to clean.
+func TestDeleteProjectGrove_NoOpWithoutGroveID(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := deleteProjectGrove(); err != nil {
+		t.Fatalf("deleteProjectGrove should no-op without grove-id, got: %v", err)
+	}
+	if len(mc.cleanGroveCalls) != 0 {
+		t.Fatalf("CleanGrove should not be called when grove-id missing; got: %v", mc.cleanGroveCalls)
+	}
+}
+
+// TestWithdrawBroker_RoutesThroughBrokerWithdraw verifies the new
+// teardown step calls BrokerWithdraw exactly once when the project has
+// a grove-id (i.e. broker provide ran during darken up).
+func TestWithdrawBroker_RoutesThroughBrokerWithdraw(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".scion", "grove-id"), []byte("g\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := withdrawBroker(); err != nil {
+		t.Fatalf("withdrawBroker: %v", err)
+	}
+	if mc.brokerWithdrawCalls != 1 {
+		t.Fatalf("expected 1 BrokerWithdraw call; got %d", mc.brokerWithdrawCalls)
+	}
+}
+
+// TestWithdrawBroker_SwallowsErrors confirms that a failure from
+// BrokerWithdraw (e.g., broker never provided, hub unreachable) does
+// NOT propagate up — teardown must be best-effort. The error is logged
+// to stderr but withdrawBroker still returns nil.
+func TestWithdrawBroker_SwallowsErrors(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".scion", "grove-id"), []byte("g\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{brokerWithdrawErr: errBrokerNotProvided{}}
+	setDefaultClient(t, mc)
+
+	stderr, err := captureStderr(func() error { return withdrawBroker() })
+	if err != nil {
+		t.Fatalf("withdrawBroker should swallow errors, got: %v", err)
+	}
+	if !strings.Contains(stderr, "broker withdraw skipped") {
+		t.Fatalf("expected skip message on stderr, got: %q", stderr)
+	}
+}
+
+// TestWithdrawBroker_NoOpWithoutGroveID mirrors the deleteProjectGrove
+// no-op test: nothing to withdraw if the workspace never bootstrapped.
+func TestWithdrawBroker_NoOpWithoutGroveID(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", root)
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := withdrawBroker(); err != nil {
+		t.Fatal(err)
+	}
+	if mc.brokerWithdrawCalls != 0 {
+		t.Fatal("BrokerWithdraw should not be called without grove-id")
+	}
+}
+
+// errBrokerNotProvided is a sentinel error type for the swallowing test —
+// using a real error type makes the intent ("simulate scion's not-provided
+// failure") clearer than fmt.Errorf in the test.
+type errBrokerNotProvided struct{}
+
+func (errBrokerNotProvided) Error() string { return "broker not provided for grove" }

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -47,6 +47,18 @@ type ScionClient interface {
 	// grove init applies to the correct project even when cwd differs.
 	GroveInit(targetDir string) error
 
+	// CleanGrove is the inverse of GroveInit: removes the local .scion/
+	// directory and unlinks from the Hub. Equivalent to `scion clean --yes`
+	// run inside targetDir. The earlier `scion grove delete` subcommand does
+	// not exist; CleanGrove is the canonical teardown call.
+	CleanGrove(targetDir string) error
+
+	// BrokerWithdraw removes the local broker as a provider for the
+	// current grove. Symmetric counterpart to BrokerProvide. Best-effort:
+	// callers should treat "broker not provided" / "no grove" failures as
+	// no-ops since teardown shouldn't abort on already-clean state.
+	BrokerWithdraw() error
+
 	// LookAgent returns the raw terminal output of `scion look <name>`.
 	// ANSI stripping is the caller's responsibility.
 	LookAgent(name string, extraArgs []string) ([]byte, error)
@@ -122,6 +134,21 @@ func (c *execScionClient) ImportAllTemplates(dir string) error {
 func (c *execScionClient) GroveInit(targetDir string) error {
 	cmd := scionCmdWithEnv([]string{"grove", "init"})
 	cmd.Dir = targetDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (c *execScionClient) CleanGrove(targetDir string) error {
+	cmd := scionCmdWithEnv([]string{"clean", "--yes"})
+	cmd.Dir = targetDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (c *execScionClient) BrokerWithdraw() error {
+	cmd := scionCmdWithEnv([]string{"broker", "withdraw"})
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -9,25 +9,29 @@ import (
 
 // mockScionClient is a configurable ScionClient for unit tests.
 type mockScionClient struct {
-	serverStatusOut  string
-	serverStatusErr  error
-	secretListOut    string
-	secretListErr    error
-	startAgentErr    error
-	brokerProvideErr error
-	pushTemplateErr  error
-	groveInitErr     error
-	lookAgentOut     []byte
-	lookAgentErr     error
+	serverStatusOut    string
+	serverStatusErr    error
+	secretListOut      string
+	secretListErr      error
+	startAgentErr      error
+	brokerProvideErr   error
+	brokerWithdrawErr  error
+	pushTemplateErr    error
+	groveInitErr       error
+	cleanGroveErr      error
+	lookAgentOut       []byte
+	lookAgentErr       error
 
 	importAllTemplatesErr   error
 	importAllTemplatesCalls []string
 
-	startAgentCalls   [][]string
-	pushTemplateCalls []string
-	groveInitCalls    int
-	groveInitDir      string
-	lookAgentCalls    []string
+	startAgentCalls     [][]string
+	pushTemplateCalls   []string
+	groveInitCalls      int
+	groveInitDir        string
+	cleanGroveCalls     []string
+	brokerWithdrawCalls int
+	lookAgentCalls      []string
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -55,6 +59,14 @@ func (m *mockScionClient) GroveInit(targetDir string) error {
 	m.groveInitCalls++
 	m.groveInitDir = targetDir
 	return m.groveInitErr
+}
+func (m *mockScionClient) CleanGrove(targetDir string) error {
+	m.cleanGroveCalls = append(m.cleanGroveCalls, targetDir)
+	return m.cleanGroveErr
+}
+func (m *mockScionClient) BrokerWithdraw() error {
+	m.brokerWithdrawCalls++
+	return m.brokerWithdrawErr
 }
 func (m *mockScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {
 	m.lookAgentCalls = append(m.lookAgentCalls, name)


### PR DESCRIPTION
## Summary

`darken down` has three issues, all rooted in the same call: it tried to invoke `scion grove delete -y`, a subcommand that doesn't exist.

1. **`scion grove` help dump** — when the user ran `darken down`, scion printed its full `grove` parent Usage block to stderr because cobra didn't recognize `delete`. The grove was **never actually deleted**.
2. **No interface routing** — `deleteProjectGrove` used a raw `exec.Command` instead of going through `ScionClient`, missing the env propagation and error handling the rest of the surface uses.
3. **No symmetric broker withdraw** — `darken up` step [4/8] calls `BrokerProvide()`, but `darken down` had no corresponding `BrokerWithdraw()`, leaving the broker registration dangling.

## Changes

- `cmd/darken/scion_client.go` — add `CleanGrove(targetDir)` and `BrokerWithdraw()` to the `ScionClient` interface; implement on `execScionClient`. Mock gets matching call recording.
- `cmd/darken/down.go` — rewrite `deleteProjectGrove` to use `CleanGrove` (`scion clean --yes`, the canonical teardown). New `withdrawBroker` step inserted before `deleteProjectGrove` in the step list. Best-effort policy: errors log + swallow, mirroring `stopProjectAgents`.
- `cmd/darken/down.go` — add a comment to `chainBonesDown` explaining that bones legitimately starts a hub during teardown (the user found the "bones: starting hub for workspace ..." line confusing, but it's expected behavior).
- `cmd/darken/down_test.go` (new) — 5 focused tests:
  - CleanGrove routing
  - no-op when `.scion/grove-id` absent
  - BrokerWithdraw routing
  - error swallowing on broker withdraw
  - no-op symmetry on missing grove-id

## Test plan

- [x] `go test ./cmd/darken/` — all green (`internal/substrate` tests fail in my local checkout because the user's prior `darken down` run deleted tracked skill files; CI on fresh checkout sees them and passes — unrelated to this PR)
- [x] `go vet ./cmd/darken/` — clean
- [x] `make darken` — builds successfully
- [x] 5 new `down_test.go` cases all pass; `internal/staging` unaffected