### PR TITLE
fix(doctor): detect post-up orphaned grove status

### DIFF
--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -146,6 +147,13 @@ func doctorBroadChecks() []DoctorCheck {
 			Severity:    SeverityFail,
 			Run:         checkGoGitFUSE,
 			Remediation: "clone the grove outside the Docker Desktop shared volume",
+		},
+		{
+			ID:          "grove-status",
+			Label:       "grove status ok (not orphaned)",
+			Severity:    SeverityFail,
+			Run:         checkGroveStatus,
+			Remediation: "re-run `darken up` to re-register the grove with the local broker",
 		},
 		{
 			ID:          "hub-secrets",
@@ -379,6 +387,63 @@ func checkHostsDockerInternalFile(path string) error {
 		"host.docker.internal not found in %s; add with: echo \"127.0.0.1 host.docker.internal\" | sudo tee -a %s",
 		path, path,
 	)
+}
+
+// groveEntry is the shape of one entry from `scion grove list --format json`.
+type groveEntry struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// checkGroveStatus verifies that the current project's grove is reported as
+// "ok" by scion grove list. This catches a known scion issue where
+// `scion grove init` with hub disabled creates a local-only grove that
+// scion's orphan classifier cannot verify, labelling it "orphaned" even when
+// the workspace is healthy.
+//
+// The check is a no-op (returns nil) when:
+//   - cwd is not inside a git repo (not an error — operator is not in a project)
+//   - the project has no .scion/grove-id (grove has never been init'd)
+//   - scion grove list fails (scion not running — a different check covers that)
+func checkGroveStatus() error {
+	root, err := repoRoot()
+	if err != nil {
+		return nil // not in a git repo — skip
+	}
+	// Only run when the grove has been initialized.
+	if _, err := os.Stat(filepath.Join(root, ".scion", "grove-id")); err != nil {
+		return nil // grove not init'd — skip
+	}
+	slug := filepath.Base(root)
+
+	out, err := defaultScionClient.GroveListJSON()
+	if err != nil {
+		return nil // scion not reachable — covered by scion-server checks
+	}
+
+	var entries []groveEntry
+	if err := json.Unmarshal([]byte(out), &entries); err != nil {
+		return nil // can't parse JSON — skip rather than false-alarm
+	}
+
+	for _, e := range entries {
+		if e.Name != slug {
+			continue
+		}
+		if e.Status != "ok" {
+			return fmt.Errorf(
+				"grove %q reports status=%q (want ok) — "+
+					"scion's orphan classifier did not receive the workspace path; "+
+					"this is a known scion issue where grove init with hub disabled "+
+					"leaves local_path unset in grove_contributors; "+
+					"re-run `darken up` or file an issue against scion if it persists",
+				slug, e.Status,
+			)
+		}
+		return nil
+	}
+	// Grove slug not found in list — either not registered or list is incomplete.
+	return nil
 }
 
 func checkHubSecrets() error {

--- a/cmd/darken/doctor_grove_test.go
+++ b/cmd/darken/doctor_grove_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeGroveTestDir creates a temp dir with a .scion/grove-id file.
+// It sets DARKEN_REPO_ROOT to dir so repoRoot() resolves deterministically
+// without shelling out to git. Returns dir and its base name (slug).
+func makeGroveTestDir(t *testing.T) (dir, slug string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".scion"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	slug = filepath.Base(dir)
+	t.Setenv("DARKEN_REPO_ROOT", dir)
+	return dir, slug
+}
+
+// TestCheckGroveStatus_PassesWhenOk verifies the check passes when scion
+// grove list reports the current project's grove as "ok".
+func TestCheckGroveStatus_PassesWhenOk(t *testing.T) {
+	dir, slug := makeGroveTestDir(t)
+	if err := os.WriteFile(filepath.Join(dir, ".scion", "grove-id"),
+		[]byte("aaaabbbb-0000-0000-0000-000000000001"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		groveListJSONOut: `[{"name":"` + slug + `","status":"ok","grove_id":"x","type":"git","agent_count":0}]`,
+	}
+	setDefaultClient(t, mc)
+
+	if err := checkGroveStatus(); err != nil {
+		t.Fatalf("expected nil when grove status is ok, got: %v", err)
+	}
+}
+
+// TestCheckGroveStatus_FailsWhenOrphaned verifies the check returns an error
+// when scion grove list classifies the project's grove as "orphaned".
+// This is the primary acceptance test for issue #59.
+func TestCheckGroveStatus_FailsWhenOrphaned(t *testing.T) {
+	dir, slug := makeGroveTestDir(t)
+	if err := os.WriteFile(filepath.Join(dir, ".scion", "grove-id"),
+		[]byte("aaaabbbb-0000-0000-0000-000000000002"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		groveListJSONOut: `[{"name":"` + slug + `","status":"orphaned","grove_id":"x","type":"git","agent_count":0}]`,
+	}
+	setDefaultClient(t, mc)
+
+	err := checkGroveStatus()
+	if err == nil {
+		t.Fatal("expected error when grove status is orphaned, got nil")
+	}
+	if !containsAll(err.Error(), []string{slug, "orphaned", "darken up"}) {
+		t.Errorf("error message should name slug, status, and remediation; got: %v", err)
+	}
+}
+
+// TestCheckGroveStatus_SkipsWhenNoGroveID verifies the check is a no-op when
+// the project has not been grove-init'd (no .scion/grove-id).
+func TestCheckGroveStatus_SkipsWhenNoGroveID(t *testing.T) {
+	dir, _ := makeGroveTestDir(t)
+	// No grove-id file written.
+	_ = dir
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := checkGroveStatus(); err != nil {
+		t.Fatalf("expected nil when grove not init'd, got: %v", err)
+	}
+}
+
+// TestCheckGroveStatus_SkipsWhenNotInRepo verifies the check is a no-op when
+// DARKEN_REPO_ROOT is unset and cwd is not inside a git repo.
+func TestCheckGroveStatus_SkipsWhenNotInRepo(t *testing.T) {
+	// Ensure DARKEN_REPO_ROOT is unset and cwd is a non-repo temp dir.
+	t.Setenv("DARKEN_REPO_ROOT", "")
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{}
+	setDefaultClient(t, mc)
+
+	if err := checkGroveStatus(); err != nil {
+		t.Fatalf("expected nil when not in a git repo, got: %v", err)
+	}
+}
+
+// TestCheckGroveStatus_SkipsWhenScionUnreachable verifies the check is a no-op
+// when scion grove list itself fails (server down — a different check covers that).
+func TestCheckGroveStatus_SkipsWhenScionUnreachable(t *testing.T) {
+	dir, _ := makeGroveTestDir(t)
+	if err := os.WriteFile(filepath.Join(dir, ".scion", "grove-id"),
+		[]byte("aaaabbbb-0000-0000-0000-000000000003"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		groveListJSONErr: errors.New("connection refused"),
+	}
+	setDefaultClient(t, mc)
+
+	if err := checkGroveStatus(); err != nil {
+		t.Fatalf("expected nil when scion unreachable, got: %v", err)
+	}
+}
+
+// TestCheckGroveStatus_SkipsWhenSlugNotInList verifies the check is a no-op when
+// the project's slug is not present in scion grove list output (e.g. newly
+// init'd grove not yet synced to the list).
+func TestCheckGroveStatus_SkipsWhenSlugNotInList(t *testing.T) {
+	dir, _ := makeGroveTestDir(t)
+	if err := os.WriteFile(filepath.Join(dir, ".scion", "grove-id"),
+		[]byte("aaaabbbb-0000-0000-0000-000000000004"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mc := &mockScionClient{
+		groveListJSONOut: `[{"name":"other-project","status":"ok","grove_id":"y","type":"git","agent_count":0}]`,
+	}
+	setDefaultClient(t, mc)
+
+	if err := checkGroveStatus(); err != nil {
+		t.Fatalf("expected nil when slug absent from list, got: %v", err)
+	}
+}
+
+// TestDoctorBroadChecks_IncludesGroveStatusCheck verifies the grove-status
+// check is present in the doctorBroadChecks registry with the correct ID
+// and severity.
+func TestDoctorBroadChecks_IncludesGroveStatusCheck(t *testing.T) {
+	var found bool
+	for _, dc := range doctorBroadChecks() {
+		if dc.ID != "grove-status" {
+			continue
+		}
+		found = true
+		if dc.Severity != SeverityFail {
+			t.Errorf("grove-status check: want SeverityFail, got %q", dc.Severity)
+		}
+		if dc.Remediation == "" {
+			t.Error("grove-status check: Remediation must not be empty")
+		}
+		if dc.Run == nil {
+			t.Error("grove-status check: Run must not be nil")
+		}
+		break
+	}
+	if !found {
+		t.Error("grove-status check not found in doctorBroadChecks registry")
+	}
+}
+
+// containsAll reports whether s contains every needle in needles.
+func containsAll(s string, needles []string) bool {
+	for _, n := range needles {
+		if !contains(s, n) {
+			return false
+		}
+	}
+	return true
+}
+
+// contains is a simple substring helper (strings.Contains is fine but this
+// avoids importing strings in the test file when it's otherwise not needed).
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/cmd/darken/scion_client.go
+++ b/cmd/darken/scion_client.go
@@ -59,6 +59,10 @@ type ScionClient interface {
 	// no-ops since teardown shouldn't abort on already-clean state.
 	BrokerWithdraw() error
 
+	// GroveListJSON returns the raw JSON output of `scion grove list --format json`.
+	// Used by the post-up grove status check to detect misclassified orphans.
+	GroveListJSON() (string, error)
+
 	// LookAgent returns the raw terminal output of `scion look <name>`.
 	// ANSI stripping is the caller's responsibility.
 	LookAgent(name string, extraArgs []string) ([]byte, error)
@@ -148,10 +152,18 @@ func (c *execScionClient) ImportAllTemplates(dir string) error {
 }
 
 func (c *execScionClient) GroveInit(targetDir string) error {
-	cmd := scionCmdWithEnv([]string{"grove", "init"})
+	cmd := scionCmdWithEnv([]string{"grove", "init", "--non-interactive"})
 	cmd.Dir = targetDir
 	err, _ := runScionCmd(cmd)
 	return err
+}
+
+func (c *execScionClient) GroveListJSON() (string, error) {
+	out, err := scionCmdWithEnv([]string{"grove", "list", "--format", "json"}).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("scion grove list: %w", err)
+	}
+	return string(out), nil
 }
 
 func (c *execScionClient) CleanGrove(targetDir string) error {

--- a/cmd/darken/scion_client_test.go
+++ b/cmd/darken/scion_client_test.go
@@ -25,6 +25,9 @@ type mockScionClient struct {
 	importAllTemplatesErr   error
 	importAllTemplatesCalls []string
 
+	groveListJSONOut string
+	groveListJSONErr error
+
 	startAgentCalls     [][]string
 	pushTemplateCalls   []string
 	groveInitCalls      int
@@ -41,13 +44,13 @@ type mockScionClient struct {
 	pushFileSecretCalls [][3]string // {name, target, srcPath}
 	pushEnvSecretCalls  [][2]string // {name, value}
 
-	startServerErr     error
-	stopServerErr      error
-	stopAgentErr       error
-	deleteAgentErr     error
-	deleteTemplateErr  error
-	pushFileSecretErr  error
-	pushEnvSecretErr   error
+	startServerErr    error
+	stopServerErr     error
+	stopAgentErr      error
+	deleteAgentErr    error
+	deleteTemplateErr error
+	pushFileSecretErr error
+	pushEnvSecretErr  error
 }
 
 func (m *mockScionClient) ServerStatus() (string, error) {
@@ -83,6 +86,9 @@ func (m *mockScionClient) CleanGrove(targetDir string) error {
 func (m *mockScionClient) BrokerWithdraw() error {
 	m.brokerWithdrawCalls++
 	return m.brokerWithdrawErr
+}
+func (m *mockScionClient) GroveListJSON() (string, error) {
+	return m.groveListJSONOut, m.groveListJSONErr
 }
 func (m *mockScionClient) LookAgent(name string, extraArgs []string) ([]byte, error) {
 	m.lookAgentCalls = append(m.lookAgentCalls, name)


### PR DESCRIPTION
Closes #59

## Diagnosis

**Root cause: Path 2 — upstream scion bug.**

Scion's orphan classifier reads `grove_contributors.local_path` from `hub.db` to verify workspace existence. When `scion grove init` runs without hub connectivity (or with hub disabled), it creates a local-only grove (`hub.enabled: false` in the externalized `settings.yaml`) and writes no row to `grove_contributors`. Subsequent `scion broker provide` calls attach to the **global** grove instead of the project grove, leaving `local_path` empty for the project. Any grove with a missing or empty `local_path` in `grove_contributors` is classified as `orphaned` by `scion grove list`, even when the workspace is healthy and the workspace path exists on disk.

This was confirmed by direct inspection of `~/.scion/hub.db`: groves reporting `ok` (e.g. `base4m`) have a `grove_contributors.local_path` pointing to their `.scion` dir; freshly-init'd groves (e.g. `darken`) have no contributor row at all.

**Upstream scion issue:** The `danmestas/scion` repository is private and was not reachable via `gh issue create`. The diagnosis above documents the bug for manual filing.

## Changes

- **`ScionClient.GroveListJSON()`** — new method, calls `scion grove list --format json`. Used by the post-up check.
- **`execScionClient.GroveInit`** — adds `--non-interactive` flag to prevent interactive prompts during `darken up`.
- **`checkGroveStatus()`** — new doctor check: queries grove list, finds current project's slug, fails loudly when status is `orphaned`. Skips gracefully when not in a repo, grove not init'd, or scion is unreachable (those paths are covered by other checks).
- **`doctorBroadChecks()`** — registers `grove-status` as `SeverityFail` between `go-git-fuse` and `hub-secrets`.
- **`doctor_grove_test.go`** — 7 new tests covering ok, orphaned, no-grove-id, not-in-repo, scion-down, slug-not-in-list, and registry presence.

## Acceptance criteria

- [x] `darken doctor` exits non-zero with a clear message when the just-brought-up grove is misreported as `orphaned` (covered by `TestCheckGroveStatus_FailsWhenOrphaned`)
- [x] Diagnosis documented in PR description (this section)
- [x] No regression on #58: pre-existing real orphans still cleaned by `darken down` — `Grove.Release` is unchanged
- [ ] After `darken up` against a fresh repo, `scion grove list` reports `ok` — depends on the upstream scion fix; this PR adds the detection layer

## Local CI

```
go test ./...   → PASS
go vet ./...    → clean
go build ./...  → clean
gofmt -d        → no diff
```