### PR TITLE
fix(grove): CleanGrove runs unconditionally on Release

### DIFF
--- a/cmd/darken/down_test.go
+++ b/cmd/darken/down_test.go
@@ -34,21 +34,26 @@ func TestGrove_ReleaseRoutesThroughCleanGrove(t *testing.T) {
 	}
 }
 
-// TestGrove_ReleaseNoOpWithoutGroveID confirms the resource is a clean
-// no-op (no client call, no error) when .scion/grove-id is absent — i.e.
-// the workspace was never bootstrapped, so there's nothing to clean.
-func TestGrove_ReleaseNoOpWithoutGroveID(t *testing.T) {
+// TestGrove_Release_CleansHubEvenWhenLocalStateMissing is the regression
+// test for the bug where Grove.Release silently no-oped when .scion/grove-id
+// was absent, leaving the hub grove registration stranded. CleanGrove must
+// be called unconditionally so scion clean --yes can decide idempotency.
+func TestGrove_Release_CleansHubEvenWhenLocalStateMissing(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", root)
+	// Intentionally do NOT create .scion/grove-id.
 
 	mc := &mockScionClient{}
 	setDefaultClient(t, mc)
 
 	if err := (Grove{}).Release(); err != nil {
-		t.Fatalf("Grove.Release should no-op without grove-id, got: %v", err)
+		t.Fatalf("Grove.Release: %v", err)
 	}
-	if len(mc.cleanGroveCalls) != 0 {
-		t.Fatalf("CleanGrove should not be called when grove-id missing; got: %v", mc.cleanGroveCalls)
+	if len(mc.cleanGroveCalls) == 0 {
+		t.Fatal("CleanGrove must be called even when .scion/grove-id is absent; got 0 calls")
+	}
+	if mc.cleanGroveCalls[0] != root {
+		t.Errorf("CleanGrove called with %q; want %q", mc.cleanGroveCalls[0], root)
 	}
 }
 

--- a/cmd/darken/resources.go
+++ b/cmd/darken/resources.go
@@ -207,9 +207,9 @@ func (ScionServer) Observe() (string, string) {
 // impossible because both methods are required.
 type GroveBroker struct{}
 
-func (GroveBroker) Name() string    { return "broker provided to grove" }
-func (GroveBroker) Ensure() error   { return defaultScionClient.BrokerProvide() }
-func (GroveBroker) Release() error  { return defaultScionClient.BrokerWithdraw() }
+func (GroveBroker) Name() string   { return "broker provided to grove" }
+func (GroveBroker) Ensure() error  { return defaultScionClient.BrokerProvide() }
+func (GroveBroker) Release() error { return defaultScionClient.BrokerWithdraw() }
 
 // DarkenImages ensures every per-backend image is built. Idempotent
 // per-backend via imageExists. Release is a no-op — the image cache is
@@ -292,9 +292,6 @@ func (Grove) Ensure() error {
 func (Grove) Release() error {
 	root, err := repoRoot()
 	if err != nil {
-		return nil
-	}
-	if _, err := os.Stat(filepath.Join(root, ".scion", "grove-id")); err != nil {
 		return nil
 	}
 	return defaultScionClient.CleanGrove(root)

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -157,7 +157,10 @@ func (c *execScionClient) GroveInit(targetDir string) error {
 func (c *execScionClient) CleanGrove(targetDir string) error {
 	cmd := scionCmdWithEnv([]string{"clean", "--yes"})
 	cmd.Dir = targetDir
-	err, _ := runScionCmd(cmd)
+	err, suppressed := runScionCmd(cmd, "no scion grove found")
+	if suppressed {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
Closes #58

## Summary

- Removes the `.scion/grove-id` presence gate in `Grove.Release()` so `CleanGrove` is called unconditionally; `scion clean --yes` already handles missing local state idempotently.
- Adds `"no scion grove found"` to the noisy-substring filter in `execScionClient.CleanGrove` so teardowns against already-clean workspaces suppress that known-benign error rather than surfacing it as a failure.
- Inverts `TestGrove_ReleaseNoOpWithoutGroveID` (which codified the bug) into `TestGrove_Release_CleansHubEvenWhenLocalStateMissing`, asserting `cleanGroveCalls` is non-empty even when `.scion/grove-id` is absent.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (3 packages)
- [x] `go build ./...` — clean
- [x] `gofmt -d` on changed files — clean (fixed pre-existing alignment drift on GroveBroker stubs while in the file)