### PR TITLE
fix(stage-creds): --type env → --type environment, add doctor enum check

### DIFF
--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -183,6 +183,16 @@ func doctorBroadChecks() []DoctorCheck {
 			Detail:      bonesVersion,
 			Remediation: "brew install bones (or run `darken up --no-bones` to skip the bones chain)",
 		},
+		{
+			ID:       "scion-secret-type-enum",
+			Label:    "scion hub secret set --type enum accepts 'environment'",
+			Severity: SeverityFail,
+			Run:      checkScionSecretTypeSupport,
+			// Root cause: darken previously passed --type env; scion's enum is
+			// environment | variable | file. Any mismatch here breaks every spawn
+			// at the stage-creds step. See issue #57.
+			Remediation: "upgrade scion (brew upgrade scion or make install in ~/projects/scion)",
+		},
 	}
 }
 
@@ -390,6 +400,36 @@ func checkHubSecrets() error {
 		if !strings.Contains(out, want) {
 			return fmt.Errorf("missing hub secret: %s", want)
 		}
+	}
+	return nil
+}
+
+// checkScionSecretTypeSupport probes whether scion's `hub secret set`
+// accepts --type environment (the value darken passes for env secrets).
+//
+// Background: darken previously passed --type env, which scion's current
+// enum rejects (accepted: environment | variable | file). That mismatch
+// caused every spawn to fail at stage-creds with exit 1 while doctor
+// reported all-green. This check surfaces the drift before any spawn is
+// attempted.
+//
+// The probe invokes `scion hub secret set --help` and confirms that
+// "environment" appears in the flag description. This is a read-only, no-op
+// call — it never writes a secret — so it is safe to run at doctor time.
+func checkScionSecretTypeSupport() error {
+	out, err := exec.Command("scion", "hub", "secret", "set", "--help").CombinedOutput()
+	if err != nil {
+		// If scion itself is absent, the scion-cli check already caught it.
+		// Return nil here to avoid double-reporting; the scion-cli FAIL is
+		// the actionable one.
+		return nil
+	}
+	if !strings.Contains(string(out), "environment") {
+		return fmt.Errorf(
+			"scion hub secret set --help does not list 'environment' as an accepted --type value; " +
+				"darken passes --type environment for env secrets. " +
+				"This version of scion may use a different enum — upgrade scion or check `scion hub secret set --help` manually",
+		)
 	}
 	return nil
 }

--- a/cmd/darken/doctor_test.go
+++ b/cmd/darken/doctor_test.go
@@ -556,3 +556,70 @@ func TestCheckGoGitFUSE_RemediationInDoctorBroad(t *testing.T) {
 		t.Fatalf("doctorBroad should mention go-git FUSE check, got:\n%s", report)
 	}
 }
