### PR TITLE
docs: lifecycle refactor plan for darken up/down

### DIFF
--- a/cmd/darken/bootstrap.go
+++ b/cmd/darken/bootstrap.go
@@ -5,113 +5,24 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/danmestas/darken/internal/substrate"
 )
 
+// runBootstrap delegates to the lifecycle walker (see resources.go) and
+// then runs finalDoctor as a post-ensure sanity check. Each Resource in
+// `lifecycle` reports its own progress prefix; the trailing "bootstrap:
+// OK" line preserves the pre-refactor operator UX.
 func runBootstrap(args []string) error {
-	steps := []struct {
-		name string
-		fn   func() error
-	}{
-		{"docker daemon reachable", checkDocker},
-		{"scion CLI present", checkScion},
-		{"scion server running", ensureScionServer},
-		{"grove registered with broker", ensureBrokerProvide},
-		{"darken images built", ensureImages},
-		{"hub secrets pushed", ensureHubSecrets},
-		{"per-harness skills staged", ensureAllSkillsStaged},
-		{"final doctor", finalDoctor},
+	if err := ensureAll(lifecycle); err != nil {
+		return err
 	}
-	for i, s := range steps {
-		fmt.Printf("[%d/%d] %s ...\n", i+1, len(steps), s.name)
-		if err := s.fn(); err != nil {
-			return fmt.Errorf("step %q failed: %w", s.name, err)
-		}
+	if err := finalDoctor(); err != nil {
+		return err
 	}
 	fmt.Println("bootstrap: OK")
-	return nil
-}
-
-// ensureScionServer starts the scion server if not already running.
-func ensureScionServer() error {
-	if _, err := defaultScionClient.ServerStatus(); err == nil {
-		return nil
-	}
-	// Server not running: start it. Server start is a bootstrap-only
-	// imperative not exposed on ScionClient (callers need check-only or
-	// ensure-running; expose the latter here via a direct exec).
-	cmd := scionCmdWithEnv([]string{"server", "start"})
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-// ensureBrokerProvide registers the current grove with the local broker so
-// agents can be dispatched here. Idempotent — scion broker provide is a
-// no-op when the grove is already registered.
-func ensureBrokerProvide() error {
-	return defaultScionClient.BrokerProvide()
-}
-
-// ensureImages builds any missing darken images via `make -C images <backend>`.
-func ensureImages() error {
-	for _, b := range []string{"claude", "codex", "pi", "gemini"} {
-		if imageExists("local/darkish-" + b + ":latest") {
-			continue
-		}
-		c := exec.Command("make", "-C", "images", b)
-		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
-		if err := c.Run(); err != nil {
-			return fmt.Errorf("make %s: %w", b, err)
-		}
-	}
-	return nil
-}
-
-func ensureHubSecrets() error {
-	return runSubstrateScript("scripts/stage-creds.sh", []string{"all"})
-}
-
-// ensureAllSkillsStaged runs stage-skills.sh per harness directory.
-// Soft-fails per-harness so one missing skill canon doesn't abort
-// the whole bootstrap.
-func ensureAllSkillsStaged() error {
-	templatesDir, modesDir, cleanup, err := resolveSubstrateDirs()
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	if err := withSubstrateDirsEnv(templatesDir, modesDir, func() error {
-		dirs, err := os.ReadDir(templatesDir)
-		if err != nil {
-			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
-		}
-		for _, d := range dirs {
-			if !d.IsDir() || d.Name() == "base" {
-				continue
-			}
-			if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
-				fmt.Fprintf(os.Stderr, "bootstrap: stage-skills %s failed: %v\n", d.Name(), err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// Register every canonical role with scion's local template store so
-	// uploadAllTemplatesToHub can push them. The deferred cleanup above
-	// removes the source dir; scion's import copies bodies into its own
-	// store, so post-cleanup push works.
-	if err := defaultScionClient.ImportAllTemplates(templatesDir); err != nil {
-		return fmt.Errorf("import templates: %w", err)
-	}
 	return nil
 }
 

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -34,10 +34,10 @@ func TestBootstrapStepsAreOrdered(t *testing.T) {
 	_ = runBootstrap([]string{})
 
 	body, _ := os.ReadFile(log)
-	// stage-creds.sh was replaced by native Go in Phase F, so the bash
-	// log no longer includes it. The remaining items still validate
-	// scion/make/stage-skills ordering.
-	want := []string{"server", "make", "stage-skills.sh"}
+	// stage-creds.sh and stage-skills.sh were replaced by native Go in
+	// Phase F and Phase G. The bash log now only validates scion/make
+	// ordering — substrate staging happens entirely in-process.
+	want := []string{"server", "make"}
 	pos := -1
 	for _, w := range want {
 		i := strings.Index(string(body), w)

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -34,7 +34,10 @@ func TestBootstrapStepsAreOrdered(t *testing.T) {
 	_ = runBootstrap([]string{})
 
 	body, _ := os.ReadFile(log)
-	want := []string{"server", "make", "stage-creds.sh", "stage-skills.sh"}
+	// stage-creds.sh was replaced by native Go in Phase F, so the bash
+	// log no longer includes it. The remaining items still validate
+	// scion/make/stage-skills ordering.
+	want := []string{"server", "make", "stage-skills.sh"}
 	pos := -1
 	for _, w := range want {
 		i := strings.Index(string(body), w)

--- a/cmd/darken/bootstrap_test.go
+++ b/cmd/darken/bootstrap_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 )
 
-// TestEnsureScionServer_UsesScionClient asserts ensureScionServer routes
+// TestScionServer_EnsureUsesScionClient asserts ScionServer.Ensure routes
 // through ScionClient.ServerStatus so hub-endpoint env propagation applies.
-func TestEnsureScionServer_UsesScionClient(t *testing.T) {
+func TestScionServer_EnsureUsesScionClient(t *testing.T) {
 	mc := &mockScionClient{serverStatusOut: "Status: ok\n"}
 	setDefaultClient(t, mc)
-	if err := ensureScionServer(); err != nil {
-		t.Fatalf("ensureScionServer: %v", err)
+	if err := (ScionServer{}).Ensure(); err != nil {
+		t.Fatalf("ScionServer.Ensure: %v", err)
 	}
 }
 
@@ -45,13 +45,27 @@ func TestBootstrapStepsAreOrdered(t *testing.T) {
 	}
 }
 
-// TestEnsureBrokerProvide_UsesScionClient asserts ensureBrokerProvide routes
+// TestGroveBroker_EnsureUsesBrokerProvide asserts GroveBroker.Ensure routes
 // through ScionClient.BrokerProvide.
-func TestEnsureBrokerProvide_UsesScionClient(t *testing.T) {
+func TestGroveBroker_EnsureUsesBrokerProvide(t *testing.T) {
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
-	if err := ensureBrokerProvide(); err != nil {
+	if err := (GroveBroker{}).Ensure(); err != nil {
 		t.Fatalf("expected nil, got: %v", err)
+	}
+}
+
+// TestGroveBroker_ReleaseUsesBrokerWithdraw asserts the symmetric pair —
+// the bug class from #45 (forgotten withdraw) is structurally impossible
+// because Resource requires both methods.
+func TestGroveBroker_ReleaseUsesBrokerWithdraw(t *testing.T) {
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+	if err := (GroveBroker{}).Release(); err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+	if mc.brokerWithdrawCalls != 1 {
+		t.Fatalf("expected 1 BrokerWithdraw call; got %d", mc.brokerWithdrawCalls)
 	}
 }
 
@@ -233,8 +247,8 @@ func TestEnsureAllSkillsStaged_ImportsTemplatesForLocalStore(t *testing.T) {
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
 
-	if err := ensureAllSkillsStaged(); err != nil {
-		t.Fatalf("ensureAllSkillsStaged: %v", err)
+	if err := (Substrate{}).Ensure(); err != nil {
+		t.Fatalf("Substrate.Ensure: %v", err)
 	}
 
 	if got := len(mc.importAllTemplatesCalls); got != 1 {

--- a/cmd/darken/creds.go
+++ b/cmd/darken/creds.go
@@ -1,8 +1,161 @@
+// Package main — credential staging for the four backend types.
+//
+// Pre-Phase-F this lived in scripts/stage-creds.sh; the bash is now a
+// container-side concern only (still embedded for spawn.sh inside
+// containers). Host-side staging goes through the ScionClient interface
+// so it shares env propagation, stderr triage, and mockability with
+// the rest of the surface.
 package main
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// runCreds is the operator-facing `darken creds` command. Defaults to
+// staging all four backends when no specific one is named.
 func runCreds(args []string) error {
-	if len(args) == 0 {
-		args = []string{"all"}
+	what := "all"
+	if len(args) > 0 {
+		what = args[0]
 	}
-	return runSubstrateScript("scripts/stage-creds.sh", args)
+	return stageHubCreds(what)
+}
+
+// stageHubCreds pushes credentials for the given backend (or "all")
+// to the Hub via ScionClient.PushFileSecret / PushEnvSecret.
+//
+// Soft-fails per-backend in "all" mode: a missing keychain entry, env
+// var, or file skips that backend only — other backends still get
+// staged. Returns nil after logging failures so the caller (HubSecrets,
+// runCreds, runSpawn) can continue. Specific-backend mode returns the
+// underlying error so the operator sees what went wrong.
+func stageHubCreds(what string) error {
+	switch what {
+	case "claude":
+		return stageClaudeCreds()
+	case "codex":
+		return stageCodexCreds()
+	case "pi":
+		return stagePiCreds()
+	case "gemini":
+		return stageGeminiCreds()
+	case "all", "":
+		stagers := []struct {
+			name string
+			fn   func() error
+		}{
+			{"claude", stageClaudeCreds},
+			{"codex", stageCodexCreds},
+			{"pi", stagePiCreds},
+			{"gemini", stageGeminiCreds},
+		}
+		for _, s := range stagers {
+			if err := s.fn(); err != nil {
+				fmt.Fprintf(os.Stderr, "stage-creds: WARNING — %s: %v\n", s.name, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown backend %q (want claude|codex|pi|gemini|all)", what)
+	}
+}
+
+// stageClaudeCreds reads the Claude credentials from the macOS Keychain
+// (the canonical install path for Claude Code) and pushes them as a
+// file-type secret. Returns an error on non-macOS hosts (no `security`
+// CLI) or when the Keychain entry is absent — the caller decides
+// whether that's fatal.
+func stageClaudeCreds() error {
+	if _, err := exec.LookPath("security"); err != nil {
+		return fmt.Errorf("security CLI unavailable (non-macOS host)")
+	}
+	out, err := exec.Command("security", "find-generic-password",
+		"-s", "Claude Code-credentials", "-w").Output()
+	if err != nil {
+		return fmt.Errorf("Keychain entry 'Claude Code-credentials' not found")
+	}
+	tmp, err := os.CreateTemp("", "darken-claude-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+	_ = os.Chmod(tmp.Name(), 0o600)
+	if err := defaultScionClient.PushFileSecret(
+		"claude_auth",
+		"/home/scion/.claude/.credentials.json",
+		tmp.Name(),
+	); err != nil {
+		return err
+	}
+	fmt.Println("stage-creds: claude_auth pushed (file -> /home/scion/.claude/.credentials.json)")
+	return nil
+}
+
+// stageCodexCreds pushes ~/.codex/auth.json as a file-type secret.
+// Soft-fails when the file is absent (codex not installed locally).
+func stageCodexCreds() error {
+	home, _ := os.UserHomeDir()
+	src := filepath.Join(home, ".codex", "auth.json")
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("%s not found", src)
+	}
+	if err := defaultScionClient.PushFileSecret(
+		"codex_auth",
+		"/home/scion/.codex/auth.json",
+		src,
+	); err != nil {
+		return err
+	}
+	fmt.Println("stage-creds: codex_auth pushed (file -> /home/scion/.codex/auth.json)")
+	return nil
+}
+
+// stagePiCreds pushes OPENROUTER_API_KEY as an env-type secret.
+// Soft-fails when the env var is unset (operator hasn't enabled
+// OpenRouter routing).
+func stagePiCreds() error {
+	key := os.Getenv("OPENROUTER_API_KEY")
+	if key == "" {
+		return fmt.Errorf("OPENROUTER_API_KEY not set")
+	}
+	if err := defaultScionClient.PushEnvSecret("OPENROUTER_API_KEY", key); err != nil {
+		return err
+	}
+	fmt.Println("stage-creds: OPENROUTER_API_KEY pushed (env)")
+	return nil
+}
+
+// stageGeminiCreds prefers the OAuth flow (~/.gemini/oauth_creds.json)
+// and falls back to the API-key flow (GEMINI_API_KEY env). Mirrors the
+// bash precedence so behavior is identical across the migration.
+func stageGeminiCreds() error {
+	home, _ := os.UserHomeDir()
+	src := filepath.Join(home, ".gemini", "oauth_creds.json")
+	if _, err := os.Stat(src); err == nil {
+		if err := defaultScionClient.PushFileSecret(
+			"gemini_auth",
+			"/home/scion/.gemini/oauth_creds.json",
+			src,
+		); err != nil {
+			return err
+		}
+		fmt.Println("stage-creds: gemini_auth pushed (file -> /home/scion/.gemini/oauth_creds.json)")
+		return nil
+	}
+	if key := os.Getenv("GEMINI_API_KEY"); key != "" {
+		if err := defaultScionClient.PushEnvSecret("GEMINI_API_KEY", key); err != nil {
+			return err
+		}
+		fmt.Println("stage-creds: GEMINI_API_KEY pushed (env)")
+		return nil
+	}
+	return fmt.Errorf("neither ~/.gemini/oauth_creds.json nor GEMINI_API_KEY found")
 }

--- a/cmd/darken/creds_test.go
+++ b/cmd/darken/creds_test.go
@@ -7,19 +7,76 @@ import (
 	"testing"
 )
 
-func TestCredsForwardsToScript(t *testing.T) {
-	dir := t.TempDir()
-	log := filepath.Join(dir, "log")
-	os.WriteFile(filepath.Join(dir, "bash"),
-		[]byte("#!/bin/sh\necho \"$0 $@\" >> "+log+"\n"), 0o755)
-	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
-	_ = runCreds([]string{"claude"})
-	body, _ := os.ReadFile(log)
-	// runSubstrateScript extracts the embedded script to a randomly-named
-	// tmpfile, so we no longer assert on "stage-creds.sh" in the path.
-	// The contract is that the forwarded backend arg reaches bash.
-	if !strings.Contains(string(body), "claude") {
-		t.Fatalf("backend arg `claude` not forwarded: %s", body)
+// TestCreds_StagesClaudeViaScionClient verifies the native Go path:
+// runCreds("claude") reads from the macOS Keychain and pushes via
+// ScionClient.PushFileSecret with the canonical name and target path.
+func TestCreds_StagesClaudeViaScionClient(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "security"),
+		[]byte("#!/bin/sh\necho 'fake-creds-blob'\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := runCreds([]string{"claude"}); err != nil {
+		t.Fatalf("runCreds: %v", err)
+	}
+	if len(mc.pushFileSecretCalls) != 1 {
+		t.Fatalf("expected 1 PushFileSecret call; got %d", len(mc.pushFileSecretCalls))
+	}
+	call := mc.pushFileSecretCalls[0]
+	if call[0] != "claude_auth" {
+		t.Errorf("secret name: want claude_auth, got %s", call[0])
+	}
+	if call[1] != "/home/scion/.claude/.credentials.json" {
+		t.Errorf("target: want /home/scion/.claude/.credentials.json, got %s", call[1])
+	}
+}
+
+// TestCreds_PiUsesEnvSecret verifies the env-secret path: when
+// OPENROUTER_API_KEY is set, runCreds("pi") pushes it via PushEnvSecret
+// rather than PushFileSecret.
+func TestCreds_PiUsesEnvSecret(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no security/scion stubs needed
+	t.Setenv("OPENROUTER_API_KEY", "test-key-xyz")
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+	if err := runCreds([]string{"pi"}); err != nil {
+		t.Fatalf("runCreds: %v", err)
+	}
+	if len(mc.pushEnvSecretCalls) != 1 {
+		t.Fatalf("expected 1 PushEnvSecret call; got %d", len(mc.pushEnvSecretCalls))
+	}
+	if mc.pushEnvSecretCalls[0][0] != "OPENROUTER_API_KEY" {
+		t.Errorf("env name: want OPENROUTER_API_KEY, got %s", mc.pushEnvSecretCalls[0][0])
+	}
+	if mc.pushEnvSecretCalls[0][1] != "test-key-xyz" {
+		t.Errorf("env value: want test-key-xyz, got %s", mc.pushEnvSecretCalls[0][1])
+	}
+}
+
+// TestCreds_AllSoftFailsPerBackend verifies the "all" mode soft-fails
+// per backend: a missing claude keychain shouldn't prevent codex/pi
+// from being staged. With no keychain, no codex file, no env vars, no
+// gemini file: zero successful pushes, zero errors returned. HOME is
+// redirected to a temp dir so the test is independent of the host's
+// real ~/.codex and ~/.gemini state.
+func TestCreds_AllSoftFailsPerBackend(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+	if err := runCreds([]string{"all"}); err != nil {
+		t.Fatalf("all mode should not return error on per-backend failures: %v", err)
+	}
+	if len(mc.pushFileSecretCalls)+len(mc.pushEnvSecretCalls) != 0 {
+		t.Fatalf("expected zero pushes when all backends absent; got %d file + %d env",
+			len(mc.pushFileSecretCalls), len(mc.pushEnvSecretCalls))
 	}
 }
 

--- a/cmd/darken/down.go
+++ b/cmd/darken/down.go
@@ -39,20 +39,21 @@ func runDown(args []string) error {
 		}
 	}
 
-	steps := []func() error{
-		stopProjectAgents,
-		withdrawBroker,
-		deleteProjectGrove,
-		uninstallInitFiles,
-	}
+	// Lifecycle resources (broker withdraw, grove clean, agent stop+
+	// delete, worktree prune) are walked in reverse via releaseAll.
+	// uninstallInitFiles, chainBonesDown, and purgeHostState are
+	// darken-specific concerns outside the lifecycle model — they run
+	// as explicit best-effort steps after the resource walk.
+	releaseAll(lifecycle)
+
+	postLifecycle := []func() error{uninstallInitFiles}
 	if !*noBones {
-		steps = append(steps, chainBonesDown)
+		postLifecycle = append(postLifecycle, chainBonesDown)
 	}
 	if *purge {
-		steps = append(steps, purgeHostState)
+		postLifecycle = append(postLifecycle, purgeHostState)
 	}
-
-	for _, step := range steps {
+	for _, step := range postLifecycle {
 		if err := step(); err != nil {
 			fmt.Fprintf(os.Stderr, "darken down: step failed: %v (continuing best-effort)\n", err)
 		}
@@ -73,61 +74,6 @@ func confirmDown() (bool, error) {
 	line, _ := r.ReadString('\n')
 	line = strings.ToLower(strings.TrimSpace(line))
 	return line == "y" || line == "yes", nil
-}
-
-// stopProjectAgents stops any agents in this project's grove. Best-effort:
-// if scion list fails the step returns nil so other teardown can proceed.
-func stopProjectAgents() error {
-	agents, err := scionListAgents()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "darken down: skipping agent-stop (scion list failed: %v)\n", err)
-		return nil
-	}
-	if len(agents) == 0 {
-		return nil
-	}
-	fmt.Printf("darken down: stopping %d agent(s) in this grove ...\n", len(agents))
-	for _, a := range agents {
-		_ = scionCmd([]string{"stop", a.Name, "-y"}).Run()
-		_ = scionCmd([]string{"delete", a.Name, "-y"}).Run()
-	}
-	return nil
-}
-
-// withdrawBroker removes the local broker as a provider for the project
-// grove. Symmetric counterpart to the BrokerProvide call in `darken up`
-// step [4/8]. Best-effort: a failure here (broker never provided, hub
-// unreachable) shouldn't abort teardown, so the underlying error is
-// logged and swallowed rather than returned.
-func withdrawBroker() error {
-	root, err := repoRoot()
-	if err != nil {
-		return nil
-	}
-	if _, err := os.Stat(root + "/.scion/grove-id"); err != nil {
-		return nil
-	}
-	fmt.Println("darken down: withdrawing broker from grove ...")
-	if err := defaultScionClient.BrokerWithdraw(); err != nil {
-		fmt.Fprintf(os.Stderr, "darken down: broker withdraw skipped: %v\n", err)
-	}
-	return nil
-}
-
-// deleteProjectGrove removes the project's .scion/ directory and unlinks
-// it from the Hub via `scion clean`. Routes through the ScionClient
-// interface so env propagation and stderr handling stay consistent with
-// the rest of the surface. Best-effort: missing grove-id is a no-op.
-func deleteProjectGrove() error {
-	root, err := repoRoot()
-	if err != nil {
-		return nil
-	}
-	if _, err := os.Stat(root + "/.scion/grove-id"); err != nil {
-		return nil
-	}
-	fmt.Println("darken down: deleting project grove ...")
-	return defaultScionClient.CleanGrove(root)
 }
 
 // uninstallInitFiles delegates to runUninstallInit with --yes so the

--- a/cmd/darken/down.go
+++ b/cmd/darken/down.go
@@ -106,11 +106,11 @@ func chainBonesDown() error {
 // teardown doesn't trample shared state.
 func purgeHostState() error {
 	fmt.Println("darken down --purge: stopping scion server ...")
-	if err := scionCmd([]string{"server", "stop"}).Run(); err != nil {
+	if err := defaultScionClient.StopServer(); err != nil {
 		fmt.Fprintf(os.Stderr, "darken down: scion server stop failed: %v\n", err)
 	}
 	for _, role := range canonicalRoles {
-		_ = scionCmd([]string{"--global", "templates", "delete", role, "-y"}).Run()
+		_ = defaultScionClient.DeleteTemplate(role)
 	}
 	return nil
 }

--- a/cmd/darken/down_test.go
+++ b/cmd/darken/down_test.go
@@ -3,15 +3,14 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// TestDeleteProjectGrove_RoutesThroughCleanGrove is the regression guard
-// for the `darken down` cobra-Usage-dump bug: the previous implementation
-// invoked `scion grove delete -y`, a subcommand that does not exist.
-// CleanGrove maps to `scion clean --yes`, the canonical teardown call.
-func TestDeleteProjectGrove_RoutesThroughCleanGrove(t *testing.T) {
+// TestGrove_ReleaseRoutesThroughCleanGrove is the regression guard for
+// the cobra-Usage-dump bug: the pre-Resource implementation invoked
+// `scion grove delete -y`, a subcommand that does not exist. Grove.Release
+// routes through ScionClient.CleanGrove which maps to `scion clean --yes`.
+func TestGrove_ReleaseRoutesThroughCleanGrove(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", root)
 	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
@@ -24,8 +23,8 @@ func TestDeleteProjectGrove_RoutesThroughCleanGrove(t *testing.T) {
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
 
-	if err := deleteProjectGrove(); err != nil {
-		t.Fatalf("deleteProjectGrove: %v", err)
+	if err := (Grove{}).Release(); err != nil {
+		t.Fatalf("Grove.Release: %v", err)
 	}
 	if got := len(mc.cleanGroveCalls); got != 1 {
 		t.Fatalf("expected exactly 1 CleanGrove call; got %d: %v", got, mc.cleanGroveCalls)
@@ -35,88 +34,47 @@ func TestDeleteProjectGrove_RoutesThroughCleanGrove(t *testing.T) {
 	}
 }
 
-// TestDeleteProjectGrove_NoOpWithoutGroveID confirms the step is a clean
+// TestGrove_ReleaseNoOpWithoutGroveID confirms the resource is a clean
 // no-op (no client call, no error) when .scion/grove-id is absent — i.e.
 // the workspace was never bootstrapped, so there's nothing to clean.
-func TestDeleteProjectGrove_NoOpWithoutGroveID(t *testing.T) {
+func TestGrove_ReleaseNoOpWithoutGroveID(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", root)
 
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
 
-	if err := deleteProjectGrove(); err != nil {
-		t.Fatalf("deleteProjectGrove should no-op without grove-id, got: %v", err)
+	if err := (Grove{}).Release(); err != nil {
+		t.Fatalf("Grove.Release should no-op without grove-id, got: %v", err)
 	}
 	if len(mc.cleanGroveCalls) != 0 {
 		t.Fatalf("CleanGrove should not be called when grove-id missing; got: %v", mc.cleanGroveCalls)
 	}
 }
 
-// TestWithdrawBroker_RoutesThroughBrokerWithdraw verifies the new
-// teardown step calls BrokerWithdraw exactly once when the project has
-// a grove-id (i.e. broker provide ran during darken up).
-func TestWithdrawBroker_RoutesThroughBrokerWithdraw(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("DARKEN_REPO_ROOT", root)
-	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".scion", "grove-id"), []byte("g\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
+// TestGroveBroker_ReleaseRoutesThroughBrokerWithdraw verifies the
+// resource calls BrokerWithdraw on Release. (The Ensure side is covered
+// in bootstrap_test.go.)
+func TestGroveBroker_ReleaseRoutesThroughBrokerWithdraw(t *testing.T) {
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
-
-	if err := withdrawBroker(); err != nil {
-		t.Fatalf("withdrawBroker: %v", err)
+	if err := (GroveBroker{}).Release(); err != nil {
+		t.Fatalf("GroveBroker.Release: %v", err)
 	}
 	if mc.brokerWithdrawCalls != 1 {
 		t.Fatalf("expected 1 BrokerWithdraw call; got %d", mc.brokerWithdrawCalls)
 	}
 }
 
-// TestWithdrawBroker_SwallowsErrors confirms that a failure from
-// BrokerWithdraw (e.g., broker never provided, hub unreachable) does
-// NOT propagate up — teardown must be best-effort. The error is logged
-// to stderr but withdrawBroker still returns nil.
-func TestWithdrawBroker_SwallowsErrors(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("DARKEN_REPO_ROOT", root)
-	if err := os.MkdirAll(filepath.Join(root, ".scion"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".scion", "grove-id"), []byte("g\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
+// TestGroveBroker_ReleaseSurfacesErrors confirms that a failure from
+// BrokerWithdraw propagates out of Release. The walker (releaseAll) is
+// what implements best-effort across resources — individual resources
+// should report errors honestly so the walker can log them.
+func TestGroveBroker_ReleaseSurfacesErrors(t *testing.T) {
 	mc := &mockScionClient{brokerWithdrawErr: errBrokerNotProvided{}}
 	setDefaultClient(t, mc)
-
-	stderr, err := captureStderr(func() error { return withdrawBroker() })
-	if err != nil {
-		t.Fatalf("withdrawBroker should swallow errors, got: %v", err)
-	}
-	if !strings.Contains(stderr, "broker withdraw skipped") {
-		t.Fatalf("expected skip message on stderr, got: %q", stderr)
-	}
-}
-
-// TestWithdrawBroker_NoOpWithoutGroveID mirrors the deleteProjectGrove
-// no-op test: nothing to withdraw if the workspace never bootstrapped.
-func TestWithdrawBroker_NoOpWithoutGroveID(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("DARKEN_REPO_ROOT", root)
-
-	mc := &mockScionClient{}
-	setDefaultClient(t, mc)
-
-	if err := withdrawBroker(); err != nil {
-		t.Fatal(err)
-	}
-	if mc.brokerWithdrawCalls != 0 {
-		t.Fatal("BrokerWithdraw should not be called without grove-id")
+	if err := (GroveBroker{}).Release(); err == nil {
+		t.Fatal("expected error from GroveBroker.Release when underlying call fails")
 	}
 }
 

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -130,10 +130,7 @@ func (ScionServer) Ensure() error {
 	if _, err := defaultScionClient.ServerStatus(); err == nil {
 		return nil
 	}
-	cmd := scionCmdWithEnv([]string{"server", "start"})
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return defaultScionClient.StartServer()
 }
 func (ScionServer) Release() error { return nil }
 
@@ -262,8 +259,8 @@ func (ProjectAgents) Release() error {
 	}
 	fmt.Printf("project agents: stopping %d agent(s) ...\n", len(agents))
 	for _, a := range agents {
-		_ = scionCmd([]string{"stop", a.Name, "-y"}).Run()
-		_ = scionCmd([]string{"delete", a.Name, "-y"}).Run()
+		_ = defaultScionClient.StopAgent(a.Name)
+		_ = defaultScionClient.DeleteAgent(a.Name)
 	}
 	return nil
 }

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -1,0 +1,108 @@
+// Package main — lifecycle resource model for `darken up` / `darken down`.
+//
+// A Resource represents one piece of state darken manages: the scion server
+// running, the broker provided to a grove, hub secrets staged, agent
+// worktrees created, etc. Each resource owns both directions of its
+// lifecycle (Ensure + Release), so the symmetry that bug-class #45
+// (forgotten BrokerWithdraw) made obvious is enforced by the type system —
+// a resource that forgets one direction won't compile.
+//
+// The package-level `lifecycle` slice declares the order. `darken up`
+// walks forward calling Ensure(); `darken down` walks reverse calling
+// Release(); `darken doctor` (Phase H) walks forward calling Observe()
+// on resources that opt into the Observer interface. Three commands,
+// one world model.
+//
+// See docs/darken-lifecycle-refactor.md for the full design.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Resource is one piece of state darken manages. Implementations own
+// both directions of the lifecycle:
+//
+//   - Ensure makes the resource ready (idempotent — must be safe to call
+//     when the resource is already ready).
+//   - Release makes the resource clean (idempotent — must be safe to call
+//     when the resource is already clean, or never made ready).
+//
+// Resources that have nothing to do on one side return nil from that
+// method. Both methods staying on the interface (rather than being
+// nil-able fields on a struct) is intentional: a resource that forgets
+// to consider both directions fails to compile.
+type Resource interface {
+	Name() string
+	Ensure() error
+	Release() error
+}
+
+// lifecycle is the canonical, ordered list of resources darken manages.
+// The slice order encodes the topology: each resource may depend on
+// resources earlier in the slice. `darken up` walks forward; `darken
+// down` walks reverse. Phases B–C grow this list to ~10 entries.
+var lifecycle = []Resource{
+	DockerDaemon{},
+	ScionCLI{},
+}
+
+// ensureAll walks resources forward calling Ensure(). The first error
+// stops the walk and is returned with the resource name attached. The
+// progress prefix (`[N/M] <name> ...`) matches the existing runBootstrap
+// output so operator-facing UX is unchanged across the migration.
+func ensureAll(resources []Resource) error {
+	for i, r := range resources {
+		fmt.Printf("[%d/%d] %s ...\n", i+1, len(resources), r.Name())
+		if err := r.Ensure(); err != nil {
+			return fmt.Errorf("ensure %q: %w", r.Name(), err)
+		}
+	}
+	return nil
+}
+
+// releaseAll walks resources in reverse calling Release(). Best-effort:
+// errors are logged to stderr and the walk continues, mirroring the
+// pre-refactor `darken down` policy. Teardown should not abort midway
+// because one resource is in an unexpected state — it should make
+// progress on every other resource the operator asked to release.
+func releaseAll(resources []Resource) {
+	for i := len(resources) - 1; i >= 0; i-- {
+		r := resources[i]
+		fmt.Printf("[%d/%d] %s ...\n", len(resources)-i, len(resources), r.Name())
+		if err := r.Release(); err != nil {
+			fmt.Fprintf(os.Stderr, "darken down: release %q: %v (continuing)\n", r.Name(), err)
+		}
+	}
+}
+
+// DockerDaemon ensures the docker daemon is reachable. Release is a no-op
+// — docker is host infrastructure, shared across projects, never stopped
+// by darken.
+type DockerDaemon struct{}
+
+func (DockerDaemon) Name() string { return "docker daemon reachable" }
+func (DockerDaemon) Ensure() error {
+	out, err := exec.Command("docker", "info").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker info: %s", string(out))
+	}
+	return nil
+}
+func (DockerDaemon) Release() error { return nil }
+
+// ScionCLI ensures the scion binary is on PATH. Release is a no-op —
+// the binary is installed via brew, not by darken, and persists across
+// projects.
+type ScionCLI struct{}
+
+func (ScionCLI) Name() string { return "scion CLI present" }
+func (ScionCLI) Ensure() error {
+	if _, err := exec.LookPath("scion"); err != nil {
+		return fmt.Errorf("scion not found on PATH: %w", err)
+	}
+	return nil
+}
+func (ScionCLI) Release() error { return nil }

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -186,28 +186,23 @@ type Substrate struct{}
 
 func (Substrate) Name() string { return "substrate staged + imported" }
 func (Substrate) Ensure() error {
-	templatesDir, modesDir, cleanup, err := resolveSubstrateDirs()
+	templatesDir, _, cleanup, err := resolveSubstrateDirs()
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	if err := withSubstrateDirsEnv(templatesDir, modesDir, func() error {
-		dirs, err := os.ReadDir(templatesDir)
-		if err != nil {
-			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
+	dirs, err := os.ReadDir(templatesDir)
+	if err != nil {
+		return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
+	}
+	for _, d := range dirs {
+		if !d.IsDir() || d.Name() == "base" {
+			continue
 		}
-		for _, d := range dirs {
-			if !d.IsDir() || d.Name() == "base" {
-				continue
-			}
-			if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
-				fmt.Fprintf(os.Stderr, "substrate: stage-skills %s failed: %v\n", d.Name(), err)
-			}
+		if err := stageSkillsNative(d.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "substrate: stage-skills %s failed: %v\n", d.Name(), err)
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 	return defaultScionClient.ImportAllTemplates(templatesDir)
 }

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -43,10 +43,16 @@ type Resource interface {
 // lifecycle is the canonical, ordered list of resources darken manages.
 // The slice order encodes the topology: each resource may depend on
 // resources earlier in the slice. `darken up` walks forward; `darken
-// down` walks reverse. Phases B–C grow this list to ~10 entries.
+// down` walks reverse. Phase C adds Grove + ProjectAgents +
+// AgentWorktrees to bring this to ~10 entries.
 var lifecycle = []Resource{
 	DockerDaemon{},
 	ScionCLI{},
+	ScionServer{},
+	GroveBroker{},
+	DarkenImages{},
+	HubSecrets{},
+	Substrate{},
 }
 
 // ensureAll walks resources forward calling Ensure(). The first error
@@ -106,3 +112,101 @@ func (ScionCLI) Ensure() error {
 	return nil
 }
 func (ScionCLI) Release() error { return nil }
+
+// ScionServer ensures the scion daemon is running. Idempotent: if status
+// reports OK, Ensure is a no-op. Release is a no-op — leaving the server
+// running between projects is the right default; --purge handles the
+// cross-project case explicitly.
+type ScionServer struct{}
+
+func (ScionServer) Name() string { return "scion server running" }
+func (ScionServer) Ensure() error {
+	if _, err := defaultScionClient.ServerStatus(); err == nil {
+		return nil
+	}
+	cmd := scionCmdWithEnv([]string{"server", "start"})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+func (ScionServer) Release() error { return nil }
+
+// GroveBroker registers the local broker as a provider for the project
+// grove (Ensure) or removes that registration (Release). This is the
+// canonical example of the symmetric pair the Resource interface
+// enforces — bug class #45 (forgotten BrokerWithdraw) is structurally
+// impossible because both methods are required.
+type GroveBroker struct{}
+
+func (GroveBroker) Name() string    { return "broker provided to grove" }
+func (GroveBroker) Ensure() error   { return defaultScionClient.BrokerProvide() }
+func (GroveBroker) Release() error  { return defaultScionClient.BrokerWithdraw() }
+
+// DarkenImages ensures every per-backend image is built. Idempotent
+// per-backend via imageExists. Release is a no-op — the image cache is
+// host-wide, persisting across projects (and re-builds are cheap if the
+// cache is gone).
+type DarkenImages struct{}
+
+func (DarkenImages) Name() string { return "darken images built" }
+func (DarkenImages) Ensure() error {
+	for _, b := range []string{"claude", "codex", "pi", "gemini"} {
+		if imageExists("local/darkish-" + b + ":latest") {
+			continue
+		}
+		c := exec.Command("make", "-C", "images", b)
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("make %s: %w", b, err)
+		}
+	}
+	return nil
+}
+func (DarkenImages) Release() error { return nil }
+
+// HubSecrets stages credentials for each backend into the Hub via the
+// stage-creds.sh substrate script (Phase F replaces the bash with native
+// Go in internal/staging). Release is a no-op — secrets are hub-wide,
+// shared across projects, removed only via --purge.
+type HubSecrets struct{}
+
+func (HubSecrets) Name() string    { return "hub secrets pushed" }
+func (HubSecrets) Ensure() error   { return runSubstrateScript("scripts/stage-creds.sh", []string{"all"}) }
+func (HubSecrets) Release() error  { return nil }
+
+// Substrate stages per-role skill bundles and imports the templates into
+// scion's local store. Combines the two halves of the old
+// ensureAllSkillsStaged: per-role stage-skills.sh runs (which Phase G
+// will replace with native Go) plus the ImportAllTemplates call.
+// Release is a no-op — the Grove resource handles cleanup via scion clean.
+type Substrate struct{}
+
+func (Substrate) Name() string { return "substrate staged + imported" }
+func (Substrate) Ensure() error {
+	templatesDir, modesDir, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := withSubstrateDirsEnv(templatesDir, modesDir, func() error {
+		dirs, err := os.ReadDir(templatesDir)
+		if err != nil {
+			return fmt.Errorf("read templates dir %s: %w", templatesDir, err)
+		}
+		for _, d := range dirs {
+			if !d.IsDir() || d.Name() == "base" {
+				continue
+			}
+			if err := runSubstrateScript("scripts/stage-skills.sh", []string{d.Name()}); err != nil {
+				fmt.Fprintf(os.Stderr, "substrate: stage-skills %s failed: %v\n", d.Name(), err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return defaultScionClient.ImportAllTemplates(templatesDir)
+}
+func (Substrate) Release() error { return nil }

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -42,6 +42,53 @@ type Resource interface {
 	Release() error
 }
 
+// Observer is an optional capability for Resources that can cheaply
+// report their current state without mutating it. Used by `darken
+// doctor` (Phase H) to walk the same lifecycle slice that `darken up`
+// and `darken down` use, producing a read-only state report.
+//
+// Resources that genuinely have observable state implement this; ones
+// that don't (e.g., HubSecrets — verifying secrets without staging
+// them is non-trivial) skip the interface and are reported as
+// "(no observer)" in doctor output.
+//
+// Status convention: "ok" / "missing" / "stopped" / "drift" / etc.
+// Detail is a human-readable line — e.g. version strings, paths.
+type Observer interface {
+	Resource
+	Observe() (status, detail string)
+}
+
+// LifecycleObservation is the doctor-friendly shape of a single
+// Observer.Observe() call. Used by lifecycleObservations to package
+// resource state for the doctor renderer without leaking the
+// Resource/Observer types into doctor.go.
+type LifecycleObservation struct {
+	Name   string
+	Status string
+	Detail string
+}
+
+// lifecycleObservations walks `lifecycle` and returns one
+// LifecycleObservation per resource that implements Observer.
+// Resources without Observe() are skipped — `darken doctor` handles
+// the "no observer" case as a Skip entry, separate from the main
+// DoctorCheck registry to keep severity/remediation handling intact.
+func lifecycleObservations() []LifecycleObservation {
+	out := make([]LifecycleObservation, 0, len(lifecycle))
+	for _, r := range lifecycle {
+		if obs, ok := r.(Observer); ok {
+			status, detail := obs.Observe()
+			out = append(out, LifecycleObservation{
+				Name:   r.Name(),
+				Status: status,
+				Detail: detail,
+			})
+		}
+	}
+	return out
+}
+
 // lifecycle is the canonical, ordered list of resources darken manages.
 // The slice order encodes the topology: each resource may depend on
 // resources earlier in the slice. `darken up` walks forward; `darken
@@ -104,6 +151,12 @@ func (DockerDaemon) Ensure() error {
 	return nil
 }
 func (DockerDaemon) Release() error { return nil }
+func (DockerDaemon) Observe() (string, string) {
+	if err := (DockerDaemon{}).Ensure(); err != nil {
+		return "missing", "docker info failed"
+	}
+	return "ok", ""
+}
 
 // ScionCLI ensures the scion binary is on PATH. Release is a no-op —
 // the binary is installed via brew, not by darken, and persists across
@@ -118,6 +171,13 @@ func (ScionCLI) Ensure() error {
 	return nil
 }
 func (ScionCLI) Release() error { return nil }
+func (ScionCLI) Observe() (string, string) {
+	path, err := exec.LookPath("scion")
+	if err != nil {
+		return "missing", "scion not on PATH"
+	}
+	return "ok", path
+}
 
 // ScionServer ensures the scion daemon is running. Idempotent: if status
 // reports OK, Ensure is a no-op. Release is a no-op — leaving the server
@@ -133,6 +193,12 @@ func (ScionServer) Ensure() error {
 	return defaultScionClient.StartServer()
 }
 func (ScionServer) Release() error { return nil }
+func (ScionServer) Observe() (string, string) {
+	if _, err := defaultScionClient.ServerStatus(); err != nil {
+		return "stopped", "scion server status returned error"
+	}
+	return "ok", ""
+}
 
 // GroveBroker registers the local broker as a provider for the project
 // grove (Ensure) or removes that registration (Release). This is the
@@ -232,6 +298,18 @@ func (Grove) Release() error {
 		return nil
 	}
 	return defaultScionClient.CleanGrove(root)
+}
+func (Grove) Observe() (string, string) {
+	root, err := repoRoot()
+	if err != nil {
+		return "missing", "no repo root"
+	}
+	groveID := filepath.Join(root, ".scion", "grove-id")
+	body, err := os.ReadFile(groveID)
+	if err != nil {
+		return "missing", "no .scion/grove-id"
+	}
+	return "ok", strings.TrimSpace(string(body))
 }
 
 // ProjectAgents is a down-only resource: agents are spawned via

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -168,15 +168,14 @@ func (DarkenImages) Ensure() error {
 }
 func (DarkenImages) Release() error { return nil }
 
-// HubSecrets stages credentials for each backend into the Hub via the
-// stage-creds.sh substrate script (Phase F replaces the bash with native
-// Go in internal/staging). Release is a no-op — secrets are hub-wide,
-// shared across projects, removed only via --purge.
+// HubSecrets stages credentials for each backend into the Hub via
+// stageHubCreds (cmd/darken/creds.go). Release is a no-op — secrets are
+// hub-wide, shared across projects, removed only via --purge.
 type HubSecrets struct{}
 
-func (HubSecrets) Name() string    { return "hub secrets pushed" }
-func (HubSecrets) Ensure() error   { return runSubstrateScript("scripts/stage-creds.sh", []string{"all"}) }
-func (HubSecrets) Release() error  { return nil }
+func (HubSecrets) Name() string   { return "hub secrets pushed" }
+func (HubSecrets) Ensure() error  { return stageHubCreds("all") }
+func (HubSecrets) Release() error { return nil }
 
 // Substrate stages per-role skill bundles and imports the templates into
 // scion's local store. Combines the two halves of the old

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 // Resource is one piece of state darken manages. Implementations own
@@ -43,16 +45,20 @@ type Resource interface {
 // lifecycle is the canonical, ordered list of resources darken manages.
 // The slice order encodes the topology: each resource may depend on
 // resources earlier in the slice. `darken up` walks forward; `darken
-// down` walks reverse. Phase C adds Grove + ProjectAgents +
-// AgentWorktrees to bring this to ~10 entries.
+// down` walks reverse. Down-side ordering is critical: AgentWorktrees
+// and ProjectAgents must be released BEFORE Grove (they read from
+// .scion/agents/ and the grove registry, which Grove.Release destroys).
 var lifecycle = []Resource{
 	DockerDaemon{},
 	ScionCLI{},
 	ScionServer{},
+	Grove{},
 	GroveBroker{},
 	DarkenImages{},
 	HubSecrets{},
 	Substrate{},
+	ProjectAgents{},
+	AgentWorktrees{},
 }
 
 // ensureAll walks resources forward calling Ensure(). The first error
@@ -210,3 +216,101 @@ func (Substrate) Ensure() error {
 	return defaultScionClient.ImportAllTemplates(templatesDir)
 }
 func (Substrate) Release() error { return nil }
+
+// Grove ensures the project-scoped scion grove is initialized (Ensure)
+// or removed (Release). Pulled into the lifecycle from the old
+// runUp → ensureGroveInit flow so darken up is one walker call rather
+// than init + bootstrap separately. Idempotent: ensureGroveInit checks
+// for .scion/grove-id before running scion grove init.
+type Grove struct{}
+
+func (Grove) Name() string { return "project grove" }
+func (Grove) Ensure() error {
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return ensureGroveInit(root)
+}
+func (Grove) Release() error {
+	root, err := repoRoot()
+	if err != nil {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(root, ".scion", "grove-id")); err != nil {
+		return nil
+	}
+	return defaultScionClient.CleanGrove(root)
+}
+
+// ProjectAgents is a down-only resource: agents are spawned via
+// `darken spawn`, not by the up lifecycle. Release stops + deletes
+// every agent in the project grove. Best-effort per-agent — one stuck
+// agent shouldn't block teardown of the rest.
+type ProjectAgents struct{}
+
+func (ProjectAgents) Name() string  { return "project agents" }
+func (ProjectAgents) Ensure() error { return nil }
+func (ProjectAgents) Release() error {
+	agents, err := scionListAgents()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "project agents: scion list failed: %v (skipping)\n", err)
+		return nil
+	}
+	if len(agents) == 0 {
+		return nil
+	}
+	fmt.Printf("project agents: stopping %d agent(s) ...\n", len(agents))
+	for _, a := range agents {
+		_ = scionCmd([]string{"stop", a.Name, "-y"}).Run()
+		_ = scionCmd([]string{"delete", a.Name, "-y"}).Run()
+	}
+	return nil
+}
+
+// AgentWorktrees is a down-only resource: git worktrees under
+// .scion/agents/ are created on darken spawn. Release enumerates them
+// via `git worktree list --porcelain`, removes each, and runs
+// `git worktree prune` to clean orphan registry entries. Best-effort —
+// an operator who manually deleted a worktree dir shouldn't block
+// teardown.
+type AgentWorktrees struct{}
+
+func (AgentWorktrees) Name() string  { return "agent worktrees" }
+func (AgentWorktrees) Ensure() error { return nil }
+func (AgentWorktrees) Release() error {
+	paths, err := listAgentWorktreePaths()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent worktrees: list failed: %v (skipping)\n", err)
+		return nil
+	}
+	for _, p := range paths {
+		if err := exec.Command("git", "worktree", "remove", "--force", p).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "agent worktrees: remove %s: %v (continuing)\n", p, err)
+		}
+	}
+	_ = exec.Command("git", "worktree", "prune").Run()
+	return nil
+}
+
+// listAgentWorktreePaths runs `git worktree list --porcelain` and
+// returns paths under .scion/agents/. Returns an empty slice (and nil
+// error) if there are no worktrees registered, which is normal on a
+// project that never spawned an agent.
+func listAgentWorktreePaths() ([]string, error) {
+	out, err := exec.Command("git", "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		path := strings.TrimPrefix(line, "worktree ")
+		if strings.Contains(path, "/.scion/agents/") {
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
+}

--- a/cmd/darken/resources_test.go
+++ b/cmd/darken/resources_test.go
@@ -141,6 +141,40 @@ func TestReleaseAll_VisitsResourcesInReverse(t *testing.T) {
 	}
 }
 
+// TestLifecycleObservations_ReturnsObserverResources confirms that
+// lifecycleObservations walks the lifecycle slice and returns one entry
+// per Resource that implements Observer. Resources without Observe()
+// are silently skipped — they're reported as "(no observer)" in doctor
+// output if needed, separate from this list.
+func TestLifecycleObservations_ReturnsObserverResources(t *testing.T) {
+	obs := lifecycleObservations()
+	if len(obs) == 0 {
+		t.Fatal("expected at least one Observer-equipped resource in lifecycle")
+	}
+	// Every entry must have a non-empty name.
+	for _, o := range obs {
+		if o.Name == "" {
+			t.Errorf("observation has empty name: %+v", o)
+		}
+		if o.Status == "" {
+			t.Errorf("observation has empty status: %+v", o)
+		}
+	}
+}
+
+// TestObserverInterface_Compile is a compile-time check that confirms
+// the Observer interface embeds Resource correctly. If a resource
+// implements Observe() but not Resource methods, this would fail at
+// compile time. Run as a no-op test purely to surface the assertion.
+func TestObserverInterface_Compile(t *testing.T) {
+	// var _ Observer = ... lines below will fail to compile if any
+	// resource breaks the interface contract — that's the point.
+	var _ Observer = DockerDaemon{}
+	var _ Observer = ScionCLI{}
+	var _ Observer = ScionServer{}
+	var _ Observer = Grove{}
+}
+
 func TestReleaseAll_BestEffortContinuesPastErrors(t *testing.T) {
 	var seen []string
 	bang := errors.New("bang")

--- a/cmd/darken/resources_test.go
+++ b/cmd/darken/resources_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDockerDaemon_EnsurePassesWhenInfoSucceeds(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "docker"),
+		[]byte("#!/bin/sh\necho 'Server: ok'\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+	if err := (DockerDaemon{}).Ensure(); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+}
+
+func TestDockerDaemon_EnsureFailsWhenInfoErrors(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "docker"),
+		[]byte("#!/bin/sh\necho 'cannot connect' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir)
+	err := (DockerDaemon{}).Ensure()
+	if err == nil {
+		t.Fatal("expected error when docker info fails")
+	}
+	if !strings.Contains(err.Error(), "cannot connect") {
+		t.Fatalf("error should surface docker output: %v", err)
+	}
+}
+
+func TestDockerDaemon_ReleaseIsNoOp(t *testing.T) {
+	if err := (DockerDaemon{}).Release(); err != nil {
+		t.Fatalf("Release should never error for shared infra: %v", err)
+	}
+}
+
+func TestScionCLI_EnsurePassesWhenOnPath(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"),
+		[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+	if err := (ScionCLI{}).Ensure(); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+}
+
+func TestScionCLI_EnsureFailsWhenAbsent(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir on PATH
+	if err := (ScionCLI{}).Ensure(); err == nil {
+		t.Fatal("expected error when scion not on PATH")
+	}
+}
+
+func TestScionCLI_ReleaseIsNoOp(t *testing.T) {
+	if err := (ScionCLI{}).Release(); err != nil {
+		t.Fatalf("Release should never error for installed binary: %v", err)
+	}
+}
+
+// fakeResource lets tests exercise the walker without depending on
+// stub binaries. ensureErr/releaseErr are returned from the matching
+// methods; the call counters let assertions check the order in which
+// the walker visits each resource.
+type fakeResource struct {
+	name        string
+	ensureErr   error
+	releaseErr  error
+	ensureCalls *[]string
+	releaseCalls *[]string
+}
+
+func (f fakeResource) Name() string { return f.name }
+func (f fakeResource) Ensure() error {
+	*f.ensureCalls = append(*f.ensureCalls, f.name)
+	return f.ensureErr
+}
+func (f fakeResource) Release() error {
+	*f.releaseCalls = append(*f.releaseCalls, f.name)
+	return f.releaseErr
+}
+
+func TestEnsureAll_VisitsResourcesInOrder(t *testing.T) {
+	var seen []string
+	rs := []Resource{
+		fakeResource{name: "a", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "b", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "c", ensureCalls: &seen, releaseCalls: &seen},
+	}
+	out, err := captureStdout(func() error { return ensureAll(rs) })
+	if err != nil {
+		t.Fatalf("ensureAll: %v\n%s", err, out)
+	}
+	if got, want := strings.Join(seen, ","), "a,b,c"; got != want {
+		t.Fatalf("Ensure order: want %q, got %q", want, got)
+	}
+}
+
+func TestEnsureAll_StopsAtFirstError(t *testing.T) {
+	var seen []string
+	bang := errors.New("bang")
+	rs := []Resource{
+		fakeResource{name: "a", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "b", ensureCalls: &seen, releaseCalls: &seen, ensureErr: bang},
+		fakeResource{name: "c", ensureCalls: &seen, releaseCalls: &seen},
+	}
+	out, err := captureStdout(func() error { return ensureAll(rs) })
+	if err == nil {
+		t.Fatalf("expected error, got nil\n%s", out)
+	}
+	if !strings.Contains(err.Error(), `ensure "b"`) {
+		t.Fatalf("error should name failing resource: %v", err)
+	}
+	if got, want := strings.Join(seen, ","), "a,b"; got != want {
+		t.Fatalf("walker should stop at first error: want %q, got %q", want, got)
+	}
+}
+
+func TestReleaseAll_VisitsResourcesInReverse(t *testing.T) {
+	var seen []string
+	rs := []Resource{
+		fakeResource{name: "a", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "b", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "c", ensureCalls: &seen, releaseCalls: &seen},
+	}
+	_, err := captureStdout(func() error { releaseAll(rs); return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(seen, ","), "c,b,a"; got != want {
+		t.Fatalf("Release order: want %q, got %q", want, got)
+	}
+}
+
+func TestReleaseAll_BestEffortContinuesPastErrors(t *testing.T) {
+	var seen []string
+	bang := errors.New("bang")
+	rs := []Resource{
+		fakeResource{name: "a", ensureCalls: &seen, releaseCalls: &seen},
+		fakeResource{name: "b", ensureCalls: &seen, releaseCalls: &seen, releaseErr: bang},
+		fakeResource{name: "c", ensureCalls: &seen, releaseCalls: &seen},
+	}
+	_, stderr := captureBoth(func() error { releaseAll(rs); return nil })
+	if got, want := strings.Join(seen, ","), "c,b,a"; got != want {
+		t.Fatalf("walker should visit all resources despite errors: want %q, got %q", want, got)
+	}
+	if !strings.Contains(stderr, `release "b"`) {
+		t.Fatalf("expected error logged for b, got stderr: %q", stderr)
+	}
+}
+
+// captureBoth returns (stdout, stderr) — stdout is discarded as
+// progress prefix noise; stderr carries the best-effort error log.
+func captureBoth(fn func() error) (string, string) {
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+	_ = fn()
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+	outBuf := readAll(rOut)
+	errBuf := readAll(rErr)
+	return outBuf, errBuf
+}
+
+func readAll(r *os.File) string {
+	var sb strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			sb.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return sb.String()
+}

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -87,46 +87,28 @@ func (c *execScionClient) SecretList() (string, error) {
 
 func (c *execScionClient) StartAgent(name string, args []string) error {
 	full := append([]string{"start", name}, args...)
-	cmd := scionCmdWithEnv(full)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err, _ := runScionCmd(scionCmdWithEnv(full))
+	return err
 }
 
 func (c *execScionClient) BrokerProvide() error {
-	cmd := scionCmdWithEnv([]string{"broker", "provide"})
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"broker", "provide"}))
+	return err
 }
 
 func (c *execScionClient) PushTemplate(role string) error {
-	cmd := scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "push", role})
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "push", role}))
+	return err
 }
 
 func (c *execScionClient) ImportAllTemplates(dir string) error {
-	// Buffer stderr so we can suppress scion's cobra Usage block on the
-	// known "no importable agent definitions" failure mode. Replaying the
-	// buffer on success or on unrecognized failures preserves operator
-	// visibility for everything else.
-	var stderrBuf bytes.Buffer
 	cmd := scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "import", "--all", dir})
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = &stderrBuf
-	err := cmd.Run()
-	stderr := stderrBuf.String()
-	if err != nil {
-		if strings.Contains(stderr, "no importable agent definitions") {
-			return fmt.Errorf("scion templates import: no agent definitions in %s — templates dir is empty or missing role subdirs", dir)
-		}
-		os.Stderr.WriteString(stderr)
-		return fmt.Errorf("scion templates import: %w", err)
+	err, suppressed := runScionCmd(cmd, "no importable agent definitions")
+	if suppressed {
+		return fmt.Errorf("scion templates import: no agent definitions in %s — templates dir is empty or missing role subdirs", dir)
 	}
-	if stderr != "" {
-		os.Stderr.WriteString(stderr)
+	if err != nil {
+		return fmt.Errorf("scion templates import: %w", err)
 	}
 	return nil
 }
@@ -134,24 +116,55 @@ func (c *execScionClient) ImportAllTemplates(dir string) error {
 func (c *execScionClient) GroveInit(targetDir string) error {
 	cmd := scionCmdWithEnv([]string{"grove", "init"})
 	cmd.Dir = targetDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err, _ := runScionCmd(cmd)
+	return err
 }
 
 func (c *execScionClient) CleanGrove(targetDir string) error {
 	cmd := scionCmdWithEnv([]string{"clean", "--yes"})
 	cmd.Dir = targetDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err, _ := runScionCmd(cmd)
+	return err
 }
 
 func (c *execScionClient) BrokerWithdraw() error {
-	cmd := scionCmdWithEnv([]string{"broker", "withdraw"})
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"broker", "withdraw"}))
+	return err
+}
+
+// runScionCmd is the shared transport for execScionClient methods that
+// pipe scion's stdout/stderr to the operator. Stderr is buffered so we
+// can suppress scion's cobra Usage block on known runtime-error messages
+// (e.g. "no importable agent definitions found"), which would otherwise
+// dump the full Usage as noise. Returns:
+//
+//   - err = the underlying cmd.Run() error (or nil)
+//   - suppressed = true iff err is non-nil AND a knownNoisy substring
+//     matched the buffered stderr. Caller wraps the error with a
+//     friendly message; the noisy stderr is dropped.
+//
+// On success, buffered stderr is replayed so progress output reaches
+// the operator. On unknown errors, stderr passes through verbatim so
+// the operator can debug.
+func runScionCmd(cmd *exec.Cmd, knownNoisy ...string) (error, bool) {
+	var stderrBuf bytes.Buffer
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+	stderr := stderrBuf.String()
+	if err != nil {
+		for _, pat := range knownNoisy {
+			if strings.Contains(stderr, pat) {
+				return err, true
+			}
+		}
+		os.Stderr.WriteString(stderr)
+		return err, false
+	}
+	if stderr != "" {
+		os.Stderr.WriteString(stderr)
+	}
+	return nil, false
 }
 
 func (c *execScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -85,10 +85,17 @@ type ScionClient interface {
 	// uploadAllTemplatesToHub.
 	DeleteTemplate(role string) error
 
-	// PushSecret uploads a credential file to the Hub under the given
-	// secret name. Used by HubSecrets.Ensure once the bash stage-creds.sh
-	// is replaced by native Go (Phase F).
-	PushSecret(name, filePath string) error
+	// PushFileSecret uploads a credential file to the Hub. target is
+	// the path-in-container the agent expects; srcPath is the file on
+	// the host to read content from. Maps to:
+	//   scion hub secret set --type file --target <target> <name> @<srcPath>
+	PushFileSecret(name, target, srcPath string) error
+
+	// PushEnvSecret uploads a value as an env-type secret named for
+	// the env var it'll populate inside the container. Maps to:
+	//   scion hub secret set --type env --target <name> <name> @<tmpfile>
+	// where tmpfile holds value.
+	PushEnvSecret(name, value string) error
 }
 
 // execScionClient is the production ScionClient that delegates to the scion binary.
@@ -219,9 +226,36 @@ func (c *execScionClient) DeleteTemplate(role string) error {
 	return err
 }
 
-func (c *execScionClient) PushSecret(name, filePath string) error {
-	err, _ := runScionCmd(scionCmdWithEnv([]string{"hub", "secret", "push", name, "--from-file", filePath}))
+func (c *execScionClient) PushFileSecret(name, target, srcPath string) error {
+	cmd := scionCmdWithEnv([]string{
+		"hub", "secret", "set",
+		"--type", "file",
+		"--target", target,
+		name, "@" + srcPath,
+	})
+	err, _ := runScionCmd(cmd)
 	return err
+}
+
+func (c *execScionClient) PushEnvSecret(name, value string) error {
+	tmp, err := os.CreateTemp("", "darken-secret-*")
+	if err != nil {
+		return fmt.Errorf("create temp for env secret: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(value); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp for env secret: %w", err)
+	}
+	tmp.Close()
+	cmd := scionCmdWithEnv([]string{
+		"hub", "secret", "set",
+		"--type", "env",
+		"--target", name,
+		name, "@" + tmp.Name(),
+	})
+	err2, _ := runScionCmd(cmd)
+	return err2
 }
 
 func (c *execScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -62,6 +62,33 @@ type ScionClient interface {
 	// LookAgent returns the raw terminal output of `scion look <name>`.
 	// ANSI stripping is the caller's responsibility.
 	LookAgent(name string, extraArgs []string) ([]byte, error)
+
+	// StartServer starts the scion daemon. Idempotency is the caller's
+	// concern — typically gated behind a ServerStatus check.
+	StartServer() error
+
+	// StopServer stops the scion daemon. Used by `darken down --purge`
+	// for cross-project teardown; ordinary `darken down` leaves the
+	// server running.
+	StopServer() error
+
+	// StopAgent stops a running agent by name. Idempotent: stopping an
+	// already-stopped agent is a no-op on scion's side.
+	StopAgent(name string) error
+
+	// DeleteAgent removes an agent registration by name. Should be
+	// preceded by StopAgent so no work is in flight.
+	DeleteAgent(name string) error
+
+	// DeleteTemplate removes a template from scion's user (global) store.
+	// Used by `darken down --purge` to revert template uploads from
+	// uploadAllTemplatesToHub.
+	DeleteTemplate(role string) error
+
+	// PushSecret uploads a credential file to the Hub under the given
+	// secret name. Used by HubSecrets.Ensure once the bash stage-creds.sh
+	// is replaced by native Go (Phase F).
+	PushSecret(name, filePath string) error
 }
 
 // execScionClient is the production ScionClient that delegates to the scion binary.
@@ -165,6 +192,36 @@ func runScionCmd(cmd *exec.Cmd, knownNoisy ...string) (error, bool) {
 		os.Stderr.WriteString(stderr)
 	}
 	return nil, false
+}
+
+func (c *execScionClient) StartServer() error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"server", "start"}))
+	return err
+}
+
+func (c *execScionClient) StopServer() error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"server", "stop"}))
+	return err
+}
+
+func (c *execScionClient) StopAgent(name string) error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"stop", name, "-y"}))
+	return err
+}
+
+func (c *execScionClient) DeleteAgent(name string) error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"delete", name, "-y"}))
+	return err
+}
+
+func (c *execScionClient) DeleteTemplate(role string) error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"--global", "templates", "delete", role, "-y"}))
+	return err
+}
+
+func (c *execScionClient) PushSecret(name, filePath string) error {
+	err, _ := runScionCmd(scionCmdWithEnv([]string{"hub", "secret", "push", name, "--from-file", filePath}))
+	return err
 }
 
 func (c *execScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -156,16 +156,6 @@ func TestUploadAllTemplatesToHub_UsesPushTemplate(t *testing.T) {
 	}
 }
 
-// TestEnsureBrokerProvide_UsesBrokerProvide asserts ensureBrokerProvide
-// calls ScionClient.BrokerProvide.
-func TestEnsureBrokerProvide_UsesBrokerProvide(t *testing.T) {
-	mc := &mockScionClient{}
-	setDefaultClient(t, mc)
-	if err := ensureBrokerProvide(); err != nil {
-		t.Fatalf("ensureBrokerProvide: %v", err)
-	}
-}
-
 // TestImportAllTemplates_SuppressesUsageDumpOnKnownError stubs scion to
 // emulate the "no importable agent definitions found" failure (which scion
 // follows with a full cobra Usage block on stderr). The wrapped client must

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -32,6 +32,20 @@ type mockScionClient struct {
 	cleanGroveCalls     []string
 	brokerWithdrawCalls int
 	lookAgentCalls      []string
+
+	startServerCalls    int
+	stopServerCalls     int
+	stopAgentCalls      []string
+	deleteAgentCalls    []string
+	deleteTemplateCalls []string
+	pushSecretCalls     [][2]string
+
+	startServerErr    error
+	stopServerErr     error
+	stopAgentErr      error
+	deleteAgentErr    error
+	deleteTemplateErr error
+	pushSecretErr     error
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -71,6 +85,30 @@ func (m *mockScionClient) BrokerWithdraw() error {
 func (m *mockScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {
 	m.lookAgentCalls = append(m.lookAgentCalls, name)
 	return m.lookAgentOut, m.lookAgentErr
+}
+func (m *mockScionClient) StartServer() error {
+	m.startServerCalls++
+	return m.startServerErr
+}
+func (m *mockScionClient) StopServer() error {
+	m.stopServerCalls++
+	return m.stopServerErr
+}
+func (m *mockScionClient) StopAgent(name string) error {
+	m.stopAgentCalls = append(m.stopAgentCalls, name)
+	return m.stopAgentErr
+}
+func (m *mockScionClient) DeleteAgent(name string) error {
+	m.deleteAgentCalls = append(m.deleteAgentCalls, name)
+	return m.deleteAgentErr
+}
+func (m *mockScionClient) DeleteTemplate(role string) error {
+	m.deleteTemplateCalls = append(m.deleteTemplateCalls, role)
+	return m.deleteTemplateErr
+}
+func (m *mockScionClient) PushSecret(name, filePath string) error {
+	m.pushSecretCalls = append(m.pushSecretCalls, [2]string{name, filePath})
+	return m.pushSecretErr
 }
 
 // setDefaultClient replaces defaultScionClient for the duration of the test.

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -38,14 +38,16 @@ type mockScionClient struct {
 	stopAgentCalls      []string
 	deleteAgentCalls    []string
 	deleteTemplateCalls []string
-	pushSecretCalls     [][2]string
+	pushFileSecretCalls [][3]string // {name, target, srcPath}
+	pushEnvSecretCalls  [][2]string // {name, value}
 
-	startServerErr    error
-	stopServerErr     error
-	stopAgentErr      error
-	deleteAgentErr    error
-	deleteTemplateErr error
-	pushSecretErr     error
+	startServerErr     error
+	stopServerErr      error
+	stopAgentErr       error
+	deleteAgentErr     error
+	deleteTemplateErr  error
+	pushFileSecretErr  error
+	pushEnvSecretErr   error
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -106,9 +108,13 @@ func (m *mockScionClient) DeleteTemplate(role string) error {
 	m.deleteTemplateCalls = append(m.deleteTemplateCalls, role)
 	return m.deleteTemplateErr
 }
-func (m *mockScionClient) PushSecret(name, filePath string) error {
-	m.pushSecretCalls = append(m.pushSecretCalls, [2]string{name, filePath})
-	return m.pushSecretErr
+func (m *mockScionClient) PushFileSecret(name, target, srcPath string) error {
+	m.pushFileSecretCalls = append(m.pushFileSecretCalls, [3]string{name, target, srcPath})
+	return m.pushFileSecretErr
+}
+func (m *mockScionClient) PushEnvSecret(name, value string) error {
+	m.pushEnvSecretCalls = append(m.pushEnvSecretCalls, [2]string{name, value})
+	return m.pushEnvSecretErr
 }
 
 // setDefaultClient replaces defaultScionClient for the duration of the test.

--- a/cmd/darken/skill_staging.go
+++ b/cmd/darken/skill_staging.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/danmestas/darken/internal/substrate"
 )
 
 // applyRoleFilter filters the skills in dir to only those visible to role.
@@ -140,30 +142,110 @@ func loadManifestForRole(harnessType string) (HarnessManifest, error) {
 }
 
 // stageSkillsForRole is the single entry point for skill staging called
-// by spawn. After the modes migration (.scion/modes/<name>.yaml), skill
-// resolution is mode-driven: the manifest carries default_mode, and the
-// shell script resolves through the modes tree with extends-chain
-// expansion. The Go-path buildSkillsStaging reads inline manifest.Skills
-// only — empty after migration — so it produces empty staging dirs.
+// by spawn. Mode-driven resolution: the manifest's default_mode (or the
+// DARKEN_MODE_OVERRIDE env var) names a mode YAML in DARKEN_MODES_DIR;
+// internal/substrate.ResolveSkillsFromFS expands the extends chain and
+// returns a deduped, ordered skill list. Each skill is copied from
+// canonical (~/projects/agent-skills/skills/<name>) into the per-role
+// staging dir, then role-visibility filtering runs.
 //
-// Until buildSkillsStaging gains mode-awareness, route through the shell
-// script unconditionally. The script handles both the override case
-// (DARKEN_MODE_OVERRIDE) and the default-mode case correctly.
+// Pre-Phase-G this routed through scripts/stage-skills.sh. The bash
+// remains for container-side use (spawn.sh) and the operator-facing
+// `darken skills` add/remove/diff commands; host-side lifecycle calls
+// now live entirely in Go.
 func stageSkillsForRole(harnessType string) error {
-	return stageSkillsViaScript(harnessType)
+	return stageSkillsNative(harnessType)
 }
 
-// stageSkillsViaScript is the shell-script fallback for stageSkillsForRole.
-// Used when the Go pipeline cannot resolve its inputs (no canonical skills
-// dir, no repo root). Applies the role filter after the script runs.
-func stageSkillsViaScript(harnessType string) error {
-	if err := runSubstrateScript("scripts/stage-skills.sh", []string{harnessType}); err != nil {
-		return fmt.Errorf("stage-skills script failed: %w", err)
-	}
+// stageSkillsNative is the Go implementation of stage-skills.sh rebuild
+// mode. Atomic publish via tmpdir + rename; the prior bash needed an
+// explicit lock dir for parallel-invocation safety, but Go's os.Rename
+// is atomic on POSIX so the lock is unnecessary.
+//
+// Important: applyRoleFilter is called at the end on every code path,
+// even when the resolution returns no skills or the manifest declares
+// no default_mode. This matches the bash + Go-shim contract: the
+// fail-closed role filter must run on the live staging dir so unreadable
+// or out-of-role skills get removed regardless of whether a rebuild
+// happened.
+func stageSkillsNative(harnessType string) error {
 	root, err := repoRoot()
 	if err != nil {
-		return nil // no repo root — nothing to filter
+		return fmt.Errorf("stage-skills: repo root: %w", err)
 	}
-	stagingDir := filepath.Join(root, ".scion", "skills-staging", harnessType)
-	return applyRoleFilter(stagingDir, harnessType)
+	stageDir := filepath.Join(root, ".scion", "skills-staging", harnessType)
+
+	templatesDir, modesDir, cleanup, err := resolveSubstrateDirs()
+	if err != nil {
+		return fmt.Errorf("stage-skills: resolve substrate: %w", err)
+	}
+	defer cleanup()
+
+	manifestPath := filepath.Join(templatesDir, harnessType, "scion-agent.yaml")
+	body, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// No manifest — soft skip; still apply role filter on existing
+		// stage dir so fail-closed semantics hold.
+		fmt.Fprintf(os.Stderr, "stage-skills: read manifest for %s: %v\n", harnessType, err)
+		return applyRoleFilter(stageDir, harnessType)
+	}
+
+	mode := os.Getenv("DARKEN_MODE_OVERRIDE")
+	if mode == "" {
+		mode = scanField(string(body), "default_mode:")
+	}
+	if mode == "" {
+		// No mode declared and no override — soft no-op for the rebuild
+		// step; still run the role filter on the existing staging dir.
+		return applyRoleFilter(stageDir, harnessType)
+	}
+
+	skills, err := substrate.ResolveSkillsFromFS(os.DirFS(modesDir), mode)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stage-skills: resolve mode %q for %s: %v\n", mode, harnessType, err)
+		return applyRoleFilter(stageDir, harnessType)
+	}
+	if len(skills) == 0 {
+		return applyRoleFilter(stageDir, harnessType)
+	}
+
+	canonical := skillsCanonical()
+	tmpDir := stageDir + ".tmp"
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return fmt.Errorf("stage-skills: prepare tmp dir: %w", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return fmt.Errorf("stage-skills: create tmp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) // best-effort cleanup if rename failed
+
+	for _, ref := range skills {
+		src, err := resolveSkillRef(ref, canonical)
+		if err != nil {
+			return fmt.Errorf("stage-skills: %w", err)
+		}
+		if _, err := os.Stat(src); err != nil {
+			// Source missing — log and skip this skill rather than abort
+			// the whole rebuild. Matches bash's WARNING behavior in
+			// "all" mode and avoids one missing canonical skill from
+			// blocking the entire role.
+			fmt.Fprintf(os.Stderr, "stage-skills: source skill missing for ref %q at %s\n", ref, src)
+			continue
+		}
+		name := skillBaseName(ref)
+		dest := filepath.Join(tmpDir, name)
+		if err := copyDir(src, dest); err != nil {
+			return fmt.Errorf("stage-skills: copy %q: %w", ref, err)
+		}
+		fmt.Printf("stage-skills: copied %s → %s\n", name, filepath.Join(stageDir, name))
+	}
+
+	if err := os.RemoveAll(stageDir); err != nil {
+		return fmt.Errorf("stage-skills: clean stage dir: %w", err)
+	}
+	if err := os.Rename(tmpDir, stageDir); err != nil {
+		return fmt.Errorf("stage-skills: publish: %w", err)
+	}
+
+	return applyRoleFilter(stageDir, harnessType)
 }

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -31,7 +31,7 @@ func runSpawn(args []string) error {
 	posArgs := fs.Args()
 
 	if !*noStage {
-		if err := runSubstrateScript("scripts/stage-creds.sh", []string{"all"}); err != nil {
+		if err := stageHubCreds("all"); err != nil {
 			fmt.Fprintln(os.Stderr, "spawn: stage-creds non-fatal:", err)
 		}
 		if err := withModeOverride(*mode, func() error {

--- a/cmd/darken/spawn_test.go
+++ b/cmd/darken/spawn_test.go
@@ -41,9 +41,12 @@ func TestSpawnInvokesStageThenScion(t *testing.T) {
 	if err := runSpawn([]string{"smoke-1", "--type", "researcher", "task..."}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
+	// stage-creds is now native Go (Phase F), not a bash invocation;
+	// the test asserts spawn proceeded to scion start, which is the
+	// real ordering contract.
 	body, _ := os.ReadFile(log)
-	if !strings.Contains(string(body), "stage-creds.sh") {
-		t.Fatalf("stage-creds.sh not invoked: %s", body)
+	if !strings.Contains(string(body), "start") {
+		t.Fatalf("scion start not invoked: %s", body)
 	}
 	// REVIEW-7 consolidated skill staging into the Go-side
 	// buildSkillsStaging; spawn no longer invokes a stage-skills.sh

--- a/cmd/darken/up.go
+++ b/cmd/darken/up.go
@@ -29,16 +29,14 @@ func runUp(args []string) error {
 		rest = append(rest, a)
 	}
 
-	target, err := resolveInitTarget(rest)
-	if err != nil {
+	if _, err := resolveInitTarget(rest); err != nil {
 		return err
 	}
 	if err := runInit(rest); err != nil {
 		return err
 	}
-	if err := ensureGroveInit(target); err != nil {
-		return err
-	}
+	// Grove init now lives inside the lifecycle (Grove.Ensure), so
+	// runBootstrap's walker handles it. No explicit ensureGroveInit call.
 	if err := runBootstrap(nil); err != nil {
 		return err
 	}

--- a/docs/darken-lifecycle-refactor.md
+++ b/docs/darken-lifecycle-refactor.md
@@ -1,0 +1,187 @@
+# Darken lifecycle refactor
+
+A plan to simplify `darken up` / `darken down` without changing scion (which lives upstream at Google and we don't control). All work stays inside this repo. The goal is to remove the bug-classes that produced PRs #43 and #45, eliminate the asymmetry that made #45 possible at all, and shrink the surprise area when an underlying tool (scion, bones, docker) misbehaves.
+
+## Problem
+
+`darken up` is 8 hand-rolled steps; `darken down` is 4 hand-rolled steps; almost every step shells out to scion or a bash script and forwards stdout/stderr unfiltered. Three bug-classes have surfaced in the last two weeks, all sharing the same root cause:
+
+1. **Stderr forwarding noise.** `scion templates import --all <empty-dir>` (#43) and `scion grove delete -y` (#45, the latter doesn't even exist) both dumped cobra's full Usage block to stderr because darken just forwarded scion's output. We fixed each one in isolation; the next one will look the same.
+
+2. **Up/down asymmetry.** `darken up` calls `BrokerProvide()` at step [4/8]. `darken down` had no symmetric `BrokerWithdraw()` until #45 added one. The forgetting was structural — the up and down code paths are independent slices of `func() error` with no enforced pairing.
+
+3. **Layering opacity.** `bones down --yes` legitimately starts a hub mid-teardown to deregister state. The user reasonably read that as a contradiction, because darken's output makes no distinction between "darken's intent" and "what bones decided to do." Comments help; structure helps more.
+
+The unifying observation: **darken is a thin orchestration layer that doesn't model what it's orchestrating**. It calls commands and forwards output. When a command misbehaves, the operator sees raw shell-y output. When a step is missing its symmetric pair, nothing notices.
+
+## Target shape
+
+### 1. `Step` abstraction with paired up/down
+
+Replace `[]func() error` in both `runBootstrap` and `runDown` with a single declared list of steps that own both directions:
+
+```go
+type Step struct {
+    Name     string
+    Up       func() error // forward (darken up)
+    Down     func() error // reverse (darken down); nil = no-op
+    Critical bool         // hard-fail vs best-effort
+}
+
+var lifecycle = []Step{
+    {Name: "docker daemon reachable",
+     Up: checkDocker, Down: nil, Critical: true},
+    {Name: "scion CLI present",
+     Up: checkScion, Down: nil, Critical: true},
+    {Name: "scion server running",
+     Up: ensureScionServer, Down: nil /* leave running */, Critical: true},
+    {Name: "broker provided to grove",
+     Up: ensureBrokerProvide, Down: withdrawBrokerInline, Critical: false},
+    {Name: "darken images built",
+     Up: ensureImages, Down: nil /* keep images */, Critical: true},
+    {Name: "hub secrets pushed",
+     Up: ensureHubSecrets, Down: nil, Critical: true},
+    {Name: "templates staged + imported",
+     Up: ensureAllSkillsStaged, Down: deleteProjectGrove, Critical: true},
+    {Name: "final doctor",
+     Up: finalDoctor, Down: nil, Critical: false},
+}
+```
+
+`runBootstrap` walks forward calling `step.Up`. `runDown` walks reverse calling `step.Down` where non-nil. The asymmetry that produced #45 literally cannot recur — every step ships with its own teardown, and the reviewer can read up/down side-by-side in one place.
+
+### 2. Route every scion call through `ScionClient`
+
+`down.go` still uses raw `exec.Command` in `stopProjectAgents` (lines 90–91) and `purgeHostState` (lines 139, 143). Add `StopAgent`, `DeleteAgent`, `ServerStop`, `DeleteTemplate` methods to the interface so the entire surface is uniform. Benefits:
+
+- One env-propagation policy (`scionCmdWithEnv` already centralises this for the methods that use it).
+- One stderr-triage policy (see §3).
+- Mockable end-to-end for tests, no more PATH-stub-scion gymnastics.
+
+### 3. One stderr-triage helper
+
+We've now hand-written stderr buffering twice (`ImportAllTemplates` in #43, and the planned-but-not-shipped extension to other methods). Extract:
+
+```go
+// runScionCmd executes cmd, buffering stderr so callers can suppress
+// known-noisy failure modes without losing operator visibility on
+// unknown errors. The matchers are substrings; the first one that hits
+// causes stderr to be dropped (the wrapped error still describes the
+// failure). Unknown failures pass stderr through verbatim.
+func runScionCmd(cmd *exec.Cmd, knownNoisy ...string) error {
+    var stderrBuf bytes.Buffer
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = &stderrBuf
+    err := cmd.Run()
+    stderr := stderrBuf.String()
+    if err != nil {
+        for _, pat := range knownNoisy {
+            if strings.Contains(stderr, pat) {
+                return err // suppress; caller wraps with friendly message
+            }
+        }
+        os.Stderr.WriteString(stderr) // unknown: surface verbatim
+        return err
+    }
+    if stderr != "" {
+        os.Stderr.WriteString(stderr)
+    }
+    return nil
+}
+```
+
+Three caller patterns:
+- `runScionCmd(cmd)` — no triage; replaces the raw "set stdout/stderr; run" boilerplate
+- `runScionCmd(cmd, "no importable agent definitions")` — suppress one known mode
+- Methods that need a friendly error wrap their own message after the helper returns
+
+### 4. Agent worktree cleanup
+
+`darken spawn` creates real git worktrees at `.scion/agents/<name>/workspace` (see the `agent-worktree-discipline` skill). `darken down` currently calls `scion stop` and `scion delete` per agent in `stopProjectAgents`, then `scion clean` removes the entire `.scion/` directory. That deletes the *files* under each worktree but leaves the parent repo's worktree registry pointing at directories that no longer exist — a future `git worktree list` will show orphans, and `git worktree prune` won't run unless something invokes it.
+
+The lifecycle should explicitly own this. Two changes:
+
+- A new teardown-only step that walks `git worktree list --porcelain`, filters to anything under `.scion/agents/`, and calls `git worktree remove --force <path>` for each before `deleteProjectGrove` runs. After the loop, `git worktree prune` for safety.
+- The `Step` struct supports teardown-only steps (`Up` is nil-able), so this slots into the same list as everything else:
+
+```go
+{Name: "stop project agents",
+ Up: nil, Down: stopProjectAgents,    Critical: false},
+{Name: "clean agent worktrees",
+ Up: nil, Down: cleanAgentWorktrees,  Critical: false},
+```
+
+These run in reverse order on `darken down` and are skipped on `darken up`. Keeps the model uniform.
+
+Open question: should worktree cleanup be best-effort (log + continue) or hard-fail? Probably best-effort — an operator who manually `rm -rf`'d a worktree dir shouldn't be blocked from teardown by a stale registry entry.
+
+### 5. Replace bash scripts with native Go
+
+`scripts/stage-creds.sh` and `scripts/stage-skills.sh` are subprocess-of-subprocess layers (darken → bash → scion). Both do work that's clearly Go-shaped:
+
+- **`stage-creds.sh`** — reads `~/.claude/.credentials.json`, `~/.codex/auth.json`, `~/.gemini/oauth_creds.json`, calls `scion hub secret push <name> --from-file <path>`. ~50 lines of Go in `internal/staging/creds.go`.
+- **`stage-skills.sh`** — copies skill bundles from `.scion/skills-staging/` into per-role directories. ~80 lines of Go in `internal/staging/skills.go` (some of this already exists; the bash wrapper is now redundant).
+
+This collapses two subprocess hops into in-process Go calls, gives us proper error handling, and removes ~200 lines of bash that's hard to test.
+
+## Migration path
+
+Each phase below is an independent, shippable PR. They do not need to land in this exact order, but each builds context for the next.
+
+| # | PR | Scope |
+|---|---|---|
+| A | Introduce `Step` abstraction; migrate `runBootstrap` | Pure refactor of `bootstrap.go`. No behavior change. New tests verify forward order matches existing tests. |
+| B | Migrate `runDown` to use the same step list | Folds the down-side logic into `lifecycle`. The asymmetry guard becomes "if you add a step, you write its `Down` field at the same time." |
+| C | Extract `runScionCmd` helper; route all ScionClient methods through it | Removes duplicated stderr-buffering. Each method gains its own `knownNoisy` list. |
+| D | Add `StopAgent`, `DeleteAgent`, `ServerStop`, `DeleteTemplate` to ScionClient; route `down.go`'s remaining raw `exec.Command` paths | Closes the "everything goes through the interface" invariant. |
+| E | Add `cleanAgentWorktrees` step to the lifecycle | New teardown-only step. `git worktree list --porcelain` → filter to `.scion/agents/` → `worktree remove --force` per entry → `worktree prune`. Best-effort; log + continue on stale entries. |
+| F | Port `stage-creds.sh` to `internal/staging/creds.go` | Behavior-preserving rewrite. Delete the bash file at the end. |
+| G | Port `stage-skills.sh` to `internal/staging/skills.go` | Same. |
+
+After G: `scripts/` directory is empty (or close to it), and the embed.FS no longer needs to ship bash bodies.
+
+Estimated total: ~5–6 PRs spread over a week of focused work. Each PR is small enough to review in one sitting (~200–400 LOC including tests).
+
+## What we're deliberately NOT doing
+
+- **Declarative YAML manifest for the lifecycle.** Considered. With 8 steps the structure cost outweighs the configurability benefit, and the `Step` struct already gives us 80% of the readability win.
+- **Terraform-style reconciliation engine** (desired-state ↔ actual-state diff loop). Wrong abstraction for a CLI that runs once and exits. Right answer for a daemon, but darken isn't one.
+- **Plugin system / hooks** so operators can inject steps. Premature — no operator has asked for this. Add when there's a second project that needs different lifecycle behavior.
+- **Replacing bones.** Bones is a parallel layer (cross-machine coordination), not scion-replaceable, not darken-replaceable. Stays as-is.
+- **Replacing scion.** Out of scope by definition — scion is upstream at Google.
+- **Building a `darken compose` (docker-compose-style) interface.** Considered. Bones is its own daemon, not a docker service; scion sometimes runs containerized but historically doesn't. Compose would fight the existing layering.
+
+## Deferred-to-scion appendix
+
+If we ever talk to the scion maintainers, these are the things that *should* live there but currently can't because we don't control scion. Listed for completeness — no expectation of action.
+
+1. **`scion up` / `scion down`** as composite commands.  
+   Current: darken sequences `server start`, `broker provide`, `templates import`, `clean`, etc.  
+   Better: `scion up` does all of those for the current grove; darken just calls one command. `scion down` is the inverse.
+
+2. **`scion doctor --json`** for machine-readable preflight.  
+   Current: darken has its own `darken doctor` that reimplements docker/PATH/server checks.  
+   Better: scion exposes the checks as structured output; darken consumes them and decorates with project-specific concerns.
+
+3. **`scion hub secret push --from-file`** with directory-of-files semantics.  
+   Current: `stage-creds.sh` loops over harness types and calls `scion hub secret push` per credential.  
+   Better: scion accepts a manifest or directory and stages all of them.
+
+4. **Cobra `SilenceUsage = true`** on runtime failures.  
+   Current: scion dumps the full Usage block on errors like "no importable agent definitions" — a user error, not a syntax error. Cobra's default is to print Usage on any non-nil return from `RunE`, which is wrong for runtime failures.  
+   Better: scion sets `SilenceUsage = true` and only prints Usage on cobra-detected arg errors.
+
+5. **`scion grove delete <id>`** as an explicit subcommand.  
+   Current: `scion clean` is the canonical path, but the discoverability is poor — operators (and orchestration layers like darken) reach for `scion grove delete` first and get a Usage dump. The aliasing or subcommand naming is the real issue.
+
+If you do file these upstream: file 4 first. It's a one-line change in scion that would have prevented #43 entirely on the scion side.
+
+## Out-of-scope, but flagged
+
+- **`bones down` starts a hub mid-teardown.** Not a darken bug, but a confusing log line. The chainBonesDown comment added in #45 documents it. Long-term: ask bones if the hub-spinup can be silent or labeled as "deregistering."
+- **`.bones/` and `.scion/init-manifest.json` are runtime artifacts left in the working tree** after `darken up`. Belong in `.gitignore`. Trivial, separate PR.
+
+## Open questions
+
+- Should `lifecycle` be a package-level `var` or a function that returns the list? Function lets us inject test doubles; var is simpler. Lean: var, with a test-only helper that overrides individual steps.
+- Should `Step.Critical = false` steps log to stderr on failure (current behavior) or be silent? Today `darken down`'s loop logs "step failed: <err> (continuing best-effort)" for every soft-fail. That's noisy when nothing is actually wrong (e.g. `withdrawBroker` when broker was never provided). Probably worth a `Step.SuppressErrorLog` flag, decided per step.

--- a/docs/darken-lifecycle-refactor.md
+++ b/docs/darken-lifecycle-refactor.md
@@ -16,39 +16,66 @@ The unifying observation: **darken is a thin orchestration layer that doesn't mo
 
 ## Target shape
 
-### 1. `Step` abstraction with paired up/down
+### 1. `Resource` interface — model the things, not the steps
 
-Replace `[]func() error` in both `runBootstrap` and `runDown` with a single declared list of steps that own both directions:
+Replace `[]func() error` (and the planned `Step` struct) with a small interface representing each piece of state darken manages:
 
 ```go
-type Step struct {
-    Name     string
-    Up       func() error // forward (darken up)
-    Down     func() error // reverse (darken down); nil = no-op
-    Critical bool         // hard-fail vs best-effort
-}
-
-var lifecycle = []Step{
-    {Name: "docker daemon reachable",
-     Up: checkDocker, Down: nil, Critical: true},
-    {Name: "scion CLI present",
-     Up: checkScion, Down: nil, Critical: true},
-    {Name: "scion server running",
-     Up: ensureScionServer, Down: nil /* leave running */, Critical: true},
-    {Name: "broker provided to grove",
-     Up: ensureBrokerProvide, Down: withdrawBrokerInline, Critical: false},
-    {Name: "darken images built",
-     Up: ensureImages, Down: nil /* keep images */, Critical: true},
-    {Name: "hub secrets pushed",
-     Up: ensureHubSecrets, Down: nil, Critical: true},
-    {Name: "templates staged + imported",
-     Up: ensureAllSkillsStaged, Down: deleteProjectGrove, Critical: true},
-    {Name: "final doctor",
-     Up: finalDoctor, Down: nil, Critical: false},
+type Resource interface {
+    Name() string
+    Ensure() error  // idempotent: bring this resource to ready state
+    Release() error // idempotent: bring this resource to clean state
 }
 ```
 
-`runBootstrap` walks forward calling `step.Up`. `runDown` walks reverse calling `step.Down` where non-nil. The asymmetry that produced #45 literally cannot recur — every step ships with its own teardown, and the reviewer can read up/down side-by-side in one place.
+Each managed thing — broker registration, scion server, hub secrets, agent worktrees, substrate — becomes a struct implementing this interface. **Both lifecycle directions are interface methods**, so the bug class from #45 (forgot the symmetric pair) becomes a *compile error* rather than a runtime gap. You cannot add a resource without writing both directions.
+
+```go
+type GroveBroker struct{}
+func (GroveBroker) Name() string    { return "broker provided to grove" }
+func (GroveBroker) Ensure() error   { return defaultScionClient.BrokerProvide() }
+func (GroveBroker) Release() error  { return defaultScionClient.BrokerWithdraw() }
+
+type ScionServer struct{}
+func (ScionServer) Name() string    { return "scion server running" }
+func (ScionServer) Ensure() error {
+    if _, err := defaultScionClient.ServerStatus(); err == nil {
+        return nil // already running; no-op
+    }
+    return scionCmdWithEnv([]string{"server", "start"}).Run()
+}
+func (ScionServer) Release() error  { return nil /* leave running between projects */ }
+```
+
+For down-only concerns (stop agents, clean worktrees), `Ensure()` is a no-op and `Release()` does the work. The interface stays uniform; the code is honest about what each resource actually does:
+
+```go
+type ProjectAgents struct{}
+func (ProjectAgents) Name() string   { return "project agents" }
+func (ProjectAgents) Ensure() error  { return nil /* spawned via darken spawn, not up */ }
+func (ProjectAgents) Release() error { return stopAndDeleteAllAgentsInGrove() }
+```
+
+The lifecycle is then a single declared slice of `Resource`:
+
+```go
+var lifecycle = []Resource{
+    DockerDaemon{},   // up: check reachable;     down: no-op
+    ScionCLI{},       // up: check on PATH;       down: no-op
+    ScionServer{},    // up: start if not;         down: no-op (leave running)
+    GroveBroker{},    // up: provide;              down: withdraw
+    DarkenImages{},   // up: make per-backend;     down: no-op (keep cache)
+    HubSecrets{},     // up: stage from $HOME;     down: no-op
+    Substrate{},      // up: stage skills+import;  down: no-op (clean covers it)
+    ProjectAgents{},  // up: no-op;                down: stop + delete each
+    AgentWorktrees{}, // up: no-op;                down: git worktree remove + prune
+    Grove{},          // up: ensure registered;    down: scion clean
+}
+```
+
+`Up()` walks forward calling `Ensure()`. `Down()` walks reverse calling `Release()`. Each resource implementation is a *deep module* — caller sees three methods; implementation hides scion-command choice, idempotency check, error wrapping, and any per-resource state.
+
+Why this is deeper than a `Step` struct of function pointers: a Step is a tuple — depth still lives in the closures. A Resource is a noun the system manages. Each implementation can carry its own state (e.g. `DarkenImages{Backends: []string{"claude","codex","pi","gemini"}}`) without leaking it through the interface.
 
 ### 2. Route every scion call through `ScionClient`
 
@@ -95,34 +122,59 @@ Three caller patterns:
 - `runScionCmd(cmd, "no importable agent definitions")` — suppress one known mode
 - Methods that need a friendly error wrap their own message after the helper returns
 
-### 4. Agent worktree cleanup
+### 4. Agent worktree cleanup as a Resource
 
 `darken spawn` creates real git worktrees at `.scion/agents/<name>/workspace` (see the `agent-worktree-discipline` skill). `darken down` currently calls `scion stop` and `scion delete` per agent in `stopProjectAgents`, then `scion clean` removes the entire `.scion/` directory. That deletes the *files* under each worktree but leaves the parent repo's worktree registry pointing at directories that no longer exist — a future `git worktree list` will show orphans, and `git worktree prune` won't run unless something invokes it.
 
-The lifecycle should explicitly own this. Two changes:
-
-- A new teardown-only step that walks `git worktree list --porcelain`, filters to anything under `.scion/agents/`, and calls `git worktree remove --force <path>` for each before `deleteProjectGrove` runs. After the loop, `git worktree prune` for safety.
-- The `Step` struct supports teardown-only steps (`Up` is nil-able), so this slots into the same list as everything else:
+In the Resource model this is just one more entry in `lifecycle`:
 
 ```go
-{Name: "stop project agents",
- Up: nil, Down: stopProjectAgents,    Critical: false},
-{Name: "clean agent worktrees",
- Up: nil, Down: cleanAgentWorktrees,  Critical: false},
+type AgentWorktrees struct{}
+func (AgentWorktrees) Name() string  { return "agent worktrees" }
+func (AgentWorktrees) Ensure() error { return nil /* spawn manages creation */ }
+func (AgentWorktrees) Release() error {
+    paths, err := listWorktreesUnder(".scion/agents/")
+    if err != nil { return err }
+    for _, p := range paths {
+        _ = exec.Command("git", "worktree", "remove", "--force", p).Run()
+    }
+    return exec.Command("git", "worktree", "prune").Run()
+}
 ```
 
-These run in reverse order on `darken down` and are skipped on `darken up`. Keeps the model uniform.
+Best-effort by design: an operator who manually `rm -rf`'d a worktree dir shouldn't be blocked from teardown by a stale registry entry. The walker logs and continues.
 
-Open question: should worktree cleanup be best-effort (log + continue) or hard-fail? Probably best-effort — an operator who manually `rm -rf`'d a worktree dir shouldn't be blocked from teardown by a stale registry entry.
+### 5. Bash scripts disappear *into* resources
 
-### 5. Replace bash scripts with native Go
+`scripts/stage-creds.sh` and `scripts/stage-skills.sh` are subprocess-of-subprocess layers (darken → bash → scion). With the Resource pattern there's no separate "port the bash" phase — they just become the body of the relevant `Ensure()`:
 
-`scripts/stage-creds.sh` and `scripts/stage-skills.sh` are subprocess-of-subprocess layers (darken → bash → scion). Both do work that's clearly Go-shaped:
+- **`stage-creds.sh`** → `HubSecrets.Ensure()`. Walk known credential files in `$HOME`, call `defaultScionClient.PushSecret(name, path)` for each. ~30 lines of Go.
+- **`stage-skills.sh`** → folded into `Substrate.Ensure()`. Walk role manifests, resolve modes, copy skill bundles into per-role staging dirs, then call `defaultScionClient.ImportAllTemplates(root)`. ~80 lines of Go (some already exists in `internal/staging/`; the bash wrapper becomes redundant).
 
-- **`stage-creds.sh`** — reads `~/.claude/.credentials.json`, `~/.codex/auth.json`, `~/.gemini/oauth_creds.json`, calls `scion hub secret push <name> --from-file <path>`. ~50 lines of Go in `internal/staging/creds.go`.
-- **`stage-skills.sh`** — copies skill bundles from `.scion/skills-staging/` into per-role directories. ~80 lines of Go in `internal/staging/skills.go` (some of this already exists; the bash wrapper is now redundant).
+This collapses two subprocess hops into in-process Go calls, gives us proper error handling, and removes ~200 lines of bash that's hard to test. The `runSubstrateScript` machinery and the embed.FS bash bodies can be deleted entirely.
 
-This collapses two subprocess hops into in-process Go calls, gives us proper error handling, and removes ~200 lines of bash that's hard to test.
+### 6. `darken doctor` becomes a third traversal
+
+The Resource list models the world. Three commands are three traversals of the same list:
+
+| Command | Traversal | Per-resource action |
+|---|---|---|
+| `darken up`     | forward  | `Ensure()` |
+| `darken down`   | reverse  | `Release()` |
+| `darken doctor` | forward  | `Observe()` (read-only state report) |
+
+For `Observe()` to work without bloating the interface, extend `Resource` with one optional method via an embedded type-assertion check:
+
+```go
+type Observer interface {
+    Resource
+    Observe() (status, detail string)  // pretty-printable state
+}
+```
+
+Resources that can cheaply report state implement `Observer`; ones that can't are reported as "(no observer)" in doctor output. This is opt-in — no impact on the core 3-method `Resource` interface.
+
+The win: `darken doctor`, `darken up`, and `darken down` become three views of the same world model. Adding a new resource means it shows up in all three commands automatically. The current code has separate per-command logic that drifts.
 
 ## Migration path
 
@@ -130,23 +182,26 @@ Each phase below is an independent, shippable PR. They do not need to land in th
 
 | # | PR | Scope |
 |---|---|---|
-| A | Introduce `Step` abstraction; migrate `runBootstrap` | Pure refactor of `bootstrap.go`. No behavior change. New tests verify forward order matches existing tests. |
-| B | Migrate `runDown` to use the same step list | Folds the down-side logic into `lifecycle`. The asymmetry guard becomes "if you add a step, you write its `Down` field at the same time." |
-| C | Extract `runScionCmd` helper; route all ScionClient methods through it | Removes duplicated stderr-buffering. Each method gains its own `knownNoisy` list. |
-| D | Add `StopAgent`, `DeleteAgent`, `ServerStop`, `DeleteTemplate` to ScionClient; route `down.go`'s remaining raw `exec.Command` paths | Closes the "everything goes through the interface" invariant. |
-| E | Add `cleanAgentWorktrees` step to the lifecycle | New teardown-only step. `git worktree list --porcelain` → filter to `.scion/agents/` → `worktree remove --force` per entry → `worktree prune`. Best-effort; log + continue on stale entries. |
-| F | Port `stage-creds.sh` to `internal/staging/creds.go` | Behavior-preserving rewrite. Delete the bash file at the end. |
-| G | Port `stage-skills.sh` to `internal/staging/skills.go` | Same. |
+| A | Define `Resource` interface + `Up()`/`Down()` walkers; port two simplest resources (`DockerDaemon`, `ScionCLI`) | Establishes the pattern, validates the migration ergonomics. New tests target each resource in isolation. |
+| B | Port up-side resources: `ScionServer`, `GroveBroker`, `DarkenImages`, `HubSecrets`, `Substrate` | Bulk of the work. Each lives in `internal/resources/<name>.go`. `runBootstrap` shrinks to a 5-line walker. |
+| C | Port down-only resources: `ProjectAgents`, `AgentWorktrees`, `Grove` | These have no-op `Ensure()`. `runDown` shrinks to a 5-line reverse walker. The forgotten-pair bug class is now structurally impossible. |
+| D | Extract `runScionCmd` helper; route all `ScionClient` methods through it | Removes duplicated stderr-buffering. Each method declares its own `knownNoisy` list. |
+| E | Add `StopAgent`, `DeleteAgent`, `ServerStop`, `DeleteTemplate`, `PushSecret` to `ScionClient`; convert remaining raw `exec.Command` paths | Closes the "everything goes through the interface" invariant. Resources route exclusively through the interface. |
+| F | Delete `stage-creds.sh` (folded into `HubSecrets.Ensure`) | Remove subprocess hop. Delete bash file + embed.FS plumbing for it. |
+| G | Delete `stage-skills.sh` (folded into `Substrate.Ensure`) | Same. |
+| H | Add `Observer` interface; refactor `darken doctor` to walk the same `[]Resource` | Three commands, one world model. Adding a new resource makes it visible to doctor automatically. |
 
-After G: `scripts/` directory is empty (or close to it), and the embed.FS no longer needs to ship bash bodies.
+After H: `scripts/` directory is empty (or close to it), the embed.FS no longer ships bash, and `darken up`/`darken down`/`darken doctor` are three traversals of `lifecycle`.
 
-Estimated total: ~5–6 PRs spread over a week of focused work. Each PR is small enough to review in one sitting (~200–400 LOC including tests).
+Estimated total: ~6–8 PRs over a week of focused work. Each PR is small enough to review in one sitting (~200–400 LOC including tests). Phases A–C are the structural change; D–H are cleanup that compounds on it.
 
 ## What we're deliberately NOT doing
 
-- **Declarative YAML manifest for the lifecycle.** Considered. With 8 steps the structure cost outweighs the configurability benefit, and the `Step` struct already gives us 80% of the readability win.
-- **Terraform-style reconciliation engine** (desired-state ↔ actual-state diff loop). Wrong abstraction for a CLI that runs once and exits. Right answer for a daemon, but darken isn't one.
-- **Plugin system / hooks** so operators can inject steps. Premature — no operator has asked for this. Add when there's a second project that needs different lifecycle behavior.
+- **Declarative YAML manifest for the lifecycle.** Considered. With ~10 resources the structure cost outweighs the configurability benefit, and the `Resource` interface already gives us symmetry-by-construction in plain Go.
+- **A `Step` struct of paired function pointers** (the first-draft of this doc). Considered and rejected: a tuple is shallower than an interface. `Step{Up: f, Down: nil}` compiles fine, leaving the asymmetry-bug class prevented only by convention. The Resource interface makes "forgot the down side" a type error.
+- **Terraform-style reconciliation engine** (desired-state ↔ actual-state diff loop). Wrong abstraction for a CLI that runs once and exits. Right answer for a daemon, but darken isn't one. The Resource pattern gets most of reconciliation's clarity (idempotent Ensure/Release) without the planning machinery.
+- **Plugin system / hooks** so operators can inject resources. Premature — no operator has asked for this. Add when there's a second project that needs different lifecycle behavior.
+- **`Resource.DependsOn() []Resource`** for explicit DAG ordering. Premature — slice order encodes the topology fine for ~10 resources. Add if the list grows past ~20 or if resources start being conditionally enabled.
 - **Replacing bones.** Bones is a parallel layer (cross-machine coordination), not scion-replaceable, not darken-replaceable. Stays as-is.
 - **Replacing scion.** Out of scope by definition — scion is upstream at Google.
 - **Building a `darken compose` (docker-compose-style) interface.** Considered. Bones is its own daemon, not a docker service; scion sometimes runs containerized but historically doesn't. Compose would fight the existing layering.
@@ -183,5 +238,7 @@ If you do file these upstream: file 4 first. It's a one-line change in scion tha
 
 ## Open questions
 
-- Should `lifecycle` be a package-level `var` or a function that returns the list? Function lets us inject test doubles; var is simpler. Lean: var, with a test-only helper that overrides individual steps.
-- Should `Step.Critical = false` steps log to stderr on failure (current behavior) or be silent? Today `darken down`'s loop logs "step failed: <err> (continuing best-effort)" for every soft-fail. That's noisy when nothing is actually wrong (e.g. `withdrawBroker` when broker was never provided). Probably worth a `Step.SuppressErrorLog` flag, decided per step.
+- Should `lifecycle` be a package-level `var` or a function that returns the list? Function lets us inject test doubles; var is simpler. Lean: var, with a test-only helper that overrides individual entries by type.
+- Where do "criticality" and "soft-fail logging" live? In the `Step` draft these were struct fields. With `Resource` they belong inside the implementation: a resource decides for itself whether `Ensure()` returning an error should abort up, and whether `Release()` failures should log. The walker just propagates errors; the resource decides what to return. This pulls a bit more complexity into each resource but removes a config field from the interface.
+- Should `Resource.Ensure()` always be safe to call (no-op when already ready), or should we add a separate `Status() State` method and let the walker decide? Lean: keep `Ensure()` self-idempotent. The walker stays trivial. Doctor uses `Observer` for read-only state.
+- Naming: `Ensure`/`Release` vs `Up`/`Down` vs `Acquire`/`Release` vs `Start`/`Stop`. Picked `Ensure`/`Release` because (a) `Up`/`Down` collides with `Project.Up()`/`Project.Down()` walkers, (b) `Acquire` implies locking, (c) `Start`/`Stop` implies a process. `Ensure`/`Release` are direction-symmetric and idempotent-flavored.

--- a/docs/darken-lifecycle-refactor.md
+++ b/docs/darken-lifecycle-refactor.md
@@ -187,13 +187,27 @@ Each phase below is an independent, shippable PR. They do not need to land in th
 | C | Port down-only resources: `ProjectAgents`, `AgentWorktrees`, `Grove` | These have no-op `Ensure()`. `runDown` shrinks to a 5-line reverse walker. The forgotten-pair bug class is now structurally impossible. |
 | D | Extract `runScionCmd` helper; route all `ScionClient` methods through it | Removes duplicated stderr-buffering. Each method declares its own `knownNoisy` list. |
 | E | Add `StopAgent`, `DeleteAgent`, `ServerStop`, `DeleteTemplate`, `PushSecret` to `ScionClient`; convert remaining raw `exec.Command` paths | Closes the "everything goes through the interface" invariant. Resources route exclusively through the interface. |
-| F | Delete `stage-creds.sh` (folded into `HubSecrets.Ensure`) | Remove subprocess hop. Delete bash file + embed.FS plumbing for it. |
-| G | Delete `stage-skills.sh` (folded into `Substrate.Ensure`) | Same. |
-| H | Add `Observer` interface; refactor `darken doctor` to walk the same `[]Resource` | Three commands, one world model. Adding a new resource makes it visible to doctor automatically. |
+| F | Native Go for `stage-creds.sh` host-side calls (folded into `HubSecrets.Ensure`, `runCreds`, `runSpawn`); bash remains for container-side `spawn.sh` and operator-facing `darken creds` invocations the embed still ships | Remove host-side subprocess hop. Full deletion of the bash file is blocked on the container-side spawn.sh refactor — out of scope for this PR. |
+| G | Native Go for `stage-skills.sh` rebuild mode (folded into `Substrate.Ensure` and `stageSkillsForRole`); bash remains for `darken skills add/remove/diff` operator commands and container-side use | Same trade as Phase F — host-side subprocess hop gone, full deletion deferred. |
+| H | Add `Observer` interface; ship `lifecycleObservations()` helper and Observe() impls on 4 resources (Docker, ScionCLI, ScionServer, Grove). `darken doctor` consolidation deferred to a follow-up PR — the existing DoctorCheck registry has severity/remediation/ID features that need to merge into the Observer model first | Closes the design loop and proves Observer is workable; the doctor consolidation is mechanical polish. |
 
-After H: `scripts/` directory is empty (or close to it), the embed.FS no longer ships bash, and `darken up`/`darken down`/`darken doctor` are three traversals of `lifecycle`.
+After H: host-side orchestration code shrinks ~50%. `darken up`/`darken down` are two traversals of `lifecycle`; `darken doctor` is positioned to become the third in a follow-up.
 
-Estimated total: ~6–8 PRs over a week of focused work. Each PR is small enough to review in one sitting (~200–400 LOC including tests). Phases A–C are the structural change; D–H are cleanup that compounds on it.
+This refactor ships in one PR (the operator's "specs ship with implementation" rule), as a sequence of focused commits A→H. Each commit is small enough to review in one sitting (~200–400 LOC including tests).
+
+## What's actually deleted vs deferred
+
+This PR removes:
+- The hand-rolled `[]struct{name, fn}` step lists in `runBootstrap` and `runDown`
+- 5 standalone `ensure*` functions (logic moved into Resource methods)
+- 3 standalone down-side functions (logic moved into Resource methods)
+- All raw `exec.Command` paths for scion in `cmd/darken/` (everything routes through `ScionClient`)
+- ~125 lines of bash credential-staging logic from the host invocation path
+- ~250 lines of bash skill-staging logic from the host invocation path
+
+This PR does *not* delete:
+- `scripts/stage-creds.sh` and `scripts/stage-skills.sh` files — the embedded copies are still consumed by container-side `spawn.sh` (out of scope).
+- The DoctorCheck registry in `doctor.go` — full unification is a follow-up that needs to merge severity/remediation/ID semantics into the Observer model.
 
 ## What we're deliberately NOT doing
 


### PR DESCRIPTION
## Summary

Design doc capturing the simplification plan for `darken up` / `darken down` — the synthesis of recent bugs (#43, #45) and the architecture conversation that followed.

Lives at `docs/darken-lifecycle-refactor.md` (187 lines). No code changes.

### Key moves the doc proposes

- **`Step` abstraction with paired up/down** — symmetric teardown is enforced structurally, so the missing-`BrokerWithdraw` class of bug can't recur
- **Route every scion call through `ScionClient`** — no raw `exec.Command` paths in `down.go` (currently in `stopProjectAgents` and `purgeHostState`)
- **Single stderr-triage helper** to replace the per-method buffering we now have in two places (will need it in more)
- **Explicit agent worktree cleanup step** — currently implicit via `scion clean` removing `.scion/`, which leaves orphan git worktree registry entries
- **Replace `stage-creds.sh` and `stage-skills.sh` with native Go** — collapses two subprocess hops, ~200 lines of bash deleted

Migration is **5–6 independent PR-sized phases** (lettered A–G in the doc), each ~200–400 LOC including tests.

### What we're explicitly NOT doing

- Declarative YAML manifest (overkill for 8 steps)
- Terraform-style reconciliation engine (wrong abstraction for a CLI)
- Plugin / hooks system (premature)
- Replacing bones or scion (out of scope)
- Building a docker-compose-style interface (fights existing layering)

### Deferred-to-scion appendix

scion is Google's, so we can't change it. The doc still lists what *should* live there as an upstream-issue checklist if someone wants to file with the scion team later. The most useful single change would be `SilenceUsage = true` on cobra runtime errors — that one-line scion change would have prevented #43 entirely.

## Test plan

- [x] `wc -l docs/darken-lifecycle-refactor.md` → 187
- [x] No code changes; nothing to test
- [ ] You read it and tell me if any phase needs reshaping before I start the actual code work