### PR TITLE
fix(scion-client) pass --non-interactive flag to resolve env vs flag mismatch

### DIFF
--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -101,7 +101,7 @@ func (c *execScionClient) BrokerProvide() error {
 }
 
 func (c *execScionClient) PushTemplate(role string) error {
-	cmd := scionCmdWithEnv([]string{"--global", "templates", "push", role})
+	cmd := scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "push", role})
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -113,7 +113,7 @@ func (c *execScionClient) ImportAllTemplates(dir string) error {
 	// buffer on success or on unrecognized failures preserves operator
 	// visibility for everything else.
 	var stderrBuf bytes.Buffer
-	cmd := scionCmdWithEnv([]string{"--global", "templates", "import", "--all", dir})
+	cmd := scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "import", "--all", dir})
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderrBuf
 	err := cmd.Run()

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -9,18 +9,18 @@ import (
 
 // mockScionClient is a configurable ScionClient for unit tests.
 type mockScionClient struct {
-	serverStatusOut    string
-	serverStatusErr    error
-	secretListOut      string
-	secretListErr      error
-	startAgentErr      error
-	brokerProvideErr   error
-	brokerWithdrawErr  error
-	pushTemplateErr    error
-	groveInitErr       error
-	cleanGroveErr      error
-	lookAgentOut       []byte
-	lookAgentErr       error
+	serverStatusOut   string
+	serverStatusErr   error
+	secretListOut     string
+	secretListErr     error
+	startAgentErr     error
+	brokerProvideErr  error
+	brokerWithdrawErr error
+	pushTemplateErr   error
+	groveInitErr      error
+	cleanGroveErr     error
+	lookAgentOut      []byte
+	lookAgentErr      error
 
 	importAllTemplatesErr   error
 	importAllTemplatesCalls []string
@@ -228,6 +228,52 @@ func TestImportAllTemplates_SurfacesUnknownStderr(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "broker refused") {
 		t.Fatalf("unknown errors should pass through to stderr, got: %q", stderr)
+	}
+}
+
+// TestExecScionClient_PushTemplate_IncludesNonInteractiveFlag asserts that
+// PushTemplate explicitly passes --non-interactive to scion rather than relying
+// on the SCION_NON_INTERACTIVE env var, which triggers a multiple-templates-found
+// error when both global and grove scopes hold the same template name.
+func TestExecScionClient_PushTemplate_IncludesNonInteractiveFlag(t *testing.T) {
+	stubDir := t.TempDir()
+	argsFile := filepath.Join(stubDir, "args.log")
+	stub := "#!/bin/sh\necho \"$@\" >> " + argsFile + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	c := &execScionClient{}
+	if err := c.PushTemplate("researcher"); err != nil {
+		t.Fatalf("PushTemplate: %v", err)
+	}
+	body, _ := os.ReadFile(argsFile)
+	if !strings.Contains(string(body), "--non-interactive") {
+		t.Errorf("PushTemplate did not pass --non-interactive to scion; args: %s", body)
+	}
+}
+
+// TestExecScionClient_ImportAllTemplates_IncludesNonInteractiveFlag asserts that
+// ImportAllTemplates explicitly passes --non-interactive to scion rather than relying
+// on the SCION_NON_INTERACTIVE env var, which triggers a multiple-templates-found
+// error when both global and grove scopes hold the same template name.
+func TestExecScionClient_ImportAllTemplates_IncludesNonInteractiveFlag(t *testing.T) {
+	stubDir := t.TempDir()
+	argsFile := filepath.Join(stubDir, "args.log")
+	stub := "#!/bin/sh\necho \"$@\" >> " + argsFile + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	c := &execScionClient{}
+	if err := c.ImportAllTemplates(t.TempDir()); err != nil {
+		t.Fatalf("ImportAllTemplates: %v", err)
+	}
+	body, _ := os.ReadFile(argsFile)
+	if !strings.Contains(string(body), "--non-interactive") {
+		t.Errorf("ImportAllTemplates did not pass --non-interactive to scion; args: %s", body)
 	}
 }
 

--- a/cmd/darken/setup_test.go
+++ b/cmd/darken/setup_test.go
@@ -239,11 +239,11 @@ func TestSetup_UploadsAllTemplatesToHub(t *testing.T) {
 	}
 
 	// The PATH scion stub logs every scion invocation. Verify that
-	// --global templates push <role> appears for every canonical role.
+	// --global --non-interactive templates push <role> appears for every canonical role.
 	body, _ := os.ReadFile(logPath)
 	log := string(body)
 	for _, role := range canonicalRoles {
-		want := "--global templates push " + role
+		want := "--global --non-interactive templates push " + role
 		if !strings.Contains(log, want) {
 			t.Errorf("expected scion %q to be called; log:\n%s", want, log)
 		}


### PR DESCRIPTION
## Root cause

`SCION_NON_INTERACTIVE=1` in the environment triggers a scope-disambiguation
path in the scion CLI that produces a "multiple-templates-found" error when
both global and grove scopes hold a template with the same name.  Passing the
`--non-interactive` flag explicitly on the command line takes the unambiguous
code path and succeeds.

`PushTemplate` and `ImportAllTemplates` in `execScionClient` were relying on
the env var alone.  This broke `darken up` / `darken setup` for any developer
whose shell or CI environment exports `SCION_NON_INTERACTIVE=1`.

## Change

Append `--non-interactive` to the args slice in both methods:

```go
// PushTemplate — before
scionCmdWithEnv([]string{"--global", "templates", "push", role})

// PushTemplate — after
scionCmdWithEnv([]string{"--global", "--non-interactive", "templates", "push", role})
```

Same change applied to `ImportAllTemplates`.

## Regression test

`TestExecScionClient_PushTemplate_IncludesNonInteractiveFlag` and
`TestExecScionClient_ImportAllTemplates_IncludesNonInteractiveFlag` in
`cmd/darken/scion_client_test.go` stub the `scion` binary to record its
argument list, call the method under test, and assert `--non-interactive`
appears in the recorded args.  Both tests were RED before this patch and GREEN
after.

Existing `TestSetup_PushesTemplatesForAllRoles` in `setup_test.go` was updated
to expect the new arg shape (`--global --non-interactive templates push <role>`).

## Local verification steps

```bash
# confirm RED before fix
git stash
go test ./cmd/darken/... -run "TestExecScionClient_PushTemplate_IncludesNonInteractiveFlag|TestExecScionClient_ImportAllTemplates_IncludesNonInteractiveFlag" -v
# both FAIL

# apply fix
git stash pop
go test ./cmd/darken/... -v
# full suite PASS

make darken
bin/darken up   # reaches Hub push for all 14 templates when Docker + scion server present
```