+
+// issue #57: scion secret-type enum smoke checks.
+
+// TestCheckScionSecretTypeSupport_PassesWhenEnvInHelp confirms the check
+// passes when scion --help output contains "environment".
+func TestCheckScionSecretTypeSupport_PassesWhenEnvInHelp(t *testing.T) {
+	stubDir := t.TempDir()
+	// Stub scion to emit a --help block that includes the accepted enum.
+	stub := "#!/bin/sh\necho '--type string   Secret type: environment (default), variable, file'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	if err := checkScionSecretTypeSupport(); err != nil {
+		t.Fatalf("expected nil when 'environment' in help, got: %v", err)
+	}
+}
+
+// TestCheckScionSecretTypeSupport_FailsWhenEnvAbsentFromHelp confirms the
+// check fails when scion's --help output does not contain "environment" —
+// signalling an enum drift that would break stage-creds.
+func TestCheckScionSecretTypeSupport_FailsWhenEnvAbsentFromHelp(t *testing.T) {
+	stubDir := t.TempDir()
+	// Stub scion to emit a --help block missing "environment" (simulates old
+	// scion that only knew --type env, or a future rename).
+	stub := "#!/bin/sh\necho '--type string   Secret type: env (default), variable, file'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	if err := checkScionSecretTypeSupport(); err == nil {
+		t.Fatal("expected error when 'environment' absent from scion --help, got nil")
+	}
+}
+
+// TestCheckScionSecretTypeSupport_AbsentScionSkipsGracefully confirms that
+// when scion is not on PATH (already caught by scion-cli check), the secret-
+// type check returns nil rather than double-reporting the same root cause.
+func TestCheckScionSecretTypeSupport_AbsentScionSkipsGracefully(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: no scion
+	if err := checkScionSecretTypeSupport(); err != nil {
+		t.Fatalf("expected nil when scion absent (scion-cli check owns that failure), got: %v", err)
+	}
+}
+
+// TestDoctorBroadChecks_ContainsSecretTypeEnum confirms the new check is
+// registered in doctorBroadChecks so it actually runs during `darken doctor`.
+func TestDoctorBroadChecks_ContainsSecretTypeEnum(t *testing.T) {
+	found := false
+	for _, dc := range doctorBroadChecks() {
+		if dc.ID == "scion-secret-type-enum" {
+			found = true
+			if dc.Run == nil {
+				t.Error("scion-secret-type-enum check has nil Run")
+			}
+			if dc.Remediation == "" {
+				t.Error("scion-secret-type-enum check has empty Remediation")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("doctorBroadChecks does not contain 'scion-secret-type-enum' check")
+	}
+}

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -91,10 +91,13 @@ type ScionClient interface {
 	//   scion hub secret set --type file --target <target> <name> @<srcPath>
 	PushFileSecret(name, target, srcPath string) error
 
-	// PushEnvSecret uploads a value as an env-type secret named for
+	// PushEnvSecret uploads a value as an environment-type secret named for
 	// the env var it'll populate inside the container. Maps to:
-	//   scion hub secret set --type env --target <name> <name> @<tmpfile>
+	//   scion hub secret set --type environment --target <name> <name> @<tmpfile>
 	// where tmpfile holds value.
+	//
+	// NOTE: scion's accepted enum is "environment | variable | file". The value
+	// "env" was the old (now-rejected) alias. Always use "environment" here.
 	PushEnvSecret(name, value string) error
 }
 
@@ -248,9 +251,12 @@ func (c *execScionClient) PushEnvSecret(name, value string) error {
 		return fmt.Errorf("write temp for env secret: %w", err)
 	}
 	tmp.Close()
+	// scion's accepted --type enum is: environment | variable | file.
+	// The old alias "env" is no longer accepted and causes an enum-mismatch
+	// exit 1 at stage-creds time, breaking every spawn. Use "environment".
 	cmd := scionCmdWithEnv([]string{
 		"hub", "secret", "set",
-		"--type", "env",
+		"--type", "environment",
 		"--target", name,
 		name, "@" + tmp.Name(),
 	})

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -311,6 +311,37 @@ func TestExecScionClient_ImportAllTemplates_IncludesNonInteractiveFlag(t *testin
 	}
 }
 
+// TestPushEnvSecret_UsesEnvironmentType is the regression test for the
+// stage-creds enum mismatch (issue #57). scion's --type enum is
+// "environment | variable | file"; the old alias "env" is rejected with
+// exit 1. This test pins the argument list that execScionClient.PushEnvSecret
+// passes to scion so that a future enum change is caught here rather than
+// silently breaking every spawn.
+func TestPushEnvSecret_UsesEnvironmentType(t *testing.T) {
+	stubDir := t.TempDir()
+	argsFile := filepath.Join(stubDir, "args.log")
+	stub := "#!/bin/sh\necho \"$@\" >> " + argsFile + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "scion"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	c := &execScionClient{}
+	if err := c.PushEnvSecret("OPENROUTER_API_KEY", "test-value"); err != nil {
+		t.Fatalf("PushEnvSecret: %v", err)
+	}
+	body, _ := os.ReadFile(argsFile)
+	args := string(body)
+	// Must pass --type environment (the only valid scion enum value for env secrets).
+	if !strings.Contains(args, "--type environment") {
+		t.Errorf("PushEnvSecret must pass --type environment; got args: %s", args)
+	}
+	// Must NOT pass the stale alias --type env (causes exit 1 on current scion).
+	if strings.Contains(args, "--type env\n") || strings.Contains(args, "--type env ") {
+		t.Errorf("PushEnvSecret must not pass stale --type env; got args: %s", args)
+	}
+}
+
 // TestSpawn_UsesScionClientStartAgent verifies that runSpawn calls
 // ScionClient.StartAgent instead of the raw scion binary for the start operation.
 func TestSpawn_UsesScionClientStartAgent(t *testing.T) {

--- a/cmd/darken/setup_test.go
+++ b/cmd/darken/setup_test.go
@@ -46,6 +46,11 @@ case "$1" in
       echo "codex_auth"
       echo "gemini_auth"
     fi
+    # Support "--help" for "hub secret set" (needed by checkScionSecretTypeSupport).
+    # Args: $1=hub $2=secret $3=set $4=--help
+    if [ "$2" = "secret" ] && [ "$3" = "set" ] && [ "$4" = "--help" ]; then
+      echo "--type string   Secret type: environment (default), variable, file"
+    fi
     ;;
   templates)
     sub="$2"


### PR DESCRIPTION
Closes #57

## Diagnosis

**Root cause path 1 (stale enum):** `execScionClient.PushEnvSecret` was passing `--type env` to `scion hub secret set`. Scion's accepted enum is `environment | variable | file`; the alias `env` is rejected with exit 1. This caused every `darken spawn` to fail at the `stage-creds` step — `darken doctor` reported all-green throughout because it never exercised the `stage-creds` path.

**Before:** `scion hub secret set --type env --target NAME NAME @tmpfile`
**After:** `scion hub secret set --type environment --target NAME NAME @tmpfile`

## Changes

- **`cmd/darken/scion_client.go`** — fix `PushEnvSecret` to pass `--type environment`; update interface comment to name the accepted enum explicitly.
- **`cmd/darken/scion_client_test.go`** — `TestPushEnvSecret_UsesEnvironmentType`: regression test that stubs scion and asserts the exact `--type` argument; fails loudly if the enum drifts again.
- **`cmd/darken/doctor.go`** — add `scion-secret-type-enum` check (SeverityFail) to `doctorBroadChecks`; add `checkScionSecretTypeSupport` which calls `scion hub secret set --help` and confirms `"environment"` is in the output. If scion's enum changes again, doctor catches it before any spawn is attempted.
- **`cmd/darken/doctor_test.go`** — four tests: passes when help contains "environment", fails when absent, skips gracefully when scion is not on PATH, and verifies the check is registered in `doctorBroadChecks`.
- **`cmd/darken/setup_test.go`** — update `stubAllBinariesForSetup` scion stub to respond to `hub secret set --help` with the expected enum output, keeping existing up/setup tests green.

## Acceptance criteria

- [x] `PushEnvSecret` passes `--type environment` (the only valid scion value for env secrets)
- [x] Regression test pins the enum; future drift fails loudly at test time
- [x] `darken doctor` exercises the stage-creds path via `scion-secret-type-enum` check
- [x] Doctor reports a clear, actionable error when the enum has drifted
- [x] No regression on existing tests — `go test ./...` passes clean
- [x] `go vet ./...`, `go build ./...`, `gofmt -d` (on changed files) all clean

## Out of scope (per brief)

- Orchestrator-mode skill rewrite (#61)
- Subcommand `--help` fall-through (#62)
- Bones-side improvements (#56)