### PR TITLE
feat(audit): darken audit append substrate helper

### DIFF
--- a/cmd/darken/audit.go
+++ b/cmd/darken/audit.go
@@ -1,0 +1,133 @@
+// Package main — `darken audit` manages workspace audit-log entries.
+//
+// Subcommands:
+//
+//	append <decision_id> <type> <payload-json>
+//	    Write a JSONL entry to <workspace-root>/.scion/audit.jsonl.
+//	    Resolves the workspace root by (in priority order):
+//	      1. $DARKEN_WORKSPACE_ROOT env var
+//	      2. Walking up from cwd until a directory containing .scion/grove-id
+//	         is found.
+//	    Exits non-zero if no workspace root can be located.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// runAudit dispatches darken audit <subcommand>.
+func runAudit(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: darken audit <subcommand>\n  subcommands: append")
+	}
+	switch args[0] {
+	case "append":
+		return runAuditAppend(args[1:])
+	default:
+		return fmt.Errorf("audit: unknown subcommand %q (available: append)", args[0])
+	}
+}
+
+// runAuditAppend implements `darken audit append <decision_id> <type> <payload-json>`.
+func runAuditAppend(args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("audit append: cannot determine cwd: %w", err)
+	}
+	return runAuditAppendFromDir(cwd, args)
+}
+
+// runAuditAppendFromDir is the testable core: runs audit-append logic as if
+// cwd were dir. Tests call this directly to simulate different working
+// directories without actually changing the process cwd.
+func runAuditAppendFromDir(dir string, args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("usage: darken audit append <decision_id> <type> <payload-json>")
+	}
+	decisionID := args[0]
+	entryType := args[1]
+	payloadRaw := args[2]
+
+	// Validate payload is JSON.
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(payloadRaw), &payload); err != nil {
+		return fmt.Errorf("audit append: payload-json is not valid JSON: %w", err)
+	}
+
+	wsRoot, err := findWorkspaceRoot(dir)
+	if err != nil {
+		return err
+	}
+
+	return writeAuditEntry(wsRoot, decisionID, entryType, payload)
+}
+
+// findWorkspaceRoot locates the darken workspace root starting from dir.
+// It checks $DARKEN_WORKSPACE_ROOT first, then walks up looking for
+// a directory containing .scion/grove-id.
+func findWorkspaceRoot(dir string) (string, error) {
+	if v := os.Getenv("DARKEN_WORKSPACE_ROOT"); v != "" {
+		return v, nil
+	}
+	return walkToWorkspaceRoot(dir)
+}
+
+// walkToWorkspaceRoot walks from dir up to the filesystem root, returning
+// the first directory that contains .scion/grove-id.
+func walkToWorkspaceRoot(dir string) (string, error) {
+	current := dir
+	for {
+		sentinel := filepath.Join(current, ".scion", "grove-id")
+		if _, err := os.Stat(sentinel); err == nil {
+			return current, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached filesystem root without finding grove-id.
+			break
+		}
+		current = parent
+	}
+	return "", fmt.Errorf("audit append: no darken workspace found (no .scion/grove-id above %s); not inside a darken-managed workspace", dir)
+}
+
+// writeAuditEntry appends a JSONL entry to <wsRoot>/.scion/audit.jsonl,
+// creating the file (and .scion/ directory) lazily on first write.
+func writeAuditEntry(wsRoot, decisionID, entryType string, payload map[string]interface{}) error {
+	type entry struct {
+		Timestamp  string                 `json:"timestamp"`
+		DecisionID string                 `json:"decision_id"`
+		Harness    string                 `json:"harness,omitempty"`
+		Type       string                 `json:"type"`
+		Payload    map[string]interface{} `json:"payload,omitempty"`
+	}
+	e := entry{
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		DecisionID: decisionID,
+		Type:       entryType,
+		Payload:    payload,
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("audit append: marshal failed: %w", err)
+	}
+
+	logPath := filepath.Join(wsRoot, ".scion", "audit.jsonl")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("audit append: cannot create .scion dir: %w", err)
+	}
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("audit append: open failed: %w", err)
+	}
+	defer f.Close()
+	_, err = f.Write(append(b, '\n'))
+	if err != nil {
+		return fmt.Errorf("audit append: write failed: %w", err)
+	}
+	return nil
+}

