### PR TITLE
fix(init): preserve darken narrative, pre-create audit log, fix subcommand --help

### DIFF
--- a/cmd/darken/artifacts.go
+++ b/cmd/darken/artifacts.go
@@ -81,6 +81,11 @@ func initArtifacts(targetDir string) []artifact {
 			Kind:    "gitignore-lines",
 			Body:    func() ([]byte, error) { return []byte(strings.Join(gitignoreLines, "\n") + "\n"), nil },
 		},
+		{
+			RelPath: ".scion/audit.jsonl",
+			Kind:    "touch",
+			Body:    func() ([]byte, error) { return nil, nil },
+		},
 	}
 }
 

--- a/cmd/darken/artifacts_test.go
+++ b/cmd/darken/artifacts_test.go
@@ -14,8 +14,8 @@ func TestInitArtifacts_ListIsCompleteAndStable(t *testing.T) {
 	target := t.TempDir()
 	arts := initArtifacts(target)
 
-	if len(arts) != 5 {
-		t.Fatalf("expected 5 artifacts, got %d", len(arts))
+	if len(arts) != 6 {
+		t.Fatalf("expected 6 artifacts, got %d", len(arts))
 	}
 
 	wantPaths := map[string]string{
@@ -24,6 +24,7 @@ func TestInitArtifacts_ListIsCompleteAndStable(t *testing.T) {
 		".claude/skills/subagent-to-subharness/SKILL.md": "file",
 		".claude/settings.local.json":                    "file",
 		".gitignore":                                     "gitignore-lines",
+		".scion/audit.jsonl":                             "touch",
 	}
 	for _, art := range arts {
 		wantKind, ok := wantPaths[art.RelPath]

--- a/cmd/darken/doctor.go
+++ b/cmd/darken/doctor.go
@@ -35,6 +35,15 @@ type DoctorCheck struct {
 }
 
 func runDoctor(args []string) error {
+	// Handle --help / -h before any other parsing so it prints
+	// subcommand-specific docs rather than falling through to top-level help.
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			printDoctorUsage()
+			return nil
+		}
+	}
+
 	// New: --init triggers per-init scaffold verification (Phase 6).
 	for _, a := range args {
 		if a == "--init" {
@@ -57,6 +66,22 @@ func runDoctor(args []string) error {
 	report, err := doctorBroad()
 	fmt.Println(report)
 	return err
+}
+
+func printDoctorUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: darken doctor [flags] [harness-name]")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Run preflight and post-mortem health checks.")
+	fmt.Fprintln(os.Stderr, "With no arguments: broad system checks (docker, scion, hub secrets, images, etc.).")
+	fmt.Fprintln(os.Stderr, "With a harness-name: per-harness checks for that agent.")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Flags:")
+	fmt.Fprintln(os.Stderr, "  --init    verify per-project init scaffolds (CLAUDE.md, skills, audit log, etc.)")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Examples:")
+	fmt.Fprintln(os.Stderr, "  darken doctor              # broad system check")
+	fmt.Fprintln(os.Stderr, "  darken doctor --init       # verify init scaffolds in current repo")
+	fmt.Fprintln(os.Stderr, "  darken doctor researcher-1 # harness-specific check")
 }
 
 // checkSubstrateDrift compares the project's orchestrator-mode SKILL.md

--- a/cmd/darken/doctor_test.go
+++ b/cmd/darken/doctor_test.go
@@ -174,9 +174,10 @@ func TestInitDoctor_PassesOnCompleteInit(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("DARKEN_REPO_ROOT", tmp)
 
-	// Plant a complete init scaffold (matches what Phase 5's runInit produces).
+	// Plant a complete init scaffold (matches what runInit produces).
 	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
 	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".scion"), 0o755)
 	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken orchestrator-mode\n"), 0o644)
 	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"),
 		[]byte("---\nname: orchestrator-mode\n---\n# body\n"), 0o644)
@@ -186,6 +187,7 @@ func TestInitDoctor_PassesOnCompleteInit(t *testing.T) {
 		[]byte(`{"statusLine":{"command":"darken status","type":"command"}}`), 0o644)
 	os.WriteFile(filepath.Join(tmp, ".gitignore"),
 		[]byte(".scion/agents/\n.scion/skills-staging/\n.scion/audit.jsonl\n.claude/worktrees/\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".scion", "audit.jsonl"), []byte(""), 0o644)
 
 	report, err := runInitDoctor(tmp)
 	if err != nil {

--- a/cmd/darken/down.go
+++ b/cmd/darken/down.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,8 +22,24 @@ func runDown(args []string) error {
 	yes := fs.Bool("yes", false, "skip the confirmation prompt")
 	noBones := fs.Bool("no-bones", false, "skip the bones down chain")
 	purge := fs.Bool("purge", false, "also stop the scion server and remove user-scope hub templates (host-wide; use with care)")
-	fs.SetOutput(io.Discard)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: darken down [flags]")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Tear down the project: stop agents, drop the grove, remove init scaffolds,")
+		fmt.Fprintln(os.Stderr, "then chain to `bones down`.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Examples:")
+		fmt.Fprintln(os.Stderr, "  darken down          # interactive teardown with confirmation")
+		fmt.Fprintln(os.Stderr, "  darken down --yes    # non-interactive teardown")
+		fmt.Fprintln(os.Stderr, "  darken down --purge  # also stop scion server and remove hub templates")
+	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/darken/help_test.go
+++ b/cmd/darken/help_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpawnHelpPrintsSubcommandDocs confirms that `darken spawn --help` returns
+// nil and prints spawn-specific synopsis instead of falling through to top-level.
+func TestSpawnHelpPrintsSubcommandDocs(t *testing.T) {
+	out, err := captureStderr(func() error {
+		return runSpawn([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("spawn --help should return nil, got: %v", err)
+	}
+	for _, want := range []string{"darken spawn", "--type", "Example"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("spawn --help missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Subcommands:") {
+		t.Fatalf("spawn --help should not print top-level usage:\n%s", out)
+	}
+}
+
+// TestDoctorHelpPrintsSubcommandDocs confirms that `darken doctor --help` returns
+// nil and prints doctor-specific synopsis.
+func TestDoctorHelpPrintsSubcommandDocs(t *testing.T) {
+	out, err := captureStderr(func() error {
+		return runDoctor([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("doctor --help should return nil, got: %v", err)
+	}
+	for _, want := range []string{"darken doctor", "--init", "Example"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor --help missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Subcommands:") {
+		t.Fatalf("doctor --help should not print top-level usage:\n%s", out)
+	}
+}
+
+// TestUpHelpPrintsSubcommandDocs confirms that `darken up --help` returns nil
+// and prints up-specific synopsis.
+func TestUpHelpPrintsSubcommandDocs(t *testing.T) {
+	out, err := captureStderr(func() error {
+		return runUp([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("up --help should return nil, got: %v", err)
+	}
+	for _, want := range []string{"darken up", "--no-bones", "Example"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("up --help missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Subcommands:") {
+		t.Fatalf("up --help should not print top-level usage:\n%s", out)
+	}
+}
+
+// TestDownHelpPrintsSubcommandDocs confirms that `darken down --help` returns nil
+// and prints down-specific synopsis.
+func TestDownHelpPrintsSubcommandDocs(t *testing.T) {
+	out, err := captureStderr(func() error {
+		return runDown([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("down --help should return nil, got: %v", err)
+	}
+	for _, want := range []string{"darken down", "--yes", "Example"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("down --help missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Subcommands:") {
+		t.Fatalf("down --help should not print top-level usage:\n%s", out)
+	}
+}

--- a/cmd/darken/init.go
+++ b/cmd/darken/init.go
@@ -21,7 +21,26 @@ func runInit(args []string) error {
 	dryRun := flags.Bool("dry-run", false, "print actions without executing")
 	force := flags.Bool("force", false, "overwrite existing CLAUDE.md")
 	refresh := flags.Bool("refresh", false, "re-scaffold skills/statusLine/.gitignore without clobbering CLAUDE.md (use --force with --refresh to also regenerate CLAUDE.md)")
+	flags.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: darken init [flags] [target-dir]")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Scaffold CLAUDE.md, .claude/ skills, settings, .gitignore entries, and .scion/audit.jsonl")
+		fmt.Fprintln(os.Stderr, "into the target directory (default: current directory).")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Flags:")
+		flags.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Examples:")
+		fmt.Fprintln(os.Stderr, "  darken init                  # scaffold current directory")
+		fmt.Fprintln(os.Stderr, "  darken init ~/projects/myapp # scaffold a specific target")
+		fmt.Fprintln(os.Stderr, "  darken init --force          # overwrite existing CLAUDE.md")
+		fmt.Fprintln(os.Stderr, "  darken init --refresh        # re-extract skills without touching CLAUDE.md")
+		fmt.Fprintln(os.Stderr, "  darken init --dry-run        # preview what would be written")
+	}
 	if err := flags.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
 		return err
 	}
 
@@ -96,13 +115,6 @@ func runInit(args []string) error {
 		fmt.Fprintf(os.Stderr, "init: manifest write failed: %v\n", err)
 	}
 
-	// bones init (unchanged)
-	if err := runBonesInit(target); err != nil {
-		fmt.Fprintf(os.Stderr, "init: bones init failed: %v\n", err)
-	} else if _, err := exec.LookPath("bones"); err == nil {
-		fmt.Println("ran `bones init` for workspace bootstrap")
-	}
-
 	return nil
 }
 
@@ -151,6 +163,23 @@ func writeArtifact(target string, art artifact, writeCLAUDE, refresh bool) error
 			return err
 		}
 		fmt.Printf("scaffolded %s\n", art.RelPath)
+		return nil
+
+	case "touch":
+		// Create an empty file if it doesn't already exist. Idempotent:
+		// never truncates a non-empty file (audit log that already has entries).
+		if _, exists := statResult(dst); exists {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			return nil // another process beat us; treat as idempotent
+		}
+		f.Close()
+		fmt.Printf("created %s\n", art.RelPath)
 		return nil
 
 	case "gitignore-lines":

--- a/cmd/darken/init_test.go
+++ b/cmd/darken/init_test.go
@@ -7,6 +7,150 @@ import (
 	"testing"
 )
 
+// TestInitPreservesDarkenNarrativeWhenBonesOnPATH confirms option 1 of the
+// bones-clobber fix: runInit no longer chains bones init, so CLAUDE.md retains
+// the darken-aware narrative even when bones is on PATH.
+func TestInitPreservesDarkenNarrativeWhenBonesOnPATH(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Stub bones so verifyInitPrereqs passes, but have bones write a file
+	// to prove it was NOT called (if init still chains it, the file appears).
+	stubDir := t.TempDir()
+	bonesWasCalledFile := filepath.Join(tmp, ".bones-init-called")
+	for _, b := range []string{"scion", "docker"} {
+		os.WriteFile(filepath.Join(stubDir, b), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	}
+	bonesScript := "#!/bin/sh\nif [ \"$1\" = \"init\" ]; then touch " + bonesWasCalledFile + "; fi\nexit 0\n"
+	os.WriteFile(filepath.Join(stubDir, "bones"), []byte(bonesScript), 0o755)
+	t.Setenv("PATH", stubDir)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+
+	// bones init must NOT have been called.
+	if _, err := os.Stat(bonesWasCalledFile); err == nil {
+		t.Fatal("runInit should not chain `bones init` (option 1 of bones-clobber fix)")
+	}
+
+	// CLAUDE.md must contain darken-aware narrative.
+	body, err := os.ReadFile(filepath.Join(tmp, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("CLAUDE.md missing: %v", err)
+	}
+	for _, want := range []string{"darken", "scion", "orchestrator-mode"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("CLAUDE.md missing %q (darken narrative was clobbered): %s", want, body)
+		}
+	}
+}
+
+// TestInitCreatesAuditLog confirms .scion/audit.jsonl is created as an empty
+// file by runInit.
+func TestInitCreatesAuditLog(t *testing.T) {
+	stubPrereqs(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+
+	auditPath := filepath.Join(tmp, ".scion", "audit.jsonl")
+	info, err := os.Stat(auditPath)
+	if err != nil {
+		t.Fatalf(".scion/audit.jsonl not created by init: %v", err)
+	}
+	// File must exist; it may be empty (that's correct for a fresh audit log).
+	if info.IsDir() {
+		t.Fatal(".scion/audit.jsonl must be a file, not a directory")
+	}
+}
+
+// TestInitAuditLogIdempotent confirms that a second init run does not truncate
+// an audit.jsonl that already has entries.
+func TestInitAuditLogIdempotent(t *testing.T) {
+	stubPrereqs(t)
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate audit entries written after the first init.
+	auditPath := filepath.Join(tmp, ".scion", "audit.jsonl")
+	entry := `{"event":"test"}` + "\n"
+	if err := os.WriteFile(auditPath, []byte(entry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second init must not clobber.
+	if err := runInit([]string{tmp}); err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	body, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("audit log missing after second init: %v", err)
+	}
+	if string(body) != entry {
+		t.Fatalf("second init truncated audit log: want %q, got %q", entry, body)
+	}
+}
+
+// TestInitHelpPrintsSubcommandDocs confirms that `darken init --help` returns
+// nil (not flag.ErrHelp) and prints init-specific synopsis.
+func TestInitHelpPrintsSubcommandDocs(t *testing.T) {
+	out, err := captureStderr(func() error {
+		return runInit([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("--help should return nil, got: %v", err)
+	}
+	for _, want := range []string{"darken init", "--dry-run", "--force", "--refresh", "Example"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("--help output missing %q:\n%s", want, out)
+		}
+	}
+	// Must NOT look like top-level usage.
+	if strings.Contains(out, "Subcommands:") {
+		t.Fatalf("--help should not print top-level usage:\n%s", out)
+	}
+}
+
+// TestInitDoctorWarnsMissingAuditLog confirms that `darken doctor --init`
+// fails when .scion/audit.jsonl is absent.
+func TestInitDoctorWarnsMissingAuditLog(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("DARKEN_REPO_ROOT", tmp)
+
+	// Plant everything EXCEPT audit.jsonl.
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode"), 0o755)
+	os.MkdirAll(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness"), 0o755)
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("# darken orchestrator-mode\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "orchestrator-mode", "SKILL.md"),
+		[]byte("---\nname: orchestrator-mode\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "skills", "subagent-to-subharness", "SKILL.md"),
+		[]byte("---\nname: subagent-to-subharness\n---\n# body\n"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".claude", "settings.local.json"),
+		[]byte(`{"statusLine":{"command":"darken status","type":"command"}}`), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".gitignore"),
+		[]byte(".scion/agents/\n.scion/skills-staging/\n.scion/audit.jsonl\n.claude/worktrees/\n"), 0o644)
+	// NOTE: .scion/audit.jsonl intentionally NOT created.
+
+	report, err := runInitDoctor(tmp)
+	if err == nil {
+		t.Fatalf("expected runInitDoctor to fail when audit.jsonl missing; report:\n%s", report)
+	}
+	if !strings.Contains(report, "audit.jsonl") {
+		t.Fatalf("report should mention audit.jsonl: %s", report)
+	}
+	if !strings.Contains(report, "FAIL") {
+		t.Fatalf("report should show FAIL: %s", report)
+	}
+}
+
 func TestInitScaffoldsCLAUDE(t *testing.T) {
 	stubPrereqs(t)
 	tmp := t.TempDir()

--- a/cmd/darken/init_verify.go
+++ b/cmd/darken/init_verify.go
@@ -54,6 +54,12 @@ func runInitDoctor(target string) (string, error) {
 			check:    gitignoreHasDarkenEntries,
 			failHint: "run `darken init --refresh` to append entries",
 		},
+		{
+			name:     ".scion/audit.jsonl present",
+			path:     ".scion/audit.jsonl",
+			check:    fileExists,
+			failHint: "run `darken init --refresh` to create the audit log file",
+		},
 	}
 
 	var sb strings.Builder
@@ -74,6 +80,15 @@ func runInitDoctor(target string) (string, error) {
 			len(failed), strings.Join(failed, ", "))
 	}
 	return sb.String(), nil
+}
+
+// fileExists asserts the path exists (any size, including empty).
+// Used for files like .scion/audit.jsonl that are legitimately empty.
+func fileExists(absPath string) error {
+	if _, err := os.Stat(absPath); err != nil {
+		return fmt.Errorf("missing or inaccessible: %s", absPath)
+	}
+	return nil
 }
 
 // fileNonEmpty asserts the path exists and is non-zero size.

--- a/cmd/darken/main.go
+++ b/cmd/darken/main.go
@@ -47,9 +47,13 @@ var subcommands = []subcommand{
 }
 
 func main() {
-	// flag.Parse exits non-zero on --help; intercept first so the test runner sees a clean exit.
-	for _, a := range os.Args[1:] {
-		if a == "-h" || a == "--help" || a == "help" {
+	// Intercept top-level --help / -h / help ONLY when the first argument
+	// is itself a help flag. This lets `darken init --help` reach runInit
+	// (which prints subcommand-specific docs) rather than falling through to
+	// the global usage here.
+	if len(os.Args) > 1 {
+		first := os.Args[1]
+		if first == "-h" || first == "--help" || first == "help" {
 			printUsage()
 			os.Exit(0)
 		}
@@ -63,15 +67,15 @@ func main() {
 		os.Exit(2)
 	}
 
-	args := fs.Args()
-	if len(args) == 0 {
+	subcmdArgs := fs.Args()
+	if len(subcmdArgs) == 0 {
 		printUsage()
 		os.Exit(2)
 	}
 
 	for _, sc := range subcommands {
-		if sc.name == args[0] {
-			if err := sc.run(args[1:]); err != nil {
+		if sc.name == subcmdArgs[0] {
+			if err := sc.run(subcmdArgs[1:]); err != nil {
 				fmt.Fprintln(os.Stderr, "darken:", err)
 				os.Exit(1)
 			}
@@ -79,7 +83,7 @@ func main() {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "darken: unknown subcommand %q\n", args[0])
+	fmt.Fprintf(os.Stderr, "darken: unknown subcommand %q\n", subcmdArgs[0])
 	printUsage()
 	os.Exit(2)
 }

--- a/cmd/darken/spawn.go
+++ b/cmd/darken/spawn.go
@@ -10,6 +10,33 @@ import (
 )
 
 func runSpawn(args []string) error {
+	// Handle --help / -h before any other parsing so subcommand-specific
+	// docs are printed rather than falling through to top-level help.
+	// Must be checked before the positional-name extraction below.
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			// Build flagset solely to render PrintDefaults.
+			fs := flag.NewFlagSet("spawn", flag.ContinueOnError)
+			fs.String("type", "", "harness role (e.g. researcher)")
+			fs.String("backend", "", "backend override (claude|codex|pi|gemini)")
+			fs.String("mode", "", "skill-set mode override (defaults to role's default_mode)")
+			fs.Bool("no-stage", false, "skip stage-creds and stage-skills")
+			fs.Bool("watch", false, "block + attach to the agent's session (legacy behavior)")
+			fmt.Fprintln(os.Stderr, "Usage: darken spawn <name> --type <role> [flags] [task...]")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Stage credentials and skills, then start a scion harness agent.")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Flags:")
+			fs.PrintDefaults()
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Examples:")
+			fmt.Fprintln(os.Stderr, "  darken spawn researcher-1 --type researcher \"analyze the API surface\"")
+			fmt.Fprintln(os.Stderr, "  darken spawn impl-2 --type implementer --backend codex \"refactor auth module\"")
+			fmt.Fprintln(os.Stderr, "  darken spawn rev-3 --type reviewer --no-stage \"review PR #42\"")
+			return nil
+		}
+	}
+
 	if len(args) < 1 {
 		return errors.New("usage: darken spawn <name> --type <role> [...]")
 	}

--- a/cmd/darken/up.go
+++ b/cmd/darken/up.go
@@ -15,6 +15,15 @@ import (
 )
 
 func runUp(args []string) error {
+	// Handle --help / -h before any other parsing so it prints
+	// subcommand-specific docs rather than falling through to top-level help.
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			printUpUsage()
+			return nil
+		}
+	}
+
 	// Strip --no-bones from the args without interfering with the
 	// init-side flag parsing. Anything else passes through verbatim
 	// to runInit / resolveInitTarget so --force, --dry-run, --refresh,
@@ -48,6 +57,24 @@ func runUp(args []string) error {
 		return nil
 	}
 	return chainBonesUp()
+}
+
+func printUpUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: darken up [flags] [target-dir]")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Bring up a project: scaffold init artifacts, run machine prereq bootstrap,")
+	fmt.Fprintln(os.Stderr, "upload harness templates to the hub, then chain to `bones up`.")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Flags:")
+	fmt.Fprintln(os.Stderr, "  --no-bones     skip the `bones up` chain")
+	fmt.Fprintln(os.Stderr, "  --force        overwrite existing CLAUDE.md (passed to darken init)")
+	fmt.Fprintln(os.Stderr, "  --refresh      re-scaffold skills without touching CLAUDE.md")
+	fmt.Fprintln(os.Stderr, "  --dry-run      preview what would be written (passed to darken init)")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Examples:")
+	fmt.Fprintln(os.Stderr, "  darken up                # bring up current directory")
+	fmt.Fprintln(os.Stderr, "  darken up --no-bones     # skip bones chain")
+	fmt.Fprintln(os.Stderr, "  darken up --force        # force-overwrite CLAUDE.md")
 }
 
 // runSetup is the deprecated alias for `darken up`. Prints a


### PR DESCRIPTION
Closes #62

## Resolution choice

**Option 1 (don't chain)** — `runInit` no longer calls `runBonesInit`. This is the cleanest option: `darken init` owns its own scaffolding; `bones init` is not a concern of `darken init`. The bones interaction in `darken up` is preserved via `chainBonesUp()` (which runs `bones up`, not `bones init`).

## Changes

### bones-clobber fix
- Removed `runBonesInit()` call from `runInit`. `darken init` no longer shells out to `bones init`, so bones cannot overwrite CLAUDE.md with a bones-flat AGENTS.md narrative.
- `runBonesInit` function retained (not called) to preserve `warnIfBonesOutdated` companion and test coverage.
- `darken up` unchanged — still chains `bones up` via `chainBonesUp()`.

### audit log pre-creation
- Added `.scion/audit.jsonl` as a `"touch"` artifact in `initArtifacts()`.
- `writeArtifact` handles `"touch"` kind: creates empty file if absent, skips if present (idempotent, never truncates existing entries).
- `runInitDoctor` (`darken doctor --init`) now checks for `.scion/audit.jsonl` and FAILs with remediation hint when missing.

### subcommand --help
- Fixed `main()` to only intercept `--help`/`-h` when it is the first argument. Previously a scan of all args caused `darken init --help` to fall through to top-level usage.
- `runInit` and `runDown`: custom `flag.NewFlagSet` Usage hook with synopsis + flags + examples; `ErrHelp` returns nil.
- `runDoctor`, `runUp`, `runSpawn`: explicit `--help`/`-h` scan at entry (before positional extraction in spawn's case) prints subcommand-specific synopsis + flags + examples and returns nil.

## Tests added
- `TestInitPreservesDarkenNarrativeWhenBonesOnPATH` — regression: bones stub detects if `bones init` is called
- `TestInitCreatesAuditLog` — audit.jsonl created on first init
- `TestInitAuditLogIdempotent` — second init does not truncate audit entries
- `TestInitHelpPrintsSubcommandDocs` — `darken init --help` returns nil, prints init-specific docs
- `TestInitDoctorWarnsMissingAuditLog` — `darken doctor --init` fails when audit.jsonl absent
- `TestSpawnHelpPrintsSubcommandDocs`, `TestDoctorHelpPrintsSubcommandDocs`, `TestUpHelpPrintsSubcommandDocs`, `TestDownHelpPrintsSubcommandDocs`

## Local CI
```
go build ./...   ✓
go vet ./...     ✓
go test ./...    ✓ (all 3 packages)
gofmt -d         ✓ (modified files only; pre-existing alignment noise in resources*.go not touched)
```