### PR TITLE
fix(rename): complete Darkish Factory→darken rename in canonical .scion/templates

### DIFF
--- a/.scion/templates/admin/agents.md
+++ b/.scion/templates/admin/agents.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are a detached background observer. You run continuously while the Darkish Factory pipeline is active. You maintain ’chronicle.md’ (the path is passed by the orchestrator at start). You do not maintain any other file. The orchestrator owns the audit log (README §5.2); you own the narrative chronicle.
+You are a detached background observer. You run continuously while the darken pipeline is active. You maintain ’chronicle.md’ (the path is passed by the orchestrator at start). You do not maintain any other file. The orchestrator owns the audit log (README §5.2); you own the narrative chronicle.
 
 ---
 

--- a/.scion/templates/admin/system-prompt.md
+++ b/.scion/templates/admin/system-prompt.md
@@ -4,7 +4,7 @@
 
 You are the admin harness. You are not a problem-solver. You are not an advisor. You are a witness and a recorder.
 
-You run continuously in the background while the Darkish Factory pipeline is active. Your sole output target is ’chronicle.md’ at the path the orchestrator passes when it starts you. You write to that file and no other.
+You run continuously in the background while the darken pipeline is active. Your sole output target is ’chronicle.md’ at the path the orchestrator passes when it starts you. You write to that file and no other.
 
 You are append-only. You never delete entries. You never rewrite entries. Every observation you commit to ’chronicle.md’ becomes part of the permanent record. This is not a preference. It is a structural constraint. Append-only means append-only.
 
@@ -163,7 +163,7 @@ Chronicle is append-only. Entries up to this point are permanent. No further obs
 **If chronicle.md does not exist at startup**: create it with a header, then treat all subsequent writes as appends:
 
 ’’’markdown
-# Darkish Factory Chronicle
+# darken Chronicle
 
 Append-only narrative record. Orchestrator owns the audit log (README §5.2). This file is the operator-readable complement.
 

--- a/.scion/templates/base/agents-git.md
+++ b/.scion/templates/base/agents-git.md
@@ -1,6 +1,6 @@
 # Git Worktree Protocol
 
-Every Darkish Factory sub-harness owns exactly one git worktree. This file defines the rules. Role-specific behavior does not override these rules.
+Every darken sub-harness owns exactly one git worktree. This file defines the rules. Role-specific behavior does not override these rules.
 
 ---
 

--- a/.scion/templates/base/agents-hub.md
+++ b/.scion/templates/base/agents-hub.md
@@ -1,6 +1,6 @@
 # Scion Hub Messaging Protocol
 
-This file defines how Darkish Factory sub-harnesses interact with the Scion hub. Role-specific files do not override these rules.
+This file defines how darken sub-harnesses interact with the Scion hub. Role-specific files do not override these rules.
 
 ---
 

--- a/.scion/templates/base/agents.md
+++ b/.scion/templates/base/agents.md
@@ -1,6 +1,6 @@
 # Base Worker Protocol
 
-This file defines the shared protocol for all Darkish Factory sub-harnesses. Role-specific ’agents.md’ files extend this protocol; they do not duplicate it.
+This file defines the shared protocol for all darken sub-harnesses. Role-specific ’agents.md’ files extend this protocol; they do not duplicate it.
 
 ---
 

--- a/.scion/templates/base/scion-agent.yaml
+++ b/.scion/templates/base/scion-agent.yaml
@@ -1,7 +1,7 @@
 schema_version: "1"
 # The template name is always derived from its containing folder.
 # Role-specific templates inherit from this base by overriding fields.
-description: "Darkish Factory base harness template — role identity is set by the extending template"
+description: "darken base harness template — role identity is set by the extending template"
 agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude

--- a/.scion/templates/base/system-prompt.md
+++ b/.scion/templates/base/system-prompt.md
@@ -1,14 +1,14 @@
-# Base System Prompt — Darkish Factory
+# Base System Prompt — darken
 
 This is the base prompt. It establishes shared identity and constraints for all
-Darkish Factory sub-harnesses. Role-specific identity, tool allowlists, and
+darken sub-harnesses. Role-specific identity, tool allowlists, and
 behavioral directives are added by the extending template’s system-prompt.md.
 
 ---
 
 ## Identity
 
-You are a Darkish Factory sub-harness running inside Scion. Your role within
+You are a darken sub-harness running inside Scion. Your role within
 the pipeline is defined by the template that extends this base. You do not have
 a role-specific identity from this file alone.
 

--- a/.scion/templates/designer/system-prompt.md
+++ b/.scion/templates/designer/system-prompt.md
@@ -1,6 +1,6 @@
 # Designer Harness
 
-You are the collapsed spec-writer and architect in the Darkish Factory. You convert intent and research into a spec and emit structural decisions with tradeoffs. Per §5.1, this is the harness where architecture and taste escalations are concentrated.
+You are the collapsed spec-writer and architect in the darken. You convert intent and research into a spec and emit structural decisions with tradeoffs. Per §5.1, this is the harness where architecture and taste escalations are concentrated.
 
 ## Role in the Pipeline
 

--- a/.scion/templates/orchestrator/LOCAL-MODE.md
+++ b/.scion/templates/orchestrator/LOCAL-MODE.md
@@ -1,6 +1,6 @@
 # Local Orchestrator Mode
 
-To run the Darkish Factory orchestrator from a local Claude Code session (observable mode), add the following to your project's CLAUDE.md or paste it as instructions.
+To run the darken orchestrator from a local Claude Code session (observable mode), add the following to your project's CLAUDE.md or paste it as instructions.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ To run the Darkish Factory orchestrator from a local Claude Code session (observ
 
 ## Instructions for Claude Code
 
-When the user asks you to run the Darkish Factory pipeline on a task:
+When the user asks you to run the darken pipeline on a task:
 
 ### 1. Enable the hub
 

--- a/.scion/templates/orchestrator/scion-agent.yaml
+++ b/.scion/templates/orchestrator/scion-agent.yaml
@@ -1,5 +1,5 @@
 schema_version: "1"
-description: "Darkish Factory orchestrator - runs the §7 loop, dispatches sub-harnesses, batches escalations to the operator"
+description: "darken orchestrator - runs the §7 loop, dispatches sub-harnesses, batches escalations to the operator"
 agent_instructions: agents.md
 system_prompt: system-prompt.md
 default_harness_config: claude

--- a/.scion/templates/orchestrator/system-prompt.md
+++ b/.scion/templates/orchestrator/system-prompt.md
@@ -1,6 +1,6 @@
 # Orchestrator
 
-You are the orchestrator harness for the Darkish Factory pipeline. You are the only harness authorized to interrupt the human.
+You are the orchestrator harness for the darken pipeline. You are the only harness authorized to interrupt the human.
 
 ## Role
 

--- a/.scion/templates/researcher/system-prompt.md
+++ b/.scion/templates/researcher/system-prompt.md
@@ -1,6 +1,6 @@
 # Researcher Harness
 
-You are a research agent in the Darkish Factory. Investigate technologies, find documentation, evaluate approaches, and produce compressed briefs for downstream harnesses. Per §5.1, you produce compressed briefs, not transcripts.
+You are a research agent in the darken. Investigate technologies, find documentation, evaluate approaches, and produce compressed briefs for downstream harnesses. Per §5.1, you produce compressed briefs, not transcripts.
 
 ## Role in the Pipeline
 

--- a/.scion/templates/reviewer/system-prompt.md
+++ b/.scion/templates/reviewer/system-prompt.md
@@ -1,6 +1,6 @@
 # Reviewer
 
-You are the reviewer harness in the Darkish Factory pipeline (per §5.1). You are the gate before anything reaches the operator.
+You are the reviewer harness in the darken pipeline (per §5.1). You are the gate before anything reaches the operator.
 
 Without you, the throughput claim collapses (§5.6): ten features landing per day is not a win if one human reviews each one. You make that claim hold.
 

--- a/.scion/templates/sme/system-prompt.md
+++ b/.scion/templates/sme/system-prompt.md
@@ -2,11 +2,11 @@
 
 ## Your Nature
 
-You are the **subject-matter expert** (SME) of the Darkish Factory: a single-use authority on software-engineering questions. You are not a collaborator, not a sounding board, not a sustained consultant. You are a **singular source of truth**, invoked when another harness — designer, planner, tdd-implementer, verifier, or reviewer — hits a specific question that exceeds general competence.
+You are the **subject-matter expert** (SME) of the darken: a single-use authority on software-engineering questions. You are not a collaborator, not a sounding board, not a sustained consultant. You are a **singular source of truth**, invoked when another harness — designer, planner, tdd-implementer, verifier, or reviewer — hits a specific question that exceeds general competence.
 
 You appear, deliver a pronouncement, and withdraw.
 
-Note: this role is borrowed from the Athenaeum oracle pattern and adapted for the Darkish Factory. It does not appear in the factory’s §5.1 harness catalog; it supplements that catalog as an on-demand deep-expertise layer.
+Note: this role is borrowed from the Athenaeum oracle pattern and adapted for the darken. It does not appear in the factory’s §5.1 harness catalog; it supplements that catalog as an on-demand deep-expertise layer.
 
 ## Your Domain
 
@@ -109,7 +109,7 @@ You receive exactly one question per invocation. If the caller has bundled multi
 - Not a reviewer who scores a diff
 - Not a planner who sequences work
 
-Those roles exist in the Darkish Factory. This is not one of them. You answer the question that exceeds those roles’ competence. Once answered, you are done.
+Those roles exist in the darken. This is not one of them. You answer the question that exceeds those roles’ competence. Once answered, you are done.
 
 ## Quality Standard
 

--- a/.scion/templates/tdd-implementer/system-prompt.md
+++ b/.scion/templates/tdd-implementer/system-prompt.md
@@ -1,6 +1,6 @@
 # TDD Implementer Harness
 
-You are the implementation agent in the Darkish Factory. You execute units of work from the planner’s plan. TDD discipline is non-negotiable: you write a failing test first, then minimal production code to pass it, then refactor. You do not write production code without a failing test. Per §5.1, this is the tdd-implementer’s defining constraint — it is not a preference.
+You are the implementation agent in the darken. You execute units of work from the planner’s plan. TDD discipline is non-negotiable: you write a failing test first, then minimal production code to pass it, then refactor. You do not write production code without a failing test. Per §5.1, this is the tdd-implementer’s defining constraint — it is not a preference.
 
 ## Role in the Pipeline
 

--- a/.scion/templates/verifier/system-prompt.md
+++ b/.scion/templates/verifier/system-prompt.md
@@ -1,6 +1,6 @@
 # Verifier
 
-You are the verifier harness in the Darkish Factory pipeline (per §5.1). Your role is adversarial correctness.
+You are the verifier harness in the darken pipeline (per §5.1). Your role is adversarial correctness.
 
 The tdd-implementer wrote the code. Your job is to break it.
 


### PR DESCRIPTION
## Summary

Completes the rename initiated in #68 (Issue #61). impl-61 renamed the embedded copies in `internal/substrate/data/.scion/templates/` but missed the canonical sources in `.scion/templates/` (16 files).

This caused `scripts/test-embed-drift.sh` to fail because `make sync-embed-data` copies canonical → embed and would re-introduce the "Darkish Factory" string. The release CI's `before:` hook runs this script, blocking v0.2.0.

## What changed

- `sed -i 's/Darkish Factory/darken/g'` on 16 canonical `.scion/templates/` files
- `make sync-embed-data` no-op on this side (embed dir already had the renamed strings; canonical is now consistent)

## Out of scope

- `docs/` and `.specify/memory/` historical planning docs still reference "Darkish Factory" — per #61's brief, those are not in the agent-visible target list.

## Test plan

- [x] grep -rn "Darkish Factory" .scion/templates/ → 0 hits
- [x] bash scripts/test-embed-drift.sh → PASS
- [x] go test ./... → 3/3 packages pass
- [x] go vet ./..., go build ./... clean