--- a/cmd/darken/audit_test.go
+++ b/cmd/darken/audit_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeWorkspace creates a temporary darken workspace with a .scion/grove-id
+// sentinel and returns the workspace root path.
+func makeWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	scionDir := filepath.Join(root, ".scion")
+	if err := os.MkdirAll(scionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scionDir, "grove-id"), []byte("test-grove\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// makeWorktree creates a subdirectory simulating a git worktree under a
+// darken workspace. The worktree does NOT have its own .scion/grove-id.
+func makeWorktree(t *testing.T, workspaceRoot string) string {
+	t.Helper()
+	wt := filepath.Join(workspaceRoot, ".claude", "worktrees", "test-wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return wt
+}
+
+func TestAuditAppend_WritesToWorkspaceRoot(t *testing.T) {
+	root := makeWorkspace(t)
+	// Invoke from workspace root — should write to <root>/.scion/audit.jsonl.
+	err := runAuditAppendFromDir(root, []string{"dec-001", "dispatch", `{"target_role":"researcher"}`})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("audit.jsonl not created: %v", err)
+	}
+	if !strings.Contains(string(data), "dec-001") {
+		t.Fatalf("expected decision_id in log, got: %s", data)
+	}
+}
+
+func TestAuditAppend_WritesFromWorktree(t *testing.T) {
+	root := makeWorkspace(t)
+	wt := makeWorktree(t, root)
+
+	// Simulate cwd == worktree (not workspace root).
+	err := runAuditAppendFromDir(wt, []string{"dec-002", "route", `{"tier":"heavy"}`})
+	if err != nil {
+		t.Fatalf("unexpected error from worktree: %v", err)
+	}
+
+	// Entry must be in workspace-root audit log.
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("audit.jsonl not at workspace root: %v", err)
+	}
+	if !strings.Contains(string(data), "dec-002") {
+		t.Fatalf("expected entry in workspace-root audit log, got: %s", data)
+	}
+
+	// No stray .scion/ created inside the worktree.
+	if _, err := os.Stat(filepath.Join(wt, ".scion", "audit.jsonl")); err == nil {
+		t.Fatal("stray .scion/audit.jsonl created inside worktree")
+	}
+}
+
+func TestAuditAppend_CreatesFileLazily(t *testing.T) {
+	root := makeWorkspace(t)
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+
+	// File must not exist yet.
+	if _, err := os.Stat(logPath); err == nil {
+		t.Fatal("audit.jsonl should not exist before first write")
+	}
+
+	err := runAuditAppendFromDir(root, []string{"dec-003", "escalate", `{"axis":"reversibility"}`})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("audit.jsonl should exist after first write: %v", err)
+	}
+}
+
+func TestAuditAppend_ExitsNonZeroOutsideWorkspace(t *testing.T) {
+	// A plain temp dir with no .scion/grove-id anywhere above it.
+	tmp := t.TempDir()
+	err := runAuditAppendFromDir(tmp, []string{"dec-004", "route", `{}`})
+	if err == nil {
+		t.Fatal("expected non-zero error outside workspace")
+	}
+	if !strings.Contains(err.Error(), "workspace") {
+		t.Fatalf("error should mention workspace, got: %v", err)
+	}
+}
+
+func TestAuditAppend_WritesValidJSON(t *testing.T) {
+	root := makeWorkspace(t)
+	err := runAuditAppendFromDir(root, []string{"dec-005", "dispatch", `{"target_role":"sme","agent_name":"s1"}`})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Each line must be valid JSON.
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("invalid JSON line %q: %v", line, err)
+		}
+		// Must contain required fields.
+		for _, field := range []string{"timestamp", "decision_id", "type"} {
+			if _, ok := m[field]; !ok {
+				t.Fatalf("missing field %q in entry: %s", field, line)
+			}
+		}
+	}
+}
+
+func TestAuditAppend_AppendsMulitpleEntries(t *testing.T) {
+	root := makeWorkspace(t)
+	for i, args := range [][]string{
+		{"dec-010", "route", `{"tier":"light"}`},
+		{"dec-011", "dispatch", `{"target_role":"researcher"}`},
+		{"dec-012", "escalate", `{"axis":"trust"}`},
+	} {
+		if err := runAuditAppendFromDir(root, args); err != nil {
+			t.Fatalf("entry %d: %v", i, err)
+		}
+	}
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 entries, got %d:\n%s", len(lines), data)
+	}
+}
+
+func TestAuditAppend_DARKEN_WORKSPACE_ROOT_Override(t *testing.T) {
+	root := makeWorkspace(t)
+	// Set env override — no grove-id walk needed.
+	t.Setenv("DARKEN_WORKSPACE_ROOT", root)
+
+	// Invoke from a completely unrelated temp dir.
+	unrelated := t.TempDir()
+	err := runAuditAppendFromDir(unrelated, []string{"dec-020", "route", `{}`})
+	if err != nil {
+		t.Fatalf("unexpected error with DARKEN_WORKSPACE_ROOT set: %v", err)
+	}
+	logPath := filepath.Join(root, ".scion", "audit.jsonl")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("expected audit.jsonl at DARKEN_WORKSPACE_ROOT: %v", err)
+	}
+}
+
+func TestAuditAppend_MissingArgs(t *testing.T) {
+	root := makeWorkspace(t)
+	// Too few args — should return usage error.
+	err := runAuditAppendFromDir(root, []string{"dec-030"})
+	if err == nil {
+		t.Fatal("expected error for missing args")
+	}
+}
+
+func TestAuditAppend_HistoryReadsCanonicalPath(t *testing.T) {
+	root := makeWorkspace(t)
+	wt := makeWorktree(t, root)
+
+	// Write from the worktree.
+	if err := runAuditAppendFromDir(wt, []string{"dec-040", "route", `{"tier":"heavy"}`}); err != nil {
+		t.Fatalf("append from worktree: %v", err)
+	}
+
+	// darken history must find the entry via the workspace root.
+	t.Setenv("DARKEN_WORKSPACE_ROOT", root)
+	out, err := captureStdout(func() error { return runHistory(nil) })
+	if err != nil {
+		t.Fatalf("history error: %v", err)
+	}
+	// History output shows type column, not decision_id. Verify the entry
+	// written from the worktree appears by its type field.
+	if !strings.Contains(out, "route") {
+		t.Fatalf("history should show entry written from worktree, got:\n%s", out)
+	}
+}

--- a/cmd/darken/history.go
+++ b/cmd/darken/history.go
@@ -34,7 +34,7 @@ func runHistory(args []string) error {
 		return err
 	}
 
-	root, err := repoRoot()
+	root, err := historyRoot()
 	if err != nil {
 		return fmt.Errorf("not in an init'd repo: %w", err)
 	}
@@ -113,6 +113,17 @@ func runHistory(args []string) error {
 	}
 
 	return nil
+}
+
+// historyRoot returns the workspace root for reading the audit log.
+// It checks $DARKEN_WORKSPACE_ROOT before falling back to repoRoot()
+// so that both darken audit append and darken history agree on the
+// canonical log location.
+func historyRoot() (string, error) {
+	if v := os.Getenv("DARKEN_WORKSPACE_ROOT"); v != "" {
+		return v, nil
+	}
+	return repoRoot()
 }
 
 // summarizePayload returns a short string describing the most-relevant

--- a/cmd/darken/main.go
+++ b/cmd/darken/main.go
@@ -43,6 +43,7 @@ var subcommands = []subcommand{
 	{"status", "print one-line status (statusLine-friendly)", runStatus},
 	{"dashboard", "open scion's web UI in the default browser", runDashboard},
 	{"history", "tabular view of .scion/audit.jsonl", runHistory},
+	{"audit", "audit-log helpers (append ...)", runAudit},
 	{"modes", "list available modes or show one (modes list | modes show <name>)", runModes},
 }
 


### PR DESCRIPTION
Closes #54

## Summary

- Adds `darken audit append <decision_id> <type> <payload-json>` command that resolves the workspace root by walking up from cwd to find `.scion/grove-id` (or reading `$DARKEN_WORKSPACE_ROOT`), then appends a JSONL entry to `<workspace-root>/.scion/audit.jsonl`.
- Creates `.scion/audit.jsonl` lazily; exits non-zero with a descriptive error outside any darken-managed workspace.
- Updates `darken history` to check `$DARKEN_WORKSPACE_ROOT` so producers and consumers use the same canonical path.

## Acceptance criteria covered

- [x] `darken audit append` exists and writes to the workspace's canonical audit log regardless of cwd
- [x] Creates `.scion/audit.jsonl` lazily on first write
- [x] Exits non-zero (writes nothing) when invoked outside any darken-managed workspace
- [x] Reproduction test: from inside a git worktree under a darken workspace, appends to workspace-root audit log; no stray `.scion/audit.jsonl` created inside the worktree
- [x] `darken history` reads from the same canonical path (via `$DARKEN_WORKSPACE_ROOT` or `repoRoot()` fallback)

## Out of scope (per brief)

- Orchestrator-mode SKILL.md migration to use `darken audit append` — handled by issue #61's implementer to avoid collision.
- Historical audit-entry migration from stray worktree files.

## Local CI

```
go vet ./...       ✓
go test ./...      ✓  (29s, 3 packages)
go build ./...     ✓
gofmt -d           ✓  (no diff)